### PR TITLE
update repo name in conf

### DIFF
--- a/docs/docsite/sphinx_conf/2.10_conf.py
+++ b/docs/docsite/sphinx_conf/2.10_conf.py
@@ -152,7 +152,7 @@ html_context = {
     'show_sphinx': False,
     'is_eol': False,
     'github_user': 'ansible',
-    'github_repo': 'ansible',
+    'github_repo': 'ansible-documentation',
     'github_version': 'devel/docs/docsite/rst/',
     'github_module_version': 'devel/lib/ansible/modules/',
     'github_root_dir': 'devel/lib/ansible',

--- a/docs/docsite/sphinx_conf/all_conf.py
+++ b/docs/docsite/sphinx_conf/all_conf.py
@@ -148,7 +148,7 @@ html_context = {
     'show_sphinx': False,
     'is_eol': False,
     'github_user': 'ansible',
-    'github_repo': 'ansible',
+    'github_repo': 'ansible-documentation',
     'github_version': 'devel/docs/docsite/rst/',
     'github_module_version': 'devel/lib/ansible/modules/',
     'github_root_dir': 'devel/lib/ansible',

--- a/docs/docsite/sphinx_conf/ansible_conf.py
+++ b/docs/docsite/sphinx_conf/ansible_conf.py
@@ -158,7 +158,7 @@ html_context = {
     'show_sphinx': False,
     'is_eol': False,
     'github_user': 'ansible',
-    'github_repo': 'ansible',
+    'github_repo': 'ansible-documentation',
     'github_version': 'devel/docs/docsite/rst/',
     'github_module_version': 'devel/lib/ansible/modules/',
     'github_root_dir': 'devel/lib/ansible',

--- a/docs/docsite/sphinx_conf/core_conf.py
+++ b/docs/docsite/sphinx_conf/core_conf.py
@@ -196,7 +196,7 @@ html_context = {
     'show_sphinx': False,
     'is_eol': False,
     'github_user': 'ansible',
-    'github_repo': 'ansible',
+    'github_repo': 'ansible-documentation',
     'github_version': 'devel/docs/docsite/rst/',
     'github_module_version': 'devel/lib/ansible/modules/',
     'github_root_dir': 'devel/lib/ansible',

--- a/docs/docsite/sphinx_conf/core_lang_conf.py
+++ b/docs/docsite/sphinx_conf/core_lang_conf.py
@@ -196,7 +196,7 @@ html_context = {
     'show_sphinx': False,
     'is_eol': False,
     'github_user': 'ansible',
-    'github_repo': 'ansible',
+    'github_repo': 'ansible-documentation',
     'github_version': 'devel/docs/docsite/rst/',
     'github_module_version': 'devel/lib/ansible/modules/',
     'github_root_dir': 'devel/lib/ansible',


### PR DESCRIPTION
This PR changes the value of the `github_repo` key to point to `ansible-documentation` so that the "Edit on GitHub" button in generated HTML points users to this repository.

![image](https://github.com/ansible/ansible-documentation/assets/32749632/283df255-122e-4c55-875f-cfb3f857e0a0)

![image](https://github.com/ansible/ansible-documentation/assets/32749632/841d700e-c248-4e0f-8bcc-36b7d236265d)

Needs backport to the other branches.