### PR TITLE
docs - add examples for dicts and nested dicts in main/argument_specs.yml

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
@@ -273,7 +273,7 @@ Specification format
 --------------------
 
 The role argument specification must be defined in a top-level ``argument_specs`` block within the
-role ``meta/argument_specs.yml`` file. All fields are lower-case.
+role ``meta/argument_specs.yml`` file. All fields are lowercase.
 
 :entry-point-name:
 
@@ -283,14 +283,15 @@ role ``meta/argument_specs.yml`` file. All fields are lower-case.
 
     :short_description:
 
-        * A short, one-line description of the entry point.
+        * A short, one-line description of the entry point. Ideally, it's a phrase and not a sentence.
         * The ``short_description`` is displayed by ``ansible-doc -t role -l``.
-        * The short description should always be a string and never a list.
+        * It also becomes part of the title for the role page in the documentation.
+        * The short description should always be a string and never a list, and should not end in a period.
 
     :description:
 
         * A longer description that may contain multiple lines.
-        * This can be a single string, or a list of strings. In case this is a list of strings, every list
+        * This can be a single string or a list of strings. In case this is a list of strings, every list
            element is a new paragraph.
 
     :version_added:
@@ -319,13 +320,13 @@ role ``meta/argument_specs.yml`` file. All fields are lower-case.
 
         :version_added:
 
-            * Only needed if this option was added after the initial role/entry point release, in other words, this is greater than the top level ``version_added`` field.
+            * Only needed if this option was added after the initial role/entry point release. In other words, this is greater than the top level ``version_added`` field.
             * This is a string, and not a float, for example, ``version_added: '2.1'``.
             * In collections, this must be the collection version the option was added to. For example, ``version_added: 1.0.0``.
 
         :type:
 
-            * The data type of the option. See :ref:`Argument spec <argument_spec>` for allowed values for ``type``. Default is ``str``.
+            * The data type of the option. See :ref:`Argument spec <argument_spec>` for allowed values for ``type``. The default is ``str``.
             * If an option is of type ``list``, ``elements`` should be specified.
 
         :required:
@@ -338,7 +339,7 @@ role ``meta/argument_specs.yml`` file. All fields are lower-case.
             * If ``required`` is false/missing, ``default`` may be specified (assumed 'null' if missing).
             * Ensure that the default value in the docs matches the default value in the code. The actual
               default for the role variable will always come from ``defaults/main.yml``.
-            * The default field must not be listed as part of the description, unless it requires additional information or conditions.
+            * The default field must not be listed as part of the description unless it requires additional information or conditions.
             * If the option is a boolean value, you should use `true/false` if you want to be compatible with `ansible-lint`.
 
         :choices:
@@ -348,7 +349,7 @@ role ``meta/argument_specs.yml`` file. All fields are lower-case.
 
         :elements:
 
-            * Specifies the data type for list elements when type is ``list``.
+            * Specifies the data type for list elements when the type is ``list``.
 
         :options:
 
@@ -364,10 +365,10 @@ Sample specification
   argument_specs:
     # roles/myapp/tasks/main.yml entry point
     main:
-      short_description: The main entry point for the myapp role.
+      short_description: Main entry point for the myapp role
       description:
         - This is the main entrypoint for the C(myapp) role.
-        - Here we can describe what this entrypoint does in lenghty words.
+        - Here we can describe what this entrypoint does in lengthy words.
         - Every new list item is a new paragraph. You can have multiple sentences
           per paragraph.
       author: Daniel Ziegenberg
@@ -460,7 +461,7 @@ Sample specification
 
     # roles/myapp/tasks/alternate.yml entry point
     alternate:
-      short_description: The alternate entry point for the myapp role.
+      short_description: Alternate entry point for the myapp role
       version_added: 1.2.0
       options:
         myapp_int:

--- a/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
@@ -285,10 +285,19 @@ role ``meta/argument_specs.yml`` file. All fields are lower-case.
 
         * A short, one-line description of the entry point.
         * The ``short_description`` is displayed by ``ansible-doc -t role -l``.
+        * The short description should always be a string and never a list.
 
     :description:
 
         * A longer description that may contain multiple lines.
+        * This can be a single string, or a list of strings. In case this is a list of strings, every list
+           element is a new paragraph.
+
+    :version_added:
+
+        * The version of the role when the entrypoint was added.
+        * This is a string, and not a float, for example, ``version_added: '2.1'``.
+        * In collections, this must be the collection version the entrypoint was added to. For example, ``version_added: 1.0.0``.
 
     :author:
 
@@ -302,75 +311,163 @@ role ``meta/argument_specs.yml`` file. All fields are lower-case.
 
         :option-name:
 
-           * The name of the option/argument.
+            * The name of the option/argument.
 
         :description:
 
-           * Detailed explanation of what this option does. It should be written in full sentences.
+            * Detailed explanation of what this option does. It should be written in full sentences.
+
+        :version_added:
+
+            * Only needed if this option was added after the initial role/entry point release, in other words, this is greater than the top level ``version_added`` field.
+            * This is a string, and not a float, for example, ``version_added: '2.1'``.
+            * In collections, this must be the collection version the option was added to. For example, ``version_added: 1.0.0``.
 
         :type:
 
-           * The data type of the option. See :ref:`Argument spec <argument_spec>` for allowed values for ``type``. Default is ``str``.
-           * If an option is of type ``list``, ``elements`` should be specified.
+            * The data type of the option. See :ref:`Argument spec <argument_spec>` for allowed values for ``type``. Default is ``str``.
+            * If an option is of type ``list``, ``elements`` should be specified.
 
         :required:
 
-           * Only needed if ``true``.
-           * If missing, the option is not required.
+            * Only needed if ``true``.
+            * If missing, the option is not required.
 
         :default:
 
-           * If ``required`` is false/missing, ``default`` may be specified (assumed 'null' if missing).
-           * Ensure that the default value in the docs matches the default value in the code. The actual
-             default for the role variable will always come from ``defaults/main.yml``.
-           * The default field must not be listed as part of the description, unless it requires additional information or conditions.
-           * If the option is a boolean value, you should use `true/false` if you want to be compatible with `ansible-lint`.
+            * If ``required`` is false/missing, ``default`` may be specified (assumed 'null' if missing).
+            * Ensure that the default value in the docs matches the default value in the code. The actual
+              default for the role variable will always come from ``defaults/main.yml``.
+            * The default field must not be listed as part of the description, unless it requires additional information or conditions.
+            * If the option is a boolean value, you should use `true/false` if you want to be compatible with `ansible-lint`.
 
         :choices:
 
-           * List of option values.
-           * Should be absent if empty.
+            * List of option values.
+            * Should be absent if empty.
 
         :elements:
 
-           * Specifies the data type for list elements when type is ``list``.
+            * Specifies the data type for list elements when type is ``list``.
 
         :options:
 
-           * If this option takes a dict or list of dicts, you can define the structure here.
+            * If this option takes a dict or list of dicts, you can define the structure here.
 
 Sample specification
 --------------------
 
 .. code-block:: yaml
 
- # roles/myapp/meta/argument_specs.yml
- ---
- argument_specs:
-   # roles/myapp/tasks/main.yml entry point
-   main:
-     short_description: The main entry point for the myapp role.
-     options:
-       myapp_int:
-         type: "int"
-         required: false
-         default: 42
-         description: "The integer value, defaulting to 42."
+  # roles/myapp/meta/argument_specs.yml
+  ---
+  argument_specs:
+    # roles/myapp/tasks/main.yml entry point
+    main:
+      short_description: The main entry point for the myapp role.
+      description:
+        - This is the main entrypoint for the C(myapp) role.
+        - Here we can describe what this entrypoint does in lenghty words.
+        - Every new list item is a new paragraph. You can have multiple sentences
+          per paragraph.
+      author: Daniel Ziegenberg
+      options:
+        myapp_int:
+          type: "int"
+          required: false
+          default: 42
+          description:
+            - "The integer value, defaulting to 42."
+            - "This is a second paragraph."
 
-       myapp_str:
-         type: "str"
-         required: true
-         description: "The string value"
+        myapp_str:
+          type: "str"
+          required: true
+          description: "The string value"
 
-   # roles/myapp/tasks/alternate.yml entry point
-   alternate:
-     short_description: The alternate entry point for the myapp role.
-     options:
-       myapp_int:
-         type: "int"
-         required: false
-         default: 1024
-         description: "The integer value, defaulting to 1024."
+        myapp_list:
+          type: "list"
+          elements: "str"
+          required: true
+          description: "A list of string values."
+          version_added: 1.3.0
+
+        myapp_list_with_dicts:
+          type: "list"
+          elements: "dict"
+          required: false
+          default:
+            - myapp_food_kind: "meat"
+              myapp_food_boiling_required: true
+              myapp_food_preparation_time: 60
+            - myapp_food_kind: "fruits"
+              myapp_food_preparation_time: 5
+          description: "A list of dicts with a defined structure and with default a value."
+          options:
+            myapp_food_kind:
+              type: "str"
+              choices:
+                - "vegetables"
+                - "fruits"
+                - "grains"
+                - "meat"
+              required: false
+
+            myapp_food_boiling_required:
+              type: "bool"
+              required: false
+              default: false
+              description: "Whether the kind of food requires boiling before consumption."
+
+            myapp_food_preparation_time:
+              type: int
+              required: true
+              description: "Time to prepare a dish in minutes."
+
+        myapp_dict_with_suboptions:
+          type: "dict"
+          required: false
+          default:
+            myapp_host: "bar.foo"
+            myapp_exclude_host: true
+            myapp_path: "/etc/myapp"
+          description: "A dict with a defined structure and default values."
+          options:
+            myapp_host:
+              type: "str"
+              choices:
+                - "foo.bar"
+                - "bar.foo"
+                - "ansible.foo.bar"
+              required: true
+              description: "A string value with a limited list of allowed choices."
+
+            myapp_exclude_host:
+              type: "bool"
+              required: true
+              description: "A boolean value."
+
+            myapp_path:
+              type: "path"
+              required: true
+              description: "A path value."
+
+            original_name:
+              type: list
+              elements: "str"
+              required: false
+              description: "An optional list of string values."
+
+    # roles/myapp/tasks/alternate.yml entry point
+    alternate:
+      short_description: The alternate entry point for the myapp role.
+      version_added: 1.2.0
+      options:
+        myapp_int:
+          type: "int"
+          required: false
+          default: 1024
+          description: "The integer value, defaulting to 1024."
 
 .. _run_role_twice:
 


### PR DESCRIPTION
_This was move from: ansible/ansible#79994_

##### SUMMARY
The role argument validation documentation was missing some examples for list options with dicts and suboptions and dict options with suboptions as well as the author and version_added fields.

It now also documents the `version_added` field at the entrypoint level and options level.

It now also outputs the `version_added` at the entrypoint level.

Partly fixes: ansible/ansible#77964

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#specification-format
