### PR TITLE
Getting started guide: update and rearrange seealso items

### DIFF
--- a/docs/docsite/rst/getting_started/get_started_ansible.rst
+++ b/docs/docsite/rst/getting_started/get_started_ansible.rst
@@ -64,7 +64,5 @@ Continue by :ref:`learning how to build an inventory<get_started_inventory>`.
        Demonstrations of different Ansible usecases
    `Ansible Labs <https://www.ansible.com/products/ansible-training>`_
        Labs to provide further knowledge on different topics
-   `Mailing List <https://groups.google.com/group/ansible-project>`_
-       Questions? Help? Ideas?  Stop by the list on Google Groups
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Ansible Communication Guide<communication>`
+       Questions? Help? Ideas? Ask the community


### PR DESCRIPTION
Getting started guide: update and rearrange seealso items.

I'm not sure, looks like a lot of unnecessary stuff for newcomers in that seealso.
Maybe we should
1. leave only Labs there?
2. or maybe Labs and a link to the whole communication guide? e.g. `Questions? Help? Ideas? Ask the community <link to guide>.`

Ideas?