### PR TITLE
Keep changelogs and README.rst

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ changelogs/.plugin-cache.yaml
 /requirements.txt
 /setup.cfg
 /setup.py
+/README.rst

--- a/docs/bin/clone-core.py
+++ b/docs/bin/clone-core.py
@@ -18,6 +18,7 @@ def main() -> None:
         'lib',
         'packaging',
         'test/lib',
+        'changelogs',
     ]
 
     keep_files = [
@@ -26,6 +27,7 @@ def main() -> None:
         'requirements.txt',
         'setup.cfg',
         'setup.py',
+        'README.rst',
     ]
 
     branch = (ROOT / 'docs' / 'ansible-core-branch.txt').read_text().strip()


### PR DESCRIPTION
This PR updates the `bin/clone-core.py` to include the `changelogs` folder and the `README.rst` file. Including these bits resolves warnings during docs build:

```
WARNING:antsibull:mod=antsibull_core.subprocess_util|stderr: /tmp/build-env-ixwpz4p8/lib64/python3.11/site-packages/setuptools/config/expand.py:132: SetuptoolsWarning: File '/home/dnaro/git/ansible-documentation/README.rst' cannot be found
WARNING:antsibull:mod=antsibull_core.subprocess_util|stderr: return '\n'.join(
WARNING:antsibull:mod=antsibull_core.subprocess_util|stderr: warning: no files found matching 'changelogs/CHANGELOG*.rst'
WARNING:antsibull:mod=antsibull_core.subprocess_util|stderr: warning: no files found matching 'changelogs/changelog.yaml'
WARNING:antsibull:mod=antsibull_core.subprocess_util|stderr: /tmp/build-env-ixwpz4p8/lib64/python3.11/site-packages/setuptools/config/expand.py:132: SetuptoolsWarning: File '/tmp/.tmp-ansible-pep517-sayg8faj/src/README.rst' cannot be found
WARNING:antsibull:mod=antsibull_core.subprocess_util|stderr: return '\n'.join(
WARNING:antsibull:mod=antsibull_core.subprocess_util|stderr: warning: no files found matching 'changelogs/CHANGELOG*.rst'
WARNING:antsibull:mod=antsibull_core.subprocess_util|stderr: warning: no files found matching 'changelogs/changelog.yaml'
WARNING:antsibull:mod=antsibull_core.subprocess_util|stderr: warning: sdist: standard file not found: should have one of README, README.rst, README.txt, README.md
```