### PR TITLE
Bump antsibull-docs version to 2.2.0

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,4 +5,4 @@ sphinx == 5.3.0
 sphinx-notfound-page
 sphinx-ansible-theme
 rstcheck < 6  # rstcheck 6.x has problem with rstcheck.core triggered by include files w/ sphinx directives https://github.com/rstcheck/rstcheck-core/issues/3
-antsibull-docs == 2.0.0  # currently approved version
+antsibull-docs == 2.2.0  # currently approved version


### PR DESCRIPTION
Contains several bugfixes (compared to 2.1.0) for markup rendering, both in the Sphinx extension and in the RST output itself. See https://github.com/ansible-community/antsibull-docs/blob/main/CHANGELOG.rst#v2-2-0 and https://github.com/ansible-community/antsibull-docs/blob/main/CHANGELOG.rst#v2-1-0 for all bugfixes included.