### PR TITLE
Remove fallback for modules/plugins in ansible/ansible that didn't work since ansible-base/Ansible 2.10

### DIFF
--- a/docs/docsite/.templates/breadcrumbs.html
+++ b/docs/docsite/.templates/breadcrumbs.html
@@ -7,16 +7,8 @@
           <!-- User defined GitHub URL -->
           <a href="{{ meta['github_url'] }}" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
         {%- else %}
-          <!-- Ansible-specific additions for modules etc -->
-            {% if check_meta and pagename.endswith((
-                '_module', '_become', '_cache', '_callback',
-                '_connection', '_inventory', '_lookup',
-                '_shell', '_strategy', '_vars',
-               )) %}
-            {#  <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode or "blob" }}/{{ github_module_version }}{{ meta.get('source', '') }}?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr" class="fa fa-github"> {{ _('Edit on GitHub') }}</a> #}
-              <br>
             <!-- Remove main index page as it is no longer editable -->
-            {% elif pagename == 'index' %}
+            {% if pagename == 'index' %}
               <br>
             <!-- Remove all pages under collections/ as no longer editable -->
             {% elif pagename.startswith('collections/') %}


### PR DESCRIPTION
Fixes the first part of #33. This case right now mainly prevents that some pages have an Edit on GitHub link. All plugin/module/role pages are covered by the `if check_meta and 'github_url' in meta` (ansibull-docs includes `github_url` in the page's meta if it can figure the URL out) and `{% elif pagename.startswith('collections/') %}` cases.