### PR TITLE
[stable-2.15] Update gh repo name

### DIFF
--- a/docs/docsite/sphinx_conf/2.10_conf.py
+++ b/docs/docsite/sphinx_conf/2.10_conf.py
@@ -152,7 +152,7 @@ html_context = {
     'show_sphinx': False,
     'is_eol': False,
     'github_user': 'ansible',
-    'github_repo': 'ansible',
+    'github_repo': 'ansible-documentation',
     'github_version': 'devel/docs/docsite/rst/',
     'github_module_version': 'devel/lib/ansible/modules/',
     'github_root_dir': 'devel/lib/ansible',

--- a/docs/docsite/sphinx_conf/all_conf.py
+++ b/docs/docsite/sphinx_conf/all_conf.py
@@ -148,7 +148,7 @@ html_context = {
     'show_sphinx': False,
     'is_eol': False,
     'github_user': 'ansible',
-    'github_repo': 'ansible',
+    'github_repo': 'ansible-documentation',
     'github_version': 'devel/docs/docsite/rst/',
     'github_module_version': 'devel/lib/ansible/modules/',
     'github_root_dir': 'devel/lib/ansible',

--- a/docs/docsite/sphinx_conf/ansible_conf.py
+++ b/docs/docsite/sphinx_conf/ansible_conf.py
@@ -158,7 +158,7 @@ html_context = {
     'show_sphinx': False,
     'is_eol': False,
     'github_user': 'ansible',
-    'github_repo': 'ansible',
+    'github_repo': 'ansible-documentation',
     'github_version': 'devel/docs/docsite/rst/',
     'github_module_version': 'devel/lib/ansible/modules/',
     'github_root_dir': 'devel/lib/ansible',

--- a/docs/docsite/sphinx_conf/core_conf.py
+++ b/docs/docsite/sphinx_conf/core_conf.py
@@ -196,7 +196,7 @@ html_context = {
     'show_sphinx': False,
     'is_eol': False,
     'github_user': 'ansible',
-    'github_repo': 'ansible',
+    'github_repo': 'ansible-documentation',
     'github_version': 'devel/docs/docsite/rst/',
     'github_module_version': 'devel/lib/ansible/modules/',
     'github_root_dir': 'devel/lib/ansible',

--- a/docs/docsite/sphinx_conf/core_lang_conf.py
+++ b/docs/docsite/sphinx_conf/core_lang_conf.py
@@ -196,7 +196,7 @@ html_context = {
     'show_sphinx': False,
     'is_eol': False,
     'github_user': 'ansible',
-    'github_repo': 'ansible',
+    'github_repo': 'ansible-documentation',
     'github_version': 'devel/docs/docsite/rst/',
     'github_module_version': 'devel/lib/ansible/modules/',
     'github_root_dir': 'devel/lib/ansible',


### PR DESCRIPTION
Change the GH repo name so **Edit on GitHub** points to `ansible/ansible-documentation`.