### PR TITLE
[stable-2.15] Bump antsibull-docs version to 2.2.0

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,4 +5,4 @@ sphinx == 5.3.0
 sphinx-notfound-page
 sphinx-ansible-theme
 rstcheck < 6  # rstcheck 6.x has problem with rstcheck.core triggered by include files w/ sphinx directives https://github.com/rstcheck/rstcheck-core/issues/3
-antsibull-docs == 2.0.0  # currently approved version
+antsibull-docs == 2.2.0  # currently approved version


### PR DESCRIPTION
Backport of #32 to stable-2.15.

Now that we are no longer bound to the 'no new features in stable branches' policy of ansible/ansible, we can also upgrade antsibull-docs for the docs build in stable branches.

(Interestingly antsibull-docs has already been bumped from 1.x.y to 2.x.y in stable-2.15.)