### PR TITLE
Add patchback config

### DIFF
--- a/.github/patchback.yml
+++ b/.github/patchback.yml
@@ -1,0 +1,9 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+backport_branch_prefix: patchback/backports/
+backport_label_prefix: backport-
+target_branch_prefix: stable-
+...


### PR DESCRIPTION
Adds config for #41.

If this is wanted, the following needs to be done next:
1. Create labels `backport-2.13`, `backport-2.14`, `backport-2.15`;
2. Enable the patchback bot (https://github.com/apps/patchback) for this repository.

Then backporting PRs such as https://github.com/ansible/ansible-documentation/pull/42 to branches such as `stable-2.15` is as simple as adding the `backport-2.15` label to the original PR - the bot cherry-picks the commit and creates a PR for it.