### PR TITLE
Build script: remove no longer necessary workaround

### DIFF
--- a/hacking/build_library/build_ansible/command_plugins/docs_build.py
+++ b/hacking/build_library/build_ansible/command_plugins/docs_build.py
@@ -176,10 +176,6 @@ def generate_full_docs(args):
 
             deps_data['_ansible_core_version'] = ansible_core__version__
 
-            # antsibull-docs will choke when a key `_python` is found. Remove it to work around
-            # that until antsibull-docs is fixed.
-            deps_data.pop('_python', None)
-
             write_deps_file(modified_deps_file, deps_data)
 
             params = ['stable', '--deps-file', modified_deps_file]


### PR DESCRIPTION
This got fixed in antsibull-docs quite some time ago... (in 1.7.1 to be precise: https://github.com/ansible-community/antsibull-docs/blob/main/CHANGELOG.rst#v171)