### PR TITLE
plugin: add a note about the dataloader

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -422,7 +422,8 @@ Here's a simple lookup plugin implementation --- this lookup returns the content
               display.vvvv(u"File lookup using %s as file" % lookupfile)
               try:
                   if lookupfile:
-                      contents, show_data = self._loader._get_file_contents(lookupfile)
+                      # Get contents of the file using `_get_file_contents` API from `self.loader`
+                      contents, show_data = self.loader._get_file_contents(lookupfile)
                       ret.append(contents.rstrip())
                   else:
                       # Always use ansible error classes to throw 'final' exceptions,
@@ -438,6 +439,10 @@ Here's a simple lookup plugin implementation --- this lookup returns the content
 
           return ret
 
+.. note::
+
+  Use `plugin_obj.loader` to access the DataLoader APIs instead of using `plugin_obj._loader`.
+  As per architecture, not all plugins have access to `plugin_obj.loader`.
 
 The following is an example of how this lookup is called:
 


### PR DESCRIPTION
##### SUMMARY

Dataloader API can be accessed using `plugin_obj.loader`.
Updated the documentation about the same. Also, updated
docs for accessibility of dataloader to the plugins.

Fixes: ansible/ansible#81168

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE

- Docs Pull Request



##### COMPONENT NAME
docs/docsite/rst/dev_guide/developing_plugins.rst

