### PR TITLE
Undo changes to the Ansible collection inclusion requirements that were not voted on by the Steering Committee

### DIFF
--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -84,12 +84,12 @@ One example scenario where the "even if" clause comes into play is when using cl
 Controller environment
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Review the :ref:`support_life` for the versions of ``ansible-core`` that the collection supports. Collections MUST document the supported Python versions for plugins which cannot support all controller Python versions (for example, if required libraries do not support them).
+In the controller environment, collections MUST support Python 2 (version 2.7) and Python 3 (Version 3.6 and higher), unless required libraries do not support these versions. Collections SHOULD also support Python v3.5 if all required libraries support this version.
 
 Other environment
 ~~~~~~~~~~~~~~~~~
 
-Review the :ref:`support_life` for the versions of ``ansible-core`` that the collection supports. Collections MUST document the supported Python versions for modules which cannot support all target Python versions (for example, if required libraries do not support them).
+In the other environment, collections MUST support Python 2 (version 2.7) and Python 3 (Version 3.6 and higher), unless required libraries do not support these versions. Collections SHOULD also support Python v2.6 and v3.5 if all required libraries support this version.
 
 .. note::
 


### PR DESCRIPTION
These changes were made in https://github.com/ansible/ansible/commit/090a5cdfcfae3f92070f6292181d2eb3879252bd.

These sections really have to be updated, but this must not be done without approval by the Ansible Community Steering Committe. I'm reverting them so we can start with the currently approved version.

CC @samccann @s-hertel @mattclay

Also CC @gotmax23 @mariolenz