### PR TITLE
Bump antsibull-docs version to 2.3.0 to support :ansplugin: and fix some aliases related bugs

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,4 +5,4 @@ sphinx == 5.3.0
 sphinx-notfound-page
 sphinx-ansible-theme
 rstcheck < 6  # rstcheck 6.x has problem with rstcheck.core triggered by include files w/ sphinx directives https://github.com/rstcheck/rstcheck-core/issues/3
-antsibull-docs == 2.2.0  # currently approved version
+antsibull-docs == 2.3.0  # currently approved version


### PR DESCRIPTION
See https://github.com/ansible-community/antsibull-docs/blob/main/CHANGELOG.rst#v2-3-0 for a detailled changelog.

The changes affecting the docs build are:

Features:
- Add a `:ansplugin:` role to the Sphinx extension. This allows to reference a module, plugin, or role with the fqcn#type syntax from semantic markup instead of having to manually compose a `ansible_collections.{fqcn}_{type}` label. An explicit reference title can also be provided with the `title <fqcn#type>` syntax similar to the `:ref:` role (https://github.com/ansible-community/antsibull-docs/pull/180).
- When parsing errors happen in the Sphinx extension, the extension now emits error messages during the build process in addition to error markup (https://github.com/ansible-community/antsibull-docs/pull/187).

Bugfixes:
- Make sure that all aliases are actually listed for plugins (https://github.com/ansible-community/antsibull-docs/pull/183).
- When looking for redirects, the `aliases` field and filesystem redirects in ansible-core were not properly considered. This ensures that all redirect stubs are created, and that no duplicates show up, not depending on whether ansible-core is installed in editable mode or not (https://github.com/ansible-community/antsibull-docs/pull/183).
