### PR TITLE
[stable-2.15] Bump antsibull-docs version to 2.3.0 to support :ansplugin: and fix some aliases related bugs

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,4 +5,4 @@ sphinx == 5.3.0
 sphinx-notfound-page
 sphinx-ansible-theme
 rstcheck < 6  # rstcheck 6.x has problem with rstcheck.core triggered by include files w/ sphinx directives https://github.com/rstcheck/rstcheck-core/issues/3
-antsibull-docs == 2.2.0  # currently approved version
+antsibull-docs == 2.3.0  # currently approved version


### PR DESCRIPTION
Backport of #64 to stable-2.15.
