### PR TITLE
Add CODEOWNERS for docs owned by the Steering Committee

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+/docs/docsite/rst/community/collection_contributors/collection_requirements.rst @ansible/steering-committee
+/docs/docsite/rst/community/steering/* @ansible/steering-committee
+/docs/docsite/rst/roadmap/COLLECTIONS_*.rst @ansible/steering-committee


### PR DESCRIPTION
I'm not interested in branch protection, but I like that this makes it clear which files we own and ensures that SC members are made aware of changes even if they're not watching the repository.

Relates: https://github.com/ansible/ansible-documentation/pull/63
Suggested-by: @gundalow