### PR TITLE
Specify default(omit) is for modules in playbooks_filters.rst

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_filters.rst
@@ -43,7 +43,7 @@ If you want to use the default value when variables evaluate to false or an empt
 Making variables optional
 -------------------------
 
-By default Ansible requires values for all variables in a templated expression. However, you can make specific variables optional. For example, you might want to use a system default for some items and control the value for others. To make a variable optional, set the default value to the special variable ``omit``:
+By default Ansible requires values for all variables in a templated expression. However, you can make specific module variables optional. For example, you might want to use a system default for some items and control the value for others. To make a module variable optional, set the default value to the special variable ``omit``:
 
 .. code-block:: yaml+jinja
 


### PR DESCRIPTION
Per https://github.com/ansible/ansible/issues/22417 , default(omit) is only intended for use with modules. The official documentation for default(omit) makes no mention of this limitation/restriction and based on that issue thread alone causes a lot of confusion for people who intend to use it within roles. If the functionality is not going to be added to other functionalities like roles due to original scope/intent or difficulty, the documentation should clearly state this limitation.