### PR TITLE
Replace apt-key with signed-by in Debian install instructions

### DIFF
--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -116,6 +116,8 @@ To get a more recent version Debian users can use the Ubuntu PPA according to th
     - Ubuntu 18.04 (Bionic)
     - bionic
 
+In the following we assume that you have installed wget and gpg (`sudo apt install wget gpg`).
+
 Run the following commands to add the repository and install Ansible.
 Replace the export of UBUNTU_CODENAME as per the table above (in this example we use jammy).
 

--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -86,13 +86,13 @@ To configure the PPA on your system and install Ansible run these commands:
 
 .. note:: On older Ubuntu distributions, "software-properties-common" is called "python-software-properties". You may want to use ``apt-get`` rather than ``apt`` in older versions. Also, be aware that only newer distributions (that is, 18.04, 18.10, and later) have a ``-u`` or ``--update`` flag. Adjust your script as needed.
 
-Please file issues in `the PPA's issue tracker <https://github.com/ansible-community/ppa/issues>`_.
+File any issues in `the PPA's issue tracker <https://github.com/ansible-community/ppa/issues>`_.
 
 
 Installing Ansible on Debian
 ----------------------------
 
-While Ansible is available from the `main Debian repository <https://packages.debian.org/stable/ansible>`_, it can be out-of-date.
+While Ansible is available from the `main Debian repository <https://packages.debian.org/stable/ansible>`_, it can be out of date.
 
 To get a more recent version, Debian users can use the Ubuntu PPA according to the following table:
 
@@ -119,7 +119,7 @@ To get a more recent version, Debian users can use the Ubuntu PPA according to t
 In the following example, we assume that you have wget and gpg already installed (``sudo apt install wget gpg``).
 
 Run the following commands to add the repository and install Ansible.
-Set ``UBUNTU_CODENAME=...`` as per the table above (we use ``jammy`` in this example).
+Set ``UBUNTU_CODENAME=...`` based on the table above (we use ``jammy`` in this example).
 
 .. code-block:: bash
 

--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -86,7 +86,7 @@ To configure the PPA on your system and install Ansible run these commands:
 
 .. note:: On older Ubuntu distributions, "software-properties-common" is called "python-software-properties". You may want to use ``apt-get`` rather than ``apt`` in older versions. Also, be aware that only newer distributions (that is, 18.04, 18.10, and later) have a ``-u`` or ``--update`` flag. Adjust your script as needed.
 
-Please file issues `here <https://github.com/ansible-community/ppa/issues>`_.
+Please file issues in `the PPA's issue tracker <https://github.com/ansible-community/ppa/issues>`_.
 
 
 Installing Ansible on Debian
@@ -94,7 +94,7 @@ Installing Ansible on Debian
 
 While Ansible is available from the `main Debian repository <https://packages.debian.org/stable/ansible>`_, it can be out-of-date.
 
-To get a more recent version Debian users can use the Ubuntu PPA according to the following table:
+To get a more recent version, Debian users can use the Ubuntu PPA according to the following table:
 
 .. list-table::
   :header-rows: 1
@@ -106,20 +106,20 @@ To get a more recent version Debian users can use the Ubuntu PPA according to th
   * - Debian 12 (Bookworm)
     - ->
     - Ubuntu 22.04 (Jammy)
-    - jammy
+    - ``jammy``
   * - Debian 11 (Bullseye)
     - ->
     - Ubuntu 20.04 (Focal)
-    - focal
+    - ``focal``
   * - Debian 10 (Buster)
     - ->
     - Ubuntu 18.04 (Bionic)
-    - bionic
+    - ``bionic``
 
-In the following we assume that you have installed wget and gpg (`sudo apt install wget gpg`).
+In the following example, we assume that you have wget and gpg already installed (``sudo apt install wget gpg``).
 
 Run the following commands to add the repository and install Ansible.
-Replace the export of UBUNTU_CODENAME as per the table above (in this example we use jammy).
+Set ``UBUNTU_CODENAME=...`` as per the table above (we use ``jammy`` in this example).
 
 .. code-block:: bash
 
@@ -133,11 +133,12 @@ Around the "echo deb" it is important to use " " rather than ' '.
 
 These commands download the signing key and add an entry to apt's sources pointing to the PPA.
 
-Previously you may haved used `apt-key add`.
+Previously, you may have used ``apt-key add``.
 This is now `deprecated <https://manpages.debian.org/testing/apt/apt-key.8.en.html>`_
 for security reasons (on Debian, Ubuntu, and elsewhere).
-For more details see `this AskUbuntu post <https://askubuntu.com/a/1307181>`_.
-Also note that for security reasons we do NOT add the key to `/etc/apt/trusted.gpg.d/` or `/etc/apt/trusted.gpg` where it would be allowed to sign releases from ANY repository.
+For more details, see `this AskUbuntu post <https://askubuntu.com/a/1307181>`_.
+Also note that, for security reasons, we do NOT add the key to ``/etc/apt/trusted.gpg.d/``
+nor to ``/etc/apt/trusted.gpg`` where it would be allowed to sign releases from ANY repository.
 
 .. _from_windows:
 

--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -103,6 +103,10 @@ To get a more recent version Debian users can use the Ubuntu PPA according to th
     -
     - Ubuntu
     - UBUNTU_CODENAME
+  * - Debian 12 (Bookworm)
+    - ->
+    - Ubuntu 22.04 (Jammy)
+    - jammy
   * - Debian 11 (Bullseye)
     - ->
     - Ubuntu 20.04 (Focal)

--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -134,7 +134,8 @@ Around the "echo deb" it is important to use " " rather than ' '.
 These commands download the signing key and add an entry to apt's sources pointing to the PPA.
 
 Previously you may haved used `apt-key add`.
-This is now deprecated for security reasons (on Debian, Ubuntu, and elsewhere).
+This is now `deprecated <https://manpages.debian.org/testing/apt/apt-key.8.en.html>`_
+for security reasons (on Debian, Ubuntu, and elsewhere).
 For more details see `this AskUbuntu post <https://askubuntu.com/a/1307181>`_.
 Also note that for security reasons we do NOT add the key to `/etc/apt/trusted.gpg.d/` or `/etc/apt/trusted.gpg` where it would be allowed to sign releases from ANY repository.
 

--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -131,6 +131,12 @@ Replace the export of UBUNTU_CODENAME as per the table above (in this example we
 Note: the " " around the keyserver URL are important.
 Around the "echo deb" it is important to use " " rather than ' '.
 
+These commands download the signing key and add an entry to apt's sources pointing to the PPA.
+
+Previously you may haved used `apt-key add`.
+This is now deprecated for security reasons (on Debian, Ubuntu, and elsewhere).
+For more details see `this AskUbuntu post <https://askubuntu.com/a/1307181>`_.
+Also note that for security reasons we do NOT add the key to `/etc/apt/trusted.gpg.d/` or `/etc/apt/trusted.gpg` where it would be allowed to sign releases from ANY repository.
 
 .. _from_windows:
 

--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -121,7 +121,7 @@ Replace the export of UBUNTU_CODENAME as per the table above (in this example we
 
 .. code-block:: bash
 
-    $ export UBUNTU_CODENAME=jammy
+    $ UBUNTU_CODENAME=jammy
     $ wget -O- "https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=get&search=0x6125E2A8C77F2818FB7BD15B93C4A3FD7BB9C367" | sudo gpg --dearmour -o /usr/share/keyrings/ansible-archive-keyring.gpg
     $ echo "deb [signed-by=/usr/share/keyrings/ansible-archive-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu $UBUNTU_CODENAME main" | sudo tee /etc/apt/sources.list.d/ansible.list
     $ sudo apt update && sudo apt install ansible

--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -113,15 +113,17 @@ To get a more recent version Debian users can use the Ubuntu PPA according to th
     - bionic
 
 Run the following commands to add the repository and install Ansible.
-Replace UBUNTU_CODENAME as per the table above.
+Replace the export of UBUNTU_CODENAME as per the table above (in this example we use jammy).
 
 .. code-block:: bash
 
-    $ wget -O- 'https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=get&search=0x6125E2A8C77F2818FB7BD15B93C4A3FD7BB9C367' | sudo gpg --dearmour -o /usr/share/keyrings/ansible-archive-keyring.gpg
-    $ echo 'deb [signed-by=/usr/share/keyrings/ansible-archive-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu UBUNTU_CODENAME main' | sudo tee /etc/apt/sources.list.d/ansible.list
+    $ export UBUNTU_CODENAME=jammy
+    $ wget -O- "https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=get&search=0x6125E2A8C77F2818FB7BD15B93C4A3FD7BB9C367" | sudo gpg --dearmour -o /usr/share/keyrings/ansible-archive-keyring.gpg
+    $ echo "deb [signed-by=/usr/share/keyrings/ansible-archive-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu $UBUNTU_CODENAME main" | sudo tee /etc/apt/sources.list.d/ansible.list
     $ sudo apt update && sudo apt install ansible
 
-Note: the ' ' around the keyserver URL are important.
+Note: the " " around the keyserver URL are important.
+Around the "echo deb" it is important to use " " rather than ' '.
 
 
 .. _from_windows:

--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -86,13 +86,15 @@ To configure the PPA on your system and install Ansible run these commands:
 
 .. note:: On older Ubuntu distributions, "software-properties-common" is called "python-software-properties". You may want to use ``apt-get`` rather than ``apt`` in older versions. Also, be aware that only newer distributions (that is, 18.04, 18.10, and later) have a ``-u`` or ``--update`` flag. Adjust your script as needed.
 
-
+Please file issues `here <https://github.com/ansible-community/ppa/issues>`_.
 
 
 Installing Ansible on Debian
 ----------------------------
 
-Debian users can use the same source as the Ubuntu PPA (using the following table).
+While Ansible is available from the `main Debian repository <https://packages.debian.org/stable/ansible>`_, it can be out-of-date.
+
+To get a more recent version Debian users can use the Ubuntu PPA according to the following table:
 
 .. list-table::
   :header-rows: 1
@@ -100,38 +102,26 @@ Debian users can use the same source as the Ubuntu PPA (using the following tabl
   * - Debian
     -
     - Ubuntu
+    - UBUNTU_CODENAME
   * - Debian 11 (Bullseye)
     - ->
     - Ubuntu 20.04 (Focal)
+    - focal
   * - Debian 10 (Buster)
     - ->
     - Ubuntu 18.04 (Bionic)
+    - bionic
 
-
-.. note::
-
-    Ansible releases are only built for Ubuntu 18.04 (Bionic) or later releases.
-
-Add the following line to ``/etc/apt/sources.list`` or ``/etc/apt/sources.list.d/ansible.list``:
+Run the following commands to add the repository and install Ansible.
+Replace UBUNTU_CODENAME as per the table above.
 
 .. code-block:: bash
 
-    deb http://ppa.launchpad.net/ansible/ansible/ubuntu MATCHING_UBUNTU_CODENAME_HERE main
+    $ wget -O- 'https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=get&search=0x6125E2A8C77F2818FB7BD15B93C4A3FD7BB9C367' | sudo gpg --dearmour -o /usr/share/keyrings/ansible-archive-keyring.gpg
+    $ echo 'deb [signed-by=/usr/share/keyrings/ansible-archive-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu UBUNTU_CODENAME main' | sudo tee /etc/apt/sources.list.d/ansible.list
+    $ sudo apt update && sudo apt install ansible
 
-Example for Debian 11 (Bullseye)
-
-.. code-block:: bash
-
-    deb http://ppa.launchpad.net/ansible/ansible/ubuntu focal main
-
-Then run these commands:
-
-.. code-block:: bash
-
-    $ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
-    $ sudo apt update
-    $ sudo apt install ansible
-
+Note: the ' ' around the keyserver URL are important.
 
 
 .. _from_windows:


### PR DESCRIPTION
apt-key is deprecated for security reasons.
See https://stackoverflow.com/a/71384057/11076036

I tested the new instructions to work on both Debian 10 and 11.

I did *not* build the documentation to check whether it looks right (I'm too lazy to set up the environment). But Github renders it okay.