### PR TITLE
Add Github Action to label issues and PRs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,8 +4,11 @@
 
 "on":
   pull_request_target:
+  issues:
+    types:
+      - opened
 
-name: "Triage PRs"
+name: "Triage Issues and PRs"
 
 permissions:
   issues: write
@@ -14,7 +17,7 @@ permissions:
 jobs:
   label_prs:
     runs-on: ubuntu-latest
-    name: "Label PRs"
+    name: "Label Issue/PR"
     steps:
       - name: Checkout parent repository
         uses: actions/checkout@v3
@@ -26,8 +29,15 @@ jobs:
         run: |
           python -m venv venv
           ./venv/bin/pip install -r hacking/pr_labeler/requirements.txt
-      - name: Run the PR labeler
+      - name: "Run the issue labeler"
+        if: "github.event.issue"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
+        run:
+          ./venv/bin/python hacking/pr_labeler/label.py issue ${{ github.event.issue.number }}
+      - name: "Run the PR labeler"
+        if: "! github.event.issue"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run:
           ./venv/bin/python hacking/pr_labeler/label.py pr ${{ github.event.number }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,33 @@
+---
+# Copyright (C) 2023 Maxwell G <maxwell@gtmx.me>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"on":
+  pull_request_target:
+
+name: "Triage PRs"
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  label_prs:
+    runs-on: ubuntu-latest
+    name: "Label PRs"
+    steps:
+      - name: Checkout parent repository
+        uses: actions/checkout@v3
+      - name: Install Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Setup venv
+        run: |
+          python -m venv venv
+          ./venv/bin/pip install -r hacking/pr_labeler/requirements.txt
+      - name: Run the PR labeler
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./venv/bin/python hacking/pr_labeler/label.py pr ${{ github.event.number }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -19,6 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     name: "Label Issue/PR"
     steps:
+      - name: Print event information
+        run: |
+          echo "${{ toJSON(github.event) }}"
       - name: Checkout parent repository
         uses: actions/checkout@v3
       - name: Install Python 3.11

--- a/hacking/pr_labeler/label.py
+++ b/hacking/pr_labeler/label.py
@@ -1,0 +1,60 @@
+# Copyright (C) 2023 Maxwell G <maxwell@gtmx.me>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import github
+import github.Auth
+import github.PullRequest
+import typer
+from codeowners import CodeOwners, OwnerTuple
+
+OWNER = "ansible"
+REPO = "ansible-documentation"
+LABELS_BY_CODEOWNER: dict[OwnerTuple, list[str]] = {
+    ("TEAM", "@ansible/steering-committee"): ["sc_approval"],
+}
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent.parent
+CODEOWNERS = (ROOT / ".github/CODEOWNERS").read_text("utf-8")
+
+
+def handle_codeowner_labels(pr: github.PullRequest.PullRequest) -> None:
+    labels = LABELS_BY_CODEOWNER.copy()
+    owners = CodeOwners(CODEOWNERS)
+    files = pr.get_files()
+    for file in files:
+        for owner in owners.of(file.filename):
+            if labels_to_add := labels.pop(owner, None):
+                print("Adding labels to", f"{pr.id}:", *map(repr, labels_to_add))
+                pr.add_to_labels(*labels_to_add)
+        if not labels:
+            return
+
+
+APP = typer.Typer()
+
+
+@APP.callback()
+def cb():
+    """
+    Basic triager for ansible/ansible-documentation
+    """
+
+
+@APP.command()
+def pr(pr_number: int) -> None:
+    gclient = github.Github(auth=github.Auth.Token(os.environ["GITHUB_TOKEN"]))
+    repo = gclient.get_repo(f"{OWNER}/{REPO}")
+    pr = repo.get_pull(pr_number)
+    if pr.state != "open":
+        print("Refusing to process closed ticket")
+        return
+    handle_codeowner_labels(pr)
+
+
+if __name__ == "__main__":
+    APP()

--- a/hacking/pr_labeler/label.py
+++ b/hacking/pr_labeler/label.py
@@ -3,11 +3,15 @@
 
 from __future__ import annotations
 
+import dataclasses
 import os
+from collections.abc import Collection
+from functools import cache
 from pathlib import Path
 
 import github
 import github.Auth
+import github.Repository
 import github.PullRequest
 import typer
 from codeowners import CodeOwners, OwnerTuple
@@ -22,17 +26,45 @@ ROOT = HERE.parent.parent
 CODEOWNERS = (ROOT / ".github/CODEOWNERS").read_text("utf-8")
 
 
-def handle_codeowner_labels(pr: github.PullRequest.PullRequest) -> None:
+@dataclasses.dataclass(frozen=True)
+class LabelerCtx:
+    client: github.Github
+    repo: github.Repository.Repository
+    pr: github.PullRequest.PullRequest
+    dry_run: bool
+
+
+@cache
+def get_previously_labeled(ctx: LabelerCtx) -> frozenset[str]:
+    previously_labeled: set[str] = set()
+    for event in ctx.pr.get_issue_events():
+        if event.event in ("labeled", "unlabeled"):
+            assert event.label
+            previously_labeled.add(event.label.name)
+    return frozenset(previously_labeled)
+
+
+def handle_codeowner_labels(ctx: LabelerCtx) -> None:
     labels = LABELS_BY_CODEOWNER.copy()
     owners = CodeOwners(CODEOWNERS)
-    files = pr.get_files()
+    files = ctx.pr.get_files()
     for file in files:
         for owner in owners.of(file.filename):
             if labels_to_add := labels.pop(owner, None):
-                print("Adding labels to", f"{pr.id}:", *map(repr, labels_to_add))
-                pr.add_to_labels(*labels_to_add)
+                add_label_if_new(ctx, labels_to_add)
         if not labels:
             return
+
+
+def add_label_if_new(ctx: LabelerCtx, labels: Collection[str] | str) -> None:
+    """
+    Add a label to a PR if it wasn't added in the past
+    """
+    labels = {labels} if isinstance(labels, str) else labels
+    previously_labeled = get_previously_labeled(ctx)
+    print(f"Adding labels to {ctx.pr.number}:", *map(repr, labels))
+    if not ctx.dry_run:
+        ctx.pr.add_to_labels(*(set(labels) - previously_labeled))
 
 
 APP = typer.Typer()
@@ -46,14 +78,18 @@ def cb():
 
 
 @APP.command()
-def pr(pr_number: int) -> None:
-    gclient = github.Github(auth=github.Auth.Token(os.environ["GITHUB_TOKEN"]))
+def pr(pr_number: int, dry_run: bool = False) -> None:
+    gclient = github.Github(
+        auth=None if dry_run else github.Auth.Token(os.environ["GITHUB_TOKEN"]),
+    )
     repo = gclient.get_repo(f"{OWNER}/{REPO}")
     pr = repo.get_pull(pr_number)
     if pr.state != "open":
         print("Refusing to process closed ticket")
         return
-    handle_codeowner_labels(pr)
+    ctx = LabelerCtx(gclient, repo, pr, dry_run)
+    handle_codeowner_labels(ctx)
+    add_label_if_new(ctx, "needs_triage")
 
 
 if __name__ == "__main__":

--- a/hacking/pr_labeler/requirements.txt
+++ b/hacking/pr_labeler/requirements.txt
@@ -1,0 +1,3 @@
+codeowners
+pygithub
+typer


### PR DESCRIPTION
This script adds an `sc_approval` label to all PRs that touch files owned by `@ansible/steering-committee` in CODEOWNERS. It also add a `needs_triage` label to new issues and PRs.

This is based on discussion with @samccann and @felixfontein in #ansible-docs earlier today.

This script is relatively simple, but we should be able to easily expand it to add other labels or do other types of triage.

Relates: https://github.com/ansible/ansible-documentation/issues/101