### PR TITLE
development_process.rst: rework Ansibot workflow

### DIFF
--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -37,7 +37,7 @@ If you want to contribute a feature or fix a bug in ``ansible-core`` or in a col
 Here's an overview of the PR lifecycle:
 
 * Contributor opens a PR (always against the ``devel`` branch)
-* `Ansibot <https://github.com/mkrizek/ansibotmini/blob/main/README.md>`_ triages the PR
+* `Ansibot <https://github.com/ansible/ansibotmini#ansibotmini>`_ triages the PR
 * Azure Pipelines runs the test suite
 * Developers, maintainers, community review the PR
 * Contributor addresses any feedback from reviewers

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -37,103 +37,13 @@ If you want to contribute a feature or fix a bug in ``ansible-core`` or in a col
 Here's an overview of the PR lifecycle:
 
 * Contributor opens a PR (always against the ``devel`` branch)
-* Ansibot reviews the PR
-* Ansibot assigns labels
-* Ansibot pings maintainers
+* `Ansibot <https://github.com/mkrizek/ansibotmini/blob/main/README.md>`_ triages the PR
 * Azure Pipelines runs the test suite
 * Developers, maintainers, community review the PR
 * Contributor addresses any feedback from reviewers
 * Developers, maintainers, community re-review
 * PR merged or closed
 * PR :ref:`backported <backport_process>` to one or more ``stable-X.Y`` branches (optional, bugfixes only)
-
-Automated PR review: ansibullbot
---------------------------------
-
-Because Ansible receives many pull requests, and because we love automating things, we have automated several steps of the process of reviewing and merging pull requests with a tool called Ansibullbot, or Ansibot for short.
-
-`Ansibullbot <https://github.com/ansible/ansibullbot/blob/master/ISSUE_HELP.md>`_ serves many functions:
-
-- Responds quickly to PR submitters to thank them for submitting their PR
-- Identifies the community maintainer responsible for reviewing PRs for any files affected
-- Tracks the current status of PRs
-- Pings responsible parties to remind them of any PR actions for which they may be responsible
-- Provides maintainers with the ability to move PRs through the workflow
-- Identifies PRs abandoned by their submitters so that we can close them
-- Identifies modules abandoned by their maintainers so that we can find new maintainers
-
-Ansibot workflow
-^^^^^^^^^^^^^^^^
-
-Ansibullbot runs continuously. You can generally expect to see changes to your issue or pull request within thirty minutes. Ansibullbot examines every open pull request in the repositories, and enforces state roughly according to the following workflow:
-
--  If a pull request has no workflow labels, it's considered **new**. Files in the pull request are identified, and the maintainers of those files are pinged by the bot, along with instructions on how to review the pull request. (Note: sometimes we strip labels from a pull request to "reboot" this process.)
--  If the module maintainer is not ``$team_ansible``, the pull request then goes into the **community_review** state.
--  If the module maintainer is ``$team_ansible``, the pull request then goes into the **core_review** state (and probably sits for a while).
--  If the pull request is in **community_review** and has received comments from the maintainer:
-
-   -  If the maintainer says ``shipit``, the pull request is labeled **shipit**, whereupon the Core team assesses it for final merge.
-   -  If the maintainer says ``needs_info``, the pull request is labeled **needs_info** and the submitter is asked for more info.
-   -  If the maintainer says **needs_revision**, the pull request is labeled **needs_revision** and the submitter is asked to fix some things.
-
--  If the submitter says ``ready_for_review``, the pull request is put back into **community_review** or **core_review** and the maintainer is notified that the pull request is ready to be reviewed again.
--  If the pull request is labeled **needs_revision** or **needs_info** and the submitter has not responded lately:
-
-   -  The submitter is first politely pinged after two weeks, pinged again after two more weeks and labeled **pending action**, and the issue or pull request will be closed two weeks after that.
-   -  If the submitter responds at all, the clock is reset.
--  If the pull request is labeled **community_review** and the reviewer has not responded lately:
-
-   -  The reviewer is first politely pinged after two weeks, pinged again after two more weeks and labeled **pending_action**, and then may be reassigned to ``$team_ansible`` or labeled **core_review**, or often the submitter of the pull request is asked to step up as a maintainer.
--  If Azure Pipelines tests fail, or if the code is not able to be merged, the pull request is automatically put into **needs_revision** along with a message to the submitter explaining why.
-
-There are corner cases and frequent refinements, but this is the workflow in general.
-
-PR labels
-^^^^^^^^^
-
-There are two types of PR Labels generally: **workflow** labels and **information** labels.
-
-Workflow labels
-"""""""""""""""
-
--  **community_review**: Pull requests for modules that are currently awaiting review by their maintainers in the Ansible community.
--  **core_review**: Pull requests for modules that are currently awaiting review by their maintainers on the Ansible Core team.
--  **needs_info**: Waiting on info from the submitter.
--  **needs_rebase**: Waiting on the submitter to rebase.
--  **needs_revision**: Waiting on the submitter to make changes.
--  **shipit**: Waiting for final review by the core team for potential merge.
-
-Information labels
-""""""""""""""""""
-
--  **backport**: this is applied automatically if the PR is requested against any branch that is not devel. The bot immediately assigns the labels backport and ``core_review``.
--  **bugfix_pull_request**: applied by the bot based on the templatized description of the PR.
--  **cloud**: applied by the bot based on the paths of the modified files.
--  **docs_pull_request**: applied by the bot based on the templatized description of the PR.
--  **easyfix**: applied manually, inconsistently used but sometimes useful.
--  **feature_pull_request**: applied by the bot based on the templatized description of the PR.
--  **networking**: applied by the bot based on the paths of the modified files.
--  **owner_pr**: largely deprecated. Formerly workflow, now informational. Originally, PRs submitted by the maintainer would automatically go to **shipit** based on this label. If the submitter is also a maintainer, we notify the other maintainers and still require one of the maintainers (including the submitter) to give a **shipit**.
--  **pending_action**: applied by the bot to PRs that are not moving. Reviewed every couple of weeks by the community team, who tries to figure out the appropriate action (closure, asking for new maintainers, and so on).
-
-
-Special Labels
-""""""""""""""
-
--  **new_plugin**: this is for new modules or plugins that are not yet in Ansible.
-
-**Note:** `new_plugin` kicks off a completely separate process, and frankly it doesn't work very well at present. We're working our best to improve this process.
-
-Human PR review
----------------
-
-After Ansibot reviews the PR and applies labels, the PR is ready for human review. The most likely reviewers for any PR are the maintainers for the module that PR modifies.
-
-Each module has at least one assigned :ref:`maintainer <maintainers>`, listed in the `BOTMETA.yml <https://github.com/ansible/ansible/blob/devel/.github/BOTMETA.yml>`_ file.
-
-The maintainer's job is to review PRs that affect that module and decide whether they should be merged (``shipit``) or revised (``needs_revision``). We'd like to have at least one community maintainer for every module. If a module has no community maintainers assigned, the maintainer is listed as ``$team_ansible``.
-
-Once a human applies the ``shipit`` label, the :ref:`committers <community_committer_guidelines>` decide whether the PR is ready to be merged. Not every PR that gets the ``shipit`` label is actually ready to be merged, but the better our reviewers are, and the better our guidelines are, the more likely it will be that a PR that reaches **shipit** will be mergeable.
 
 
 Making your PR merge-worthy

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -37,7 +37,8 @@ If you want to contribute a feature or fix a bug in ``ansible-core`` or in a col
 Here's an overview of the PR lifecycle:
 
 * Contributor opens a PR (always against the ``devel`` branch)
-* `Ansibot <https://github.com/ansible/ansibotmini#ansibotmini>`_ triages the PR
+* ansible-core uses `Ansibot <https://github.com/ansible/ansibotmini#ansibotmini>`_ to triage the PR.
+  Some collection repositories use `Ansibullbot <https://github.com/ansible-community/collection_bot/blob/main/ISSUE_HELP.md>`_ to triage the PR. For most collections, this is done manually or by other means.
 * Azure Pipelines runs the test suite
 * Developers, maintainers, community review the PR
 * Contributor addresses any feedback from reviewers


### PR DESCRIPTION
With the `ansible/ansible` repo split into collections and the recent ansibot rewrite most of the information in the `Micro development: the lifecycle of a PR` section is outdated. It seems easier to just link to the bot's `README` file instead.