### PR TITLE
[stable-2.15] Use semantic markup

### DIFF
--- a/docs/docsite/rst/community/collection_contributors/collection_integration_about.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_integration_about.rst
@@ -17,7 +17,7 @@ There are :ref:`two kinds of integration tests <collections_adding_integration_t
 
 This section focuses on integration tests that use Ansible roles.
 
-Integration tests check modules with playbooks that invoke those modules. The tests pass standalone parameters and their combinations, check what the module or plugin reports with the :ref:`assert <ansible_collections.ansible.builtin.assert_module>` module, and the actual state of the system after each task.
+Integration tests check modules with playbooks that invoke those modules. The tests pass standalone parameters and their combinations, check what the module or plugin reports with the :ansplugin:`assert <ansible.builtin.assert#module>` module, and the actual state of the system after each task.
 
 Integration test example
 -------------------------
@@ -122,12 +122,12 @@ Each test action has to be tested at least the following times:
 
 To check a task:
 
-1. Register the outcome of the task as a variable, for example, ``register: result``. Using the :ref:`assert <ansible_collections.ansible.builtin.assert_module>` module, check:
+1. Register the outcome of the task as a variable, for example, ``register: result``. Using the :ansplugin:`assert <ansible.builtin.assert#module>` module, check:
 
   #. If ``- result is changed`` or not.
   #. Expected return values.
 
-2. If the module changes the system state, check the actual system state using at least one other module. For example, if the module changes a file, we can check that the file has been changed by checking its checksum with the :ref:`stat <ansible_collections.ansible.builtin.stat_module>` module before and after the test tasks.
+2. If the module changes the system state, check the actual system state using at least one other module. For example, if the module changes a file, we can check that the file has been changed by checking its checksum with the :ansplugin:`stat <ansible.builtin.stat#module>` module before and after the test tasks.
 3. Run the same task with ``check_mode: true`` if check-mode is supported by the module. Check with other modules that the actual system state has not been changed.
 4. Cover cases when the module must fail. Use the ``ignore_errors: true`` option and check the returned message with the ``assert`` module.
 

--- a/docs/docsite/rst/dev_guide/developing_collections_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_documenting.rst
@@ -12,7 +12,7 @@ Documenting modules is thoroughly documented in :ref:`module_documenting`. Plugi
 Documenting roles
 =================
 
-To document a role, you have to add a role argument spec by creating a file ``meta/argument_specs.yml`` in your role. See :ref:`role_argument_spec` for details. As an example, you can look at `the argument specs file <https://github.com/sensu/sensu-go-ansible/blob/master/roles/install/meta/argument_specs.yml>`_ of the :ref:`sensu.sensu_go.install role <ansible_collections.sensu.sensu_go.install_role>` on GitHub.
+To document a role, you have to add a role argument spec by creating a file ``meta/argument_specs.yml`` in your role. See :ref:`role_argument_spec` for details. As an example, you can look at `the argument specs file <https://github.com/sensu/sensu-go-ansible/blob/master/roles/install/meta/argument_specs.yml>`_ of the :ansplugin:`sensu.sensu_go.install role <sensu.sensu_go.install#role>` on GitHub.
 
 .. _build_collection_docsite:
 

--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -193,7 +193,7 @@ All fields in the ``DOCUMENTATION`` block are lower-case. All fields are require
   :suboptions:
 
     * If this option takes a dict or list of dicts, you can define the structure here.
-    * See :ref:`ansible_collections.azure.azcollection.azure_rm_securitygroup_module`, :ref:`ansible_collections.azure.azcollection.azure_rm_azurefirewall_module`, and :ref:`ansible_collections.openstack.cloud.baremetal_node_action_module` for examples.
+    * See :ansplugin:`azure.azcollection.azure_rm_securitygroup#module`, :ansplugin:`azure.azcollection.azure_rm_azurefirewall#module`, and :ansplugin:`openstack.cloud.baremetal_node_action#module` for examples.
 
 :requirements:
 
@@ -233,7 +233,6 @@ All fields in the ``DOCUMENTATION`` block are lower-case. All fields are require
 
 
   * If you use ``ref:`` to link to an anchor that is not associated with a title, you must add a title to the ref for the link to work correctly.
-  * You can link to non-module plugins with ``ref:`` using the rST anchor, but plugin and module anchors are never associated with a title, so you must supply a title when you link to them. For example ``ref: namespace.collection.plugin_name lookup plugin  <ansible_collections.namespace.collection.plugin_name_lookup>``.
 
 
 :notes:

--- a/docs/docsite/rst/dev_guide/style_guide/index.rst
+++ b/docs/docsite/rst/dev_guide/style_guide/index.rst
@@ -215,33 +215,70 @@ The second example adds custom text for the link.
 Adding links to modules and plugins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Ansible 2.10 and later require the extended Fully Qualified Collection Name (FQCN) as part of the links:
-
-.. code-block:: text
-
-  ansible_collections. + FQCN + _module
-
-For example:
-
-  .. code-block:: rst
-
-   :ref:`ansible.builtin.first_found lookup plugin <ansible_collections.ansible.builtin.first_found_lookup>`
-
-displays as :ref:`ansible.builtin.first_found lookup plugin <ansible_collections.ansible.builtin.first_found_lookup>`.
-
-Modules require different suffixes from other plugins:
-
-* Module links use this extended FQCN module name with ``_module`` for the anchor.
-* Plugin links use this extended FQCN plugin name with the plugin type (``_connection`` for example).
+Use the ``:ansplugin:`` RST role to link to modules and plugins using their Fully Qualified Collection Name (FQCN):
 
 .. code-block:: rst
 
-   :ref:`arista.eos.eos_config <ansible_collections.arista.eos.eos_config_module>`
-   :ref:`kubernetes.core.kubectl connection plugin <ansible_collections.kubernetes.core.kubectl_connection>`
+  The ansible.builtin.copy module can be linked with
+  :ansplugin:`ansible.builtin.copy#module`
+
+  If you want to specify an explicit type, use:
+  :ansplugin:`the copy module <ansible.builtin.copy#module>`
+
+This displays as
+"The ansible.builtin.copy module can be linked with :ansplugin:`ansible.builtin.copy#module`"
+and
+"If you want to specify an explicit type, use: :ansplugin:`the copy module <ansible.builtin.copy#module>`".
+
+Instead of ``#module``, you can also specify ``#<plugin_type>`` to reference to a plugin of type ``<plugin_type>``:
+
+.. code-block:: rst
+
+   :ansplugin:`arista.eos.eos_config <arista.eos.eos_config#module>`
+   :ansplugin:`kubernetes.core.kubectl connection plugin <kubernetes.core.kubectl#connection>`
+   :ansplugin:`ansible.builtin.file lookup plugin <ansible.builtin.file#lookup>`
 
 .. note::
 
-	``ansible.builtin`` is the FQCN for modules included in ``ansible.base``. Documentation links are the only place you prepend ``ansible_collections`` to the FQCN. This is used by the documentation build scripts to correctly fetch documentation from collections on Ansible Galaxy.
+    ``ansible.builtin`` is the FQCN for modules included in ansible-core.
+
+Adding links to module and plugin options and return values
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use the ``:ansopt:`` and ``:ansretval:`` roles to reference options and return values of modules and plugins:
+
+.. code-block:: rst
+
+  :ansopt:`ansible.builtin.file#module:path` references the ``path`` parameter of the
+  ``ansible.builtin.file`` module; :ansopt:`ansible.builtin.file#module:path=/root/.ssh/known_hosts`
+  shows the assignment ``path=/root/.ssh/known_hosts`` as a clickable link.
+
+  :ansretval:`ansible.builtin.stat#module:stat.exists` references the ``stat.exists`` return value
+  of the ``ansible.builtin.stat`` module. You can also use ``=`` as for option values:
+  :ansretval:`ansible.builtin.stat#module:stat.exists=true` shows ``stat.exists=true``.
+
+  :ansopt:`foo` and :ansopt:`foo=bar` use the same markup for an option and an option
+  assignment without a link; the same is true for return values: :ansretval:`foo` and
+  :ansretval:`foo=bar`.
+
+This displays as
+":ansopt:`ansible.builtin.file#module:path` references the ``path`` parameter of the
+``ansible.builtin.file`` module; :ansopt:`ansible.builtin.file#module:path=/root/.ssh/known_hosts`
+shows the assignment ``path=/root/.ssh/known_hosts`` as a clickable link."
+and
+":ansretval:`ansible.builtin.stat#module:stat.exists` references the ``stat.exists`` return value
+of the ``ansible.builtin.stat`` module. You can also use ``=`` as for option values:
+:ansretval:`ansible.builtin.stat#module:stat.exists=true` shows ``stat.exists=true``."
+and
+":ansopt:`foo` and :ansopt:`foo=bar` use the same markup for an option and an option
+assignment without a link; the same is true for return values: :ansretval:`foo` and
+:ansretval:`foo=bar`.".
+
+For both option and return values, ``.`` is used to reference suboptions and contained return values.
+Array stubs (``[...]``) can be used to indicate that something is a list, for example the ``:retval:``
+argument ``ansible.builtin.service_facts#module:ansible_facts.services['systemd'].state`` references
+the ``ansible_facts.services.state`` return value of the ``ansible.builtin.service_facts`` module
+(:ansretval:`ansible.builtin.service_facts#module:ansible_facts.services['systemd'].state`).
 
 .. _local_toc:
 

--- a/docs/docsite/rst/dev_guide/style_guide/index.rst
+++ b/docs/docsite/rst/dev_guide/style_guide/index.rst
@@ -215,70 +215,33 @@ The second example adds custom text for the link.
 Adding links to modules and plugins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Use the ``:ansplugin:`` RST role to link to modules and plugins using their Fully Qualified Collection Name (FQCN):
+Ansible 2.10 and later require the extended Fully Qualified Collection Name (FQCN) as part of the links:
+
+.. code-block:: text
+
+  ansible_collections. + FQCN + _module
+
+For example:
+
+  .. code-block:: rst
+
+   :ref:`ansible.builtin.first_found lookup plugin <ansible_collections.ansible.builtin.first_found_lookup>`
+
+displays as :ref:`ansible.builtin.first_found lookup plugin <ansible_collections.ansible.builtin.first_found_lookup>`.
+
+Modules require different suffixes from other plugins:
+
+* Module links use this extended FQCN module name with ``_module`` for the anchor.
+* Plugin links use this extended FQCN plugin name with the plugin type (``_connection`` for example).
 
 .. code-block:: rst
 
-  The ansible.builtin.copy module can be linked with
-  :ansplugin:`ansible.builtin.copy#module`
-
-  If you want to specify an explicit type, use:
-  :ansplugin:`the copy module <ansible.builtin.copy#module>`
-
-This displays as
-"The ansible.builtin.copy module can be linked with :ansplugin:`ansible.builtin.copy#module`"
-and
-"If you want to specify an explicit type, use: :ansplugin:`the copy module <ansible.builtin.copy#module>`".
-
-Instead of ``#module``, you can also specify ``#<plugin_type>`` to reference to a plugin of type ``<plugin_type>``:
-
-.. code-block:: rst
-
-   :ansplugin:`arista.eos.eos_config <arista.eos.eos_config#module>`
-   :ansplugin:`kubernetes.core.kubectl connection plugin <kubernetes.core.kubectl#connection>`
-   :ansplugin:`ansible.builtin.file lookup plugin <ansible.builtin.file#lookup>`
+   :ref:`arista.eos.eos_config <ansible_collections.arista.eos.eos_config_module>`
+   :ref:`kubernetes.core.kubectl connection plugin <ansible_collections.kubernetes.core.kubectl_connection>`
 
 .. note::
 
-    ``ansible.builtin`` is the FQCN for modules included in ansible-core.
-
-Adding links to module and plugin options and return values
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Use the ``:ansopt:`` and ``:ansretval:`` roles to reference options and return values of modules and plugins:
-
-.. code-block:: rst
-
-  :ansopt:`ansible.builtin.file#module:path` references the ``path`` parameter of the
-  ``ansible.builtin.file`` module; :ansopt:`ansible.builtin.file#module:path=/root/.ssh/known_hosts`
-  shows the assignment ``path=/root/.ssh/known_hosts`` as a clickable link.
-
-  :ansretval:`ansible.builtin.stat#module:stat.exists` references the ``stat.exists`` return value
-  of the ``ansible.builtin.stat`` module. You can also use ``=`` as for option values:
-  :ansretval:`ansible.builtin.stat#module:stat.exists=true` shows ``stat.exists=true``.
-
-  :ansopt:`foo` and :ansopt:`foo=bar` use the same markup for an option and an option
-  assignment without a link; the same is true for return values: :ansretval:`foo` and
-  :ansretval:`foo=bar`.
-
-This displays as
-":ansopt:`ansible.builtin.file#module:path` references the ``path`` parameter of the
-``ansible.builtin.file`` module; :ansopt:`ansible.builtin.file#module:path=/root/.ssh/known_hosts`
-shows the assignment ``path=/root/.ssh/known_hosts`` as a clickable link."
-and
-":ansretval:`ansible.builtin.stat#module:stat.exists` references the ``stat.exists`` return value
-of the ``ansible.builtin.stat`` module. You can also use ``=`` as for option values:
-:ansretval:`ansible.builtin.stat#module:stat.exists=true` shows ``stat.exists=true``."
-and
-":ansopt:`foo` and :ansopt:`foo=bar` use the same markup for an option and an option
-assignment without a link; the same is true for return values: :ansretval:`foo` and
-:ansretval:`foo=bar`.".
-
-For both option and return values, ``.`` is used to reference suboptions and contained return values.
-Array stubs (``[...]``) can be used to indicate that something is a list, for example the ``:retval:``
-argument ``ansible.builtin.service_facts#module:ansible_facts.services['systemd'].state`` references
-the ``ansible_facts.services.state`` return value of the ``ansible.builtin.service_facts`` module
-(:ansretval:`ansible.builtin.service_facts#module:ansible_facts.services['systemd'].state`).
+	``ansible.builtin`` is the FQCN for modules included in ``ansible.base``. Documentation links are the only place you prepend ``ansible_collections`` to the FQCN. This is used by the documentation build scripts to correctly fetch documentation from collections on Ansible Galaxy.
 
 .. _local_toc:
 

--- a/docs/docsite/rst/network/getting_started/first_playbook.rst
+++ b/docs/docsite/rst/network/getting_started/first_playbook.rst
@@ -159,7 +159,7 @@ Gathering facts from network devices
 
 The ``gather_facts`` keyword now supports gathering network device facts in standardized key/value pairs. You can feed these network facts into further tasks to manage the network device.
 
-You can also use the new ``gather_network_resources`` parameter with the network ``*_facts`` modules (such as :ref:`arista.eos.eos_facts <ansible_collections.arista.eos.eos_facts_module>`) to return just a subset of the device configuration, as shown below.
+You can also use the new ``gather_network_resources`` parameter with the network ``*_facts`` modules (such as :ansplugin:`arista.eos.eos_facts <arista.eos.eos_facts#module>`) to return just a subset of the device configuration, as shown below.
 
 .. code-block:: yaml
 
@@ -209,4 +209,4 @@ The playbook returns the following interface facts:
 
 Note that this returns a subset of what is returned by just setting ``gather_subset: interfaces``.
 
-You can store these facts and use them directly in another task, such as with the :ref:`eos_interfaces <ansible_collections.arista.eos.eos_interfaces_module>` resource module.
+You can store these facts and use them directly in another task, such as with the :ansplugin:`eos_interfaces <arista.eos.eos_interfaces#module>` resource module.

--- a/docs/docsite/rst/network/user_guide/cli_parsing.rst
+++ b/docs/docsite/rst/network/user_guide/cli_parsing.rst
@@ -4,7 +4,7 @@
 Parsing semi-structured text with Ansible
 *****************************************
 
-The :ref:`cli_parse <ansible_collections.ansible.utils.cli_parse_module>` module parses semi-structured data such as network configurations into structured data to allow programmatic use of the data from that device. You can pull information from a network device and update a CMDB in one playbook. Use cases include automated troubleshooting, creating dynamic documentation, updating IPAM (IP address management) tools and so on.
+The :ansplugin:`cli_parse <ansible.utils.cli_parse#module>` module parses semi-structured data such as network configurations into structured data to allow programmatic use of the data from that device. You can pull information from a network device and update a CMDB in one playbook. Use cases include automated troubleshooting, creating dynamic documentation, updating IPAM (IP address management) tools and so on.
 
 
 .. contents::
@@ -14,7 +14,7 @@ The :ref:`cli_parse <ansible_collections.ansible.utils.cli_parse_module>` module
 Understanding the CLI parser
 =============================
 
-The `ansible.utils <https://galaxy.ansible.com/ansible/utils>`_ collection version 1.0.0 or later  includes the :ref:`cli_parse <ansible_collections.ansible.utils.cli_parse_module>` module that can run CLI commands and parse the semi-structured text output. You can use the ``cli_parse`` module on a device, host, or platform that only supports a command-line interface and the commands issued return semi-structured text. The ``cli_parse`` module can either run a CLI command on a device and return a parsed result or can simply parse any text document. The ``cli_parse`` module includes cli_parser plugins to interface with a variety of parsing engines.
+The `ansible.utils <https://galaxy.ansible.com/ansible/utils>`_ collection version 1.0.0 or later  includes the :ansplugin:`cli_parse <ansible.utils.cli_parse#module>` module that can run CLI commands and parse the semi-structured text output. You can use the ``cli_parse`` module on a device, host, or platform that only supports a command-line interface and the commands issued return semi-structured text. The ``cli_parse`` module can either run a CLI command on a device and return a parsed result or can simply parse any text document. The ``cli_parse`` module includes cli_parser plugins to interface with a variety of parsing engines.
 
 Why parse the text?
 --------------------

--- a/docs/docsite/rst/network/user_guide/network_best_practices_2.5.rst
+++ b/docs/docsite/rst/network/user_guide/network_best_practices_2.5.rst
@@ -149,9 +149,9 @@ Example 1: collecting facts and creating backup files with a playbook
 
 Ansible facts modules gather system information 'facts' that are available to the rest of your playbook.
 
-Ansible Networking ships with a number of network-specific facts modules. In this example, we use the ``_facts`` modules :ref:`arista.eos.eos_facts <ansible_collections.arista.eos.eos_facts_module>`, :ref:`cisco.ios.ios_facts <ansible_collections.cisco.ios.ios_facts_module>` and :ref:`vyos.vyos.vyos_facts <ansible_collections.vyos.vyos.vyos_facts_module>` to connect to the remote networking device. As the credentials are not explicitly passed with module arguments, Ansible uses the username and password from the inventory file.
+Ansible Networking ships with a number of network-specific facts modules. In this example, we use the ``_facts`` modules :ansplugin:`arista.eos.eos_facts <arista.eos.eos_facts#module>`, :ansplugin:`cisco.ios.ios_facts <cisco.ios.ios_facts#module>` and :ansplugin:`vyos.vyos.vyos_facts <vyos.vyos.vyos_facts#module>` to connect to the remote networking device. As the credentials are not explicitly passed with module arguments, Ansible uses the username and password from the inventory file.
 
-Ansible's "Network Fact modules" gather information from the system and store the results in facts prefixed with ``ansible_net_``. The data collected by these modules is documented in the `Return Values` section of the module docs, in this case :ref:`arista.eos.eos_facts <ansible_collections.arista.eos.eos_facts_module>` and :ref:`vyos.vyos.vyos_facts <ansible_collections.vyos.vyos.vyos_facts_module>`. We can use the facts, such as ``ansible_net_version`` late on in the "Display some facts" task.
+Ansible's "Network Fact modules" gather information from the system and store the results in facts prefixed with ``ansible_net_``. The data collected by these modules is documented in the `Return Values` section of the module docs, in this case :ansplugin:`arista.eos.eos_facts <arista.eos.eos_facts#module>` and :ansplugin:`vyos.vyos.vyos_facts <vyos.vyos.vyos_facts#module>`. We can use the facts, such as ``ansible_net_version`` late on in the "Display some facts" task.
 
 To ensure we call the correct mode (``*_facts``) the task is conditionally run based on the group defined in the inventory file, for more information on the use of conditionals in Ansible Playbooks see :ref:`the_when_statement`.
 
@@ -328,7 +328,7 @@ Example 2: simplifying playbooks with platform-independent modules
 If you have two or more network platforms in your environment, you can use the platform-independent modules to simplify your playbooks. You can use platform-independent modules such as ``ansible.netcommon.cli_command`` or ``ansible.netcommon.cli_config`` in place of the platform-specific modules such as ``arista.eos.eos_config``, ``cisco.ios.ios_config``, and ``junipernetworks.junos.junos_config``. This reduces the number of tasks and conditionals you need in your playbooks.
 
 .. note::
-  Platform-independent modules require the :ref:`ansible.netcommon.network_cli <ansible_collections.ansible.netcommon.network_cli_connection>` connection plugin.
+  Platform-independent modules require the :ansplugin:`ansible.netcommon.network_cli <ansible.netcommon.network_cli#connection>` connection plugin.
 
 
 Sample playbook with platform-specific modules
@@ -465,7 +465,7 @@ For more information, see :ref:`magic_variables_and_hostvars`.
 Get running configuration
 -------------------------
 
-The :ref:`arista.eos.eos_config <ansible_collections.arista.eos.eos_config_module>` and :ref:`vyos.vyos.vyos_config <ansible_collections.vyos.vyos.vyos_config_module>` modules have a ``backup:`` option that when set will cause the module to create a full backup of the current ``running-config`` from the remote device before any changes are made. The backup file is written to the ``backup`` folder in the playbook root directory. If the directory does not exist, it is created.
+The :ansplugin:`arista.eos.eos_config <arista.eos.eos_config#module>` and :ansplugin:`vyos.vyos.vyos_config <vyos.vyos.vyos_config#module>` modules have a ``backup:`` option that when set will cause the module to create a full backup of the current ``running-config`` from the remote device before any changes are made. The backup file is written to the ``backup`` folder in the playbook root directory. If the directory does not exist, it is created.
 
 To demonstrate how we can move the backup file to a different location, we register the result and move the file to the path stored in ``backup_path``.
 

--- a/docs/docsite/rst/network/user_guide/network_resource_modules.rst
+++ b/docs/docsite/rst/network/user_guide/network_resource_modules.rst
@@ -121,7 +121,7 @@ Network resource modules return the following details:
 Example: Verifying the network device configuration has not changed
 ====================================================================
 
-The following playbook uses the :ref:`arista.eos.eos_l3_interfaces <ansible_collections.arista.eos.eos_l3_interfaces_module>` module to gather a subset of the network device configuration (Layer 3 interfaces only) and verifies the information is accurate and has not changed. This playbook passes the results of :ref:`arista.eos.eos_facts <ansible_collections.arista.eos.eos_facts_module>` directly to the ``arista.eos.eos_l3_interfaces`` module.
+The following playbook uses the :ansplugin:`arista.eos.eos_l3_interfaces <arista.eos.eos_l3_interfaces#module>` module to gather a subset of the network device configuration (Layer 3 interfaces only) and verifies the information is accurate and has not changed. This playbook passes the results of :ansplugin:`arista.eos.eos_facts <arista.eos.eos_facts#module>` directly to the ``arista.eos.eos_l3_interfaces`` module.
 
 
 .. code-block:: yaml

--- a/docs/docsite/rst/network/user_guide/network_working_with_command_output.rst
+++ b/docs/docsite/rst/network/user_guide/network_working_with_command_output.rst
@@ -74,13 +74,13 @@ command index in ``[]``, where ``0`` is the first command in the commands list,
 Handling prompts in network modules
 ===================================
 
-Network devices may require that you answer a prompt before performing a change on the device. Individual network modules such as :ref:`cisco.ios.ios_command <ansible_collections.cisco.ios.ios_command_module>` and :ref:`cisco.nxos.nxos_command <ansible_collections.cisco.nxos.nxos_command_module>` can handle this with a ``prompt`` parameter.
+Network devices may require that you answer a prompt before performing a change on the device. Individual network modules such as :ansplugin:`cisco.ios.ios_command <cisco.ios.ios_command#module>` and :ansplugin:`cisco.nxos.nxos_command <cisco.nxos.nxos_command#module>` can handle this with a ``prompt`` parameter.
 
 .. note::
 
 	``prompt`` is a Python regex. If you add special characters such as ``?`` in the ``prompt`` value, the prompt won't match and you will get a timeout. To avoid this, ensure that the ``prompt`` value is a Python regex that matches the actual device prompt. Any special characters must be handled correctly in the ``prompt`` regex.
 
-You can also use the :ref:`ansible.netcommon.cli_command <ansible_collections.ansible.netcommon.cli_command_module>` to handle multiple prompts.
+You can also use the :ansplugin:`ansible.netcommon.cli_command <ansible.netcommon.cli_command#module>` to handle multiple prompts.
 
 .. code-block:: yaml
 

--- a/docs/docsite/rst/network/user_guide/platform_eos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_eos.rst
@@ -97,7 +97,7 @@ Before you can use eAPI to connect to a switch, you must enable eAPI. To enable 
      become_method: enable
      when: ansible_network_os == 'arista.eos.eos'
 
-You can find more options for enabling HTTP/HTTPS connections in the :ref:`arista.eos.eos_eapi <ansible_collections.arista.eos.eos_eapi_module>` module documentation.
+You can find more options for enabling HTTP/HTTPS connections in the :ansplugin:`arista.eos.eos_eapi <arista.eos.eos_eapi#module>` module documentation.
 
 Once eAPI is enabled, change your ``group_vars/eos.yml`` to use the eAPI connection.
 

--- a/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
+++ b/docs/docsite/rst/network/user_guide/platform_netconf_enabled.rst
@@ -91,7 +91,7 @@ Example NETCONF task with configurable variables
      vars:
        ansible_private_key_file: /home/admin/.ssh/newprivatekeyfile
 
-Note: For netconf connection plugin configurable variables see :ref:`ansible.netcommon.netconf <ansible_collections.ansible.netcommon.netconf_connection>`.
+Note: For netconf connection plugin configurable variables see :ansplugin:`ansible.netcommon.netconf <ansible.netcommon.netconf#connection>`.
 
 Bastion/Jumphost configuration
 ------------------------------

--- a/docs/docsite/rst/network/user_guide/validate.rst
+++ b/docs/docsite/rst/network/user_guide/validate.rst
@@ -4,7 +4,7 @@
 Validate data against set criteria with Ansible
 *************************************************
 
-The :ref:`validate <ansible_collections.ansible.utils.validate_module>` module validates data against your predefined criteria using a validation engine. You can pull this data from a device or file, validate it against your defined criteria, and use the results to identify configuration or operational state drift and optionally take remedial action.
+The :ansplugin:`validate <ansible.utils.validate#module>` module validates data against your predefined criteria using a validation engine. You can pull this data from a device or file, validate it against your defined criteria, and use the results to identify configuration or operational state drift and optionally take remedial action.
 
 
 .. contents::
@@ -13,11 +13,11 @@ The :ref:`validate <ansible_collections.ansible.utils.validate_module>` module v
 Understanding the validate plugin
 ==================================
 
-The `ansible.utils <https://galaxy.ansible.com/ansible/utils>`_ collection includes the :ref:`validate <ansible_collections.ansible.utils.validate_module>` module.
+The `ansible.utils <https://galaxy.ansible.com/ansible/utils>`_ collection includes the :ansplugin:`validate <ansible.utils.validate#module>` module.
 
 To validate data:
 
-#. Pull in structured data or convert your data to structured format with the :ref:`cli_parse <ansible_collections.ansible.utils.cli_parse_module>` module.
+#. Pull in structured data or convert your data to structured format with the :ansplugin:`cli_parse <ansible.utils.cli_parse#module>` module.
 #. Define the criteria to test that data against.
 #. Select a validation engine and test the data to see if it is valid based on the selected criteria and validation engine.
 
@@ -26,7 +26,7 @@ The structure of the data and the criteria depends on the validation engine you 
 Structuring the data
 =====================
 
-You can pull previously structured data from a file, or use the :ref:`cli_parse <ansible_collections.ansible.utils.cli_parse_module>` module to structure your data.
+You can pull previously structured data from a file, or use the :ansplugin:`cli_parse <ansible.utils.cli_parse#module>` module to structure your data.
 
 The following example fetches the operational state of some network (Cisco NXOS) interfaces and translates that state to structured data using the ``ansible.netcommon.pyats`` parser.
 
@@ -110,7 +110,7 @@ The criteria for ``jsonschema`` in this example is as follows:
 Validating the data
 ====================
 
-Now that we have the structured data and the criteria, we can validate this data with the :ref:`validate <ansible_collections.ansible.utils.validate_module>` module.
+Now that we have the structured data and the criteria, we can validate this data with the :ansplugin:`validate <ansible.utils.validate#module>` module.
 
 The following tasks check if the current state of the interfaces match the desired state defined in the criteria file.
 
@@ -134,7 +134,7 @@ The following tasks check if the current state of the interfaces match the desir
 
 In these tasks, we have:
 
-#. Set ``data`` to  the structured JSON data from the :ref:`cli_parse <ansible_collections.ansible.utils.cli_parse_module>` module.
+#. Set ``data`` to  the structured JSON data from the :ansplugin:`cli_parse <ansible.utils.cli_parse#module>` module.
 #. Set ``criteria`` to the JSON criteria file we defined.
 #. Set the validate engine to ``jsonschema``.
 

--- a/docs/docsite/rst/playbook_guide/playbook_pathing.rst
+++ b/docs/docsite/rst/playbook_guide/playbook_pathing.rst
@@ -19,7 +19,7 @@ By default these should be relative to the config file, some are specifically re
 Task paths
 ==========
 
-Relative paths used in a task typically refer to remote files and directories on the managed nodes. However, paths passed to lookup plugins and some paths used in action plugins such as the "src" path for the :ref:`template <ansible_collections.ansible.builtin.template_module>` and :ref:`copy <ansible_collections.ansible.builtin.copy_module>` modules refer to local files and directories on the control node.
+Relative paths used in a task typically refer to remote files and directories on the managed nodes. However, paths passed to lookup plugins and some paths used in action plugins such as the "src" path for the :ansplugin:`template <ansible.builtin.template#module>` and :ansplugin:`copy <ansible.builtin.copy#module>` modules refer to local files and directories on the control node.
 
 Resolving local relative paths
 ------------------------------

--- a/docs/docsite/rst/playbook_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_filters.rst
@@ -101,14 +101,14 @@ In addition, you can define a one value to use on true, one value on false and a
 Managing data types
 ===================
 
-You might need to know, change, or set the data type on a variable. For example, a registered variable might contain a dictionary when your next task needs a list, or a user :ref:`prompt <playbooks_prompts>` might return a string when your playbook needs a boolean value. Use the ``type_debug``, ``dict2items``, and ``items2dict`` filters to manage data types. You can also use the data type itself to cast a value as a specific data type.
+You might need to know, change, or set the data type on a variable. For example, a registered variable might contain a dictionary when your next task needs a list, or a user :ref:`prompt <playbooks_prompts>` might return a string when your playbook needs a boolean value. Use the :ansplugin:`ansible.builtin.type_debug#filter`, :ansplugin:`ansible.builtin.dict2items#filter`, and :ansplugin:`ansible.builtin.items2dict#filter` filters to manage data types. You can also use the data type itself to cast a value as a specific data type.
 
 Discovering the data type
 -------------------------
 
 .. versionadded:: 2.3
 
-If you are unsure of the underlying Python type of a variable, you can use the ``type_debug`` filter to display it. This is useful in debugging when you need a particular type of variable:
+If you are unsure of the underlying Python type of a variable, you can use the :ansplugin:`ansible.builtin.type_debug#filter` filter to display it. This is useful in debugging when you need a particular type of variable:
 
 .. code-block:: yaml+jinja
 
@@ -124,13 +124,13 @@ Transforming dictionaries into lists
 .. versionadded:: 2.6
 
 
-Use the ``dict2items`` filter to transform a dictionary into a list of items suitable for :ref:`looping <playbooks_loops>`:
+Use the :ansplugin:`ansible.builtin.dict2items#filter` filter to transform a dictionary into a list of items suitable for :ref:`looping <playbooks_loops>`:
 
 .. code-block:: yaml+jinja
 
     {{ dict | dict2items }}
 
-Dictionary data (before applying the ``dict2items`` filter):
+Dictionary data (before applying the :ansplugin:`ansible.builtin.dict2items#filter` filter):
 
 .. code-block:: yaml
 
@@ -138,7 +138,7 @@ Dictionary data (before applying the ``dict2items`` filter):
       Application: payment
       Environment: dev
 
-List data (after applying the ``dict2items`` filter):
+List data (after applying the :ansplugin:`ansible.builtin.dict2items#filter` filter):
 
 .. code-block:: yaml
 
@@ -149,15 +149,15 @@ List data (after applying the ``dict2items`` filter):
 
 .. versionadded:: 2.8
 
-The ``dict2items`` filter is the reverse of the ``items2dict`` filter.
+The :ansplugin:`ansible.builtin.dict2items#filter` filter is the reverse of the :ansplugin:`ansible.builtin.items2dict#filter` filter.
 
-If you want to configure the names of the keys, the ``dict2items`` filter accepts 2 keyword arguments. Pass the ``key_name`` and ``value_name`` arguments to configure the names of the keys in the list output:
+If you want to configure the names of the keys, the :ansplugin:`ansible.builtin.dict2items#filter` filter accepts 2 keyword arguments. Pass the :ansopt:`ansible.builtin.dict2items#filter:key_name` and :ansopt:`ansible.builtin.dict2items#filter:value_name` arguments to configure the names of the keys in the list output:
 
 .. code-block:: yaml+jinja
 
     {{ files | dict2items(key_name='file', value_name='path') }}
 
-Dictionary data (before applying the ``dict2items`` filter):
+Dictionary data (before applying the :ansplugin:`ansible.builtin.dict2items#filter` filter):
 
 .. code-block:: yaml
 
@@ -165,7 +165,7 @@ Dictionary data (before applying the ``dict2items`` filter):
       users: /etc/passwd
       groups: /etc/group
 
-List data (after applying the ``dict2items`` filter):
+List data (after applying the :ansplugin:`ansible.builtin.dict2items#filter` filter):
 
 .. code-block:: yaml
 
@@ -180,13 +180,13 @@ Transforming lists into dictionaries
 
 .. versionadded:: 2.7
 
-Use the ``items2dict`` filter to transform a list into a dictionary, mapping the content into ``key: value`` pairs:
+Use the :ansplugin:`ansible.builtin.items2dict#filter` filter to transform a list into a dictionary, mapping the content into ``key: value`` pairs:
 
 .. code-block:: yaml+jinja
 
     {{ tags | items2dict }}
 
-List data (before applying the ``items2dict`` filter):
+List data (before applying the :ansplugin:`ansible.builtin.items2dict#filter` filter):
 
 .. code-block:: yaml
 
@@ -196,14 +196,14 @@ List data (before applying the ``items2dict`` filter):
       - key: Environment
         value: dev
 
-Dictionary data (after applying the ``items2dict`` filter):
+Dictionary data (after applying the :ansplugin:`ansible.builtin.items2dict#filter` filter):
 
 .. code-block:: text
 
     Application: payment
     Environment: dev
 
-The ``items2dict`` filter is the reverse of the ``dict2items`` filter.
+The :ansplugin:`ansible.builtin.items2dict#filter` filter is the reverse of the :ansplugin:`ansible.builtin.dict2items#filter` filter.
 
 Not all lists use ``key`` to designate keys and ``value`` to designate values. For example:
 
@@ -217,7 +217,7 @@ Not all lists use ``key`` to designate keys and ``value`` to designate values. F
       - fruit: grapefruit
         color: yellow
 
-In this example, you must pass the ``key_name`` and ``value_name`` arguments to configure the transformation. For example:
+In this example, you must pass the :ansopt:`ansible.builtin.items2dict#filter:key_name` and :ansopt:`ansible.builtin.items2dict#filter:value_name` arguments to configure the transformation. For example:
 
 .. code-block:: yaml+jinja
 
@@ -258,12 +258,16 @@ You can switch a data structure in a template from or to JSON or YAML format, wi
     {{ some_variable | to_json }}
     {{ some_variable | to_yaml }}
 
+See :ansplugin:`ansible.builtin.to_json#filter` and :ansplugin:`ansible.builtin.to_yaml#filter` for documentation on these filters.
+
 For human readable output, you can use:
 
 .. code-block:: yaml+jinja
 
     {{ some_variable | to_nice_json }}
     {{ some_variable | to_nice_yaml }}
+
+See :ansplugin:`ansible.builtin.to_nice_json#filter` and :ansplugin:`ansible.builtin.to_nice_yaml#filter` for documentation on these filters.
 
 You can change the indentation of either format:
 
@@ -272,8 +276,8 @@ You can change the indentation of either format:
     {{ some_variable | to_nice_json(indent=2) }}
     {{ some_variable | to_nice_yaml(indent=8) }}
 
-The ``to_yaml`` and ``to_nice_yaml`` filters use the `PyYAML library`_ which has a default 80 symbol string length limit. That causes unexpected line break after 80th symbol (if there is a space after 80th symbol)
-To avoid such behavior and generate long lines, use the ``width`` option. You must use a hardcoded number to define the width, instead of a construction like ``float("inf")``, because the filter does not support proxying Python functions. For example:
+The :ansplugin:`ansible.builtin.to_yaml#filter` and :ansplugin:`ansible.builtin.to_nice_yaml#filter` filters use the `PyYAML library`_ which has a default 80 symbol string length limit. That causes unexpected line break after 80th symbol (if there is a space after 80th symbol)
+To avoid such behavior and generate long lines, use the :ansopt:`width` option. You must use a hardcoded number to define the width, instead of a construction like ``float("inf")``, because the filter does not support proxying Python functions. For example:
 
 .. code-block:: yaml+jinja
 
@@ -306,7 +310,7 @@ for example:
 Filter `to_json` and Unicode support
 ------------------------------------
 
-By default `to_json` and `to_nice_json` will convert data received to ASCII, so:
+By default :ansplugin:`ansible.builtin.to_json#filter` and :ansplugin:`ansible.builtin.to_nice_json#filter` will convert data received to ASCII, so:
 
 .. code-block:: yaml+jinja
 
@@ -318,7 +322,7 @@ will return:
 
     'M\u00fcnchen'
 
-To keep Unicode characters, pass the parameter `ensure_ascii=False` to the filter:
+To keep Unicode characters, pass the parameter :ansopt:`ansible.builtin.to_json#filter:ensure_ascii=False` to the filter:
 
 .. code-block:: yaml+jinja
 
@@ -328,8 +332,8 @@ To keep Unicode characters, pass the parameter `ensure_ascii=False` to the filte
 
 .. versionadded:: 2.7
 
-To parse multi-document YAML strings, the ``from_yaml_all`` filter is provided.
-The ``from_yaml_all`` filter will return a generator of parsed YAML documents.
+To parse multi-document YAML strings, the :ansplugin:`ansible.builtin.from_yaml_all#filter` filter is provided.
+The :ansplugin:`ansible.builtin.from_yaml_all#filter` filter will return a generator of parsed YAML documents.
 
 for example:
 
@@ -357,7 +361,7 @@ Combining items from multiple lists: zip and zip_longest
 
 .. versionadded:: 2.3
 
-To get a list combining the elements of other lists use ``zip``:
+To get a list combining the elements of other lists use :ansplugin:`ansible.builtin.zip#filter`:
 
 .. code-block:: yaml+jinja
 
@@ -373,7 +377,7 @@ To get a list combining the elements of other lists use ``zip``:
 
     # => [[1, "a"], [2, "b"], [3, "c"]]
 
-To always exhaust all lists use ``zip_longest``:
+To always exhaust all lists use :ansplugin:`ansible.builtin.zip_longest#filter`:
 
 .. code-block:: yaml+jinja
 
@@ -383,13 +387,13 @@ To always exhaust all lists use ``zip_longest``:
 
     # => [[1, "a", 21], [2, "b", 22], [3, "c", 23], ["X", "d", "X"], ["X", "e", "X"], ["X", "f", "X"]]
 
-Similarly to the output of the ``items2dict`` filter mentioned above, these filters can be used to construct a ``dict``:
+Similarly to the output of the :ansplugin:`ansible.builtin.items2dict#filter` filter mentioned above, these filters can be used to construct a ``dict``:
 
 .. code-block:: yaml+jinja
 
     {{ dict(keys_list | zip(values_list)) }}
 
-List data (before applying the ``zip`` filter):
+List data (before applying the :ansplugin:`ansible.builtin.zip#filter` filter):
 
 .. code-block:: yaml
 
@@ -400,7 +404,7 @@ List data (before applying the ``zip`` filter):
       - apple
       - orange
 
-Dictionary data (after applying the ``zip`` filter):
+Dictionary data (after applying the :ansplugin:`ansible.builtin.zip#filter` filter):
 
 .. code-block:: yaml
 
@@ -412,13 +416,13 @@ Combining objects and subelements
 
 .. versionadded:: 2.7
 
-The ``subelements`` filter produces a product of an object and the subelement values of that object, similar to the ``subelements`` lookup. This lets you specify individual subelements to use in a template. For example, this expression:
+The :ansplugin:`ansible.builtin.subelements#filter` filter produces a product of an object and the subelement values of that object, similar to the :ansplugin:`ansible.builtin.subelements#lookup` lookup. This lets you specify individual subelements to use in a template. For example, this expression:
 
 .. code-block:: yaml+jinja
 
     {{ users | subelements('groups', skip_missing=True) }}
 
-Data before applying the ``subelements`` filter:
+Data before applying the :ansplugin:`ansible.builtin.subelements#filter` filter:
 
 .. code-block:: yaml
 
@@ -436,7 +440,7 @@ Data before applying the ``subelements`` filter:
       groups:
       - docker
 
-Data after applying the ``subelements`` filter:
+Data after applying the :ansplugin:`ansible.builtin.subelements#filter` filter:
 
 .. code-block:: yaml
 
@@ -483,7 +487,7 @@ Combining hashes/dictionaries
 
 .. versionadded:: 2.0
 
-The ``combine`` filter allows hashes to be merged. For example, the following would override keys in one hash:
+The :ansplugin:`ansible.builtin.combine#filter` filter allows hashes to be merged. For example, the following would override keys in one hash:
 
 .. code-block:: yaml+jinja
 
@@ -504,16 +508,16 @@ The filter can also take multiple arguments to merge:
 
 In this case, keys in ``d`` would override those in ``c``, which would override those in ``b``, and so on.
 
-The filter also accepts two optional parameters: ``recursive`` and ``list_merge``.
+The filter also accepts two optional parameters: :ansopt:`ansible.builtin.combine#filter:recursive` and :ansopt:`ansible.builtin.combine#filter:list_merge`.
 
 recursive
   Is a boolean, default to ``False``.
-  Should the ``combine`` recursively merge nested hashes.
+  Should the :ansplugin:`ansible.builtin.combine#filter` recursively merge nested hashes.
   Note: It does **not** depend on the value of the ``hash_behaviour`` setting in ``ansible.cfg``.
 
 list_merge
   Is a string, its possible values are ``replace`` (default), ``keep``, ``append``, ``prepend``, ``append_rp`` or ``prepend_rp``.
-  It modifies the behaviour of ``combine`` when the hashes to merge contain arrays/lists.
+  It modifies the behaviour of :ansplugin:`ansible.builtin.combine#filter` when the hashes to merge contain arrays/lists.
 
 .. code-block:: yaml
 
@@ -529,7 +533,7 @@ list_merge
         z: patch
       b: patch
 
-If ``recursive=False`` (the default), nested hash aren't merged:
+If :ansopt:`ansible.builtin.combine#filter:recursive=False` (the default), nested hash aren't merged:
 
 .. code-block:: yaml+jinja
 
@@ -545,7 +549,7 @@ This would result in:
     b: patch
     c: default
 
-If ``recursive=True``, recurse into nested hash and merge their keys:
+If :ansopt:`ansible.builtin.combine#filter:recursive=True`, recurse into nested hash and merge their keys:
 
 .. code-block:: yaml+jinja
 
@@ -562,7 +566,7 @@ This would result in:
     b: patch
     c: default
 
-If ``list_merge='replace'`` (the default), arrays from the right hash will "replace" the ones in the left hash:
+If :ansopt:`ansible.builtin.combine#filter:list_merge='replace'` (the default), arrays from the right hash will "replace" the ones in the left hash:
 
 .. code-block:: yaml
 
@@ -584,7 +588,7 @@ This would result in:
     a:
       - patch
 
-If ``list_merge='keep'``, arrays from the left hash will be kept:
+If :ansopt:`ansible.builtin.combine#filter:list_merge='keep'`, arrays from the left hash will be kept:
 
 .. code-block:: yaml+jinja
 
@@ -597,7 +601,7 @@ This would result in:
     a:
       - default
 
-If ``list_merge='append'``, arrays from the right hash will be appended to the ones in the left hash:
+If :ansopt:`ansible.builtin.combine#filter:list_merge='append'`, arrays from the right hash will be appended to the ones in the left hash:
 
 .. code-block:: yaml+jinja
 
@@ -611,7 +615,7 @@ This would result in:
       - default
       - patch
 
-If ``list_merge='prepend'``, arrays from the right hash will be prepended to the ones in the left hash:
+If :ansopt:`ansible.builtin.combine#filter:list_merge='prepend'`, arrays from the right hash will be prepended to the ones in the left hash:
 
 .. code-block:: yaml+jinja
 
@@ -625,7 +629,7 @@ This would result in:
       - patch
       - default
 
-If ``list_merge='append_rp'``, arrays from the right hash will be appended to the ones in the left hash. Elements of arrays in the left hash that are also in the corresponding array of the right hash will be removed ("rp" stands for "remove present"). Duplicate elements that aren't in both hashes are kept:
+If :ansopt:`ansible.builtin.combine#filter:list_merge='append_rp'`, arrays from the right hash will be appended to the ones in the left hash. Elements of arrays in the left hash that are also in the corresponding array of the right hash will be removed ("rp" stands for "remove present"). Duplicate elements that aren't in both hashes are kept:
 
 .. code-block:: yaml
 
@@ -659,7 +663,7 @@ This would result in:
       - 5
       - 5
 
-If ``list_merge='prepend_rp'``, the behavior is similar to the one for ``append_rp``, but elements of arrays in the right hash are prepended:
+If :ansopt:`ansible.builtin.combine#filter:list_merge='prepend_rp'`, the behavior is similar to the one for ``append_rp``, but elements of arrays in the right hash are prepended:
 
 .. code-block:: yaml+jinja
 
@@ -678,7 +682,7 @@ This would result in:
       - 1
       - 2
 
-``recursive`` and ``list_merge`` can be used together:
+:ansopt:`ansible.builtin.combine#filter:recursive` and :ansopt:`ansible.builtin.combine#filter:list_merge` can be used together:
 
 .. code-block:: yaml
 
@@ -825,7 +829,7 @@ This would result in:
 Selecting JSON data: JSON queries
 ---------------------------------
 
-To select a single element or a data subset from a complex data structure in JSON format (for example, Ansible facts), use the ``json_query`` filter.  The ``json_query`` filter lets you query a complex JSON structure and iterate over it using a loop structure.
+To select a single element or a data subset from a complex data structure in JSON format (for example, Ansible facts), use the :ansplugin:`community.general.json_query#filter` filter.  The :ansplugin:`community.general.json_query#filter` filter lets you query a complex JSON structure and iterate over it using a loop structure.
 
 .. note::
 
@@ -1013,7 +1017,7 @@ As of Ansible version 2.9, you can also initialize the random number generator f
 Random items or numbers
 -----------------------
 
-The ``random`` filter in Ansible is an extension of the default Jinja2 random filter, and can be used to return a random item from a sequence of items or to generate a random number based on a range.
+The :ansplugin:`ansible.builtin.random#filter` filter in Ansible is an extension of the default Jinja2 random filter, and can be used to return a random item from a sequence of items or to generate a random number based on a range.
 
 To get a random item from a list:
 
@@ -1054,7 +1058,7 @@ You can initialize the random number generator from a seed to create random-but-
 Shuffling a list
 ----------------
 
-The ``shuffle`` filter randomizes an existing list, giving a different order every invocation.
+The :ansplugin:`ansible.builtin.shuffle#filter` filter randomizes an existing list, giving a different order every invocation.
 
 To get a random list from an existing  list:
 
@@ -1268,7 +1272,7 @@ address. For example, to get the IP address itself from a CIDR, you can use:
   {{ '192.0.2.1/24' | ansible.netcommon.ipaddr('address') }}
   # => 192.0.2.1
 
-More information about ``ipaddr`` filter and complete usage guide can be found
+More information about :ansplugin:`ansible.netcommon.ipaddr#filter` filter and complete usage guide can be found
 in :ref:`playbooks_filters_ipaddr`.
 
 .. _network_filters:
@@ -1279,13 +1283,13 @@ Network CLI filters
 .. versionadded:: 2.4
 
 To convert the output of a network device CLI command into structured JSON
-output, use the ``parse_cli`` filter:
+output, use the :ansplugin:`ansible.netcommon.parse_cli#filter` filter:
 
 .. code-block:: yaml+jinja
 
     {{ output | ansible.netcommon.parse_cli('path/to/spec') }}
 
-The ``parse_cli`` filter will load the spec file and pass the command output
+The :ansplugin:`ansible.netcommon.parse_cli#filter` filter will load the spec file and pass the command output
 through it, returning JSON output. The YAML spec file defines how to parse the CLI output.
 
 The spec file should be valid formatted YAML.  It defines how to parse the CLI
@@ -1379,13 +1383,13 @@ Network XML filters
 .. versionadded:: 2.5
 
 To convert the XML output of a network device command into structured JSON
-output, use the ``parse_xml`` filter:
+output, use the :ansplugin:`ansible.netcommon.parse_xml#filter` filter:
 
 .. code-block:: yaml+jinja
 
   {{ output | ansible.netcommon.parse_xml('path/to/spec') }}
 
-The ``parse_xml`` filter will load the spec file and pass the command output
+The :ansplugin:`ansible.netcommon.parse_xml#filter` filter will load the spec file and pass the command output
 through formatted as JSON.
 
 The spec file should be valid formatted YAML. It defines how to parse the XML
@@ -1483,7 +1487,7 @@ Network VLAN filters
 
 .. versionadded:: 2.8
 
-Use the ``vlan_parser`` filter to transform an unsorted list of VLAN integers into a
+Use the :ansplugin:`ansible.netcommon.vlan_parser#filter` filter to transform an unsorted list of VLAN integers into a
 sorted string list of integers according to IOS-like VLAN list rules. This list has the following properties:
 
 * Vlans are listed in ascending order.
@@ -1572,7 +1576,7 @@ An idempotent method to generate unique hashes per system is to use a salt that 
     {{ 'secretpassword' | password_hash('sha512', 65534 | random(seed=inventory_hostname) | string) }}
     # => "$6$43927$lQxPKz2M2X.NWO.gK.t7phLwOKQMcSq72XxDZQ0XzYV6DlL1OD72h417aj16OnHTGxNzhftXJQBcjbunLEepM0"
 
-Hash types available depend on the control system running Ansible, 'hash' depends on `hashlib <https://docs.python.org/3.8/library/hashlib.html>`_, password_hash depends on `passlib <https://passlib.readthedocs.io/en/stable/lib/passlib.hash.html>`_. The `crypt <https://docs.python.org/3.8/library/crypt.html>`_ is used as a fallback if ``passlib`` is not installed.
+Hash types available depend on the control system running Ansible, :ansplugin:`ansible.builtin.hash#filter` depends on `hashlib <https://docs.python.org/3.8/library/hashlib.html>`_, :ansplugin:`ansible.builtin.password_hash#filter` depends on `passlib <https://passlib.readthedocs.io/en/stable/lib/passlib.hash.html>`_. The `crypt <https://docs.python.org/3.8/library/crypt.html>`_ is used as a fallback if ``passlib`` is not installed.
 
 .. versionadded:: 2.7
 
@@ -1606,7 +1610,7 @@ Hash type 'blowfish' (BCrypt) provides the facility to specify the version of th
 
 .. versionadded:: 2.12
 
-You can also use the Ansible :ref:`vault <vault>` filter to encrypt data:
+You can also use the Ansible :ansplugin:`ansible.builtin.vault#filter` filter to encrypt data:
 
 .. code-block:: yaml+jinja
 
@@ -1647,7 +1651,7 @@ Several filters work with text, including URLs, file names, and path names.
 Adding comments to files
 ------------------------
 
-The ``comment`` filter lets you create comments in a file from text in a template, with a variety of comment styles. By default Ansible uses ``#`` to start a comment line and adds a blank comment line above and below your comment text. For example the following:
+The :ansplugin:`ansible.builtin.comment#filter` filter lets you create comments in a file from text in a template, with a variety of comment styles. By default Ansible uses ``#`` to start a comment line and adds a blank comment line above and below your comment text. For example the following:
 
 .. code-block:: yaml+jinja
 
@@ -1751,7 +1755,7 @@ Splitting URLs
 
 .. versionadded:: 2.4
 
-The ``urlsplit`` filter extracts the fragment, hostname, netloc, password, path, port, query, scheme, and username from an URL. With no arguments, returns a dictionary of all the fields:
+The :ansplugin:`ansible.builtin.urlsplit#filter` filter extracts the fragment, hostname, netloc, password, path, port, query, scheme, and username from an URL. With no arguments, returns a dictionary of all the fields:
 
 .. code-block:: yaml+jinja
 
@@ -1799,7 +1803,7 @@ The ``urlsplit`` filter extracts the fragment, hostname, netloc, password, path,
 Searching strings with regular expressions
 ------------------------------------------
 
-To search in a string or extract parts of a string with a regular expression, use the ``regex_search`` filter:
+To search in a string or extract parts of a string with a regular expression, use the :ansplugin:`ansible.builtin.regex_search#filter` filter:
 
 .. code-block:: yaml+jinja
 
@@ -1823,7 +1827,7 @@ To search in a string or extract parts of a string with a regular expression, us
     {{ '21/42' | regex_search('(?P<dividend>[0-9]+)/(?P<divisor>[0-9]+)', '\\g<dividend>', '\\g<divisor>') }}
     # => ['21', '42']
 
-The ``regex_search`` filter returns an empty string if it cannot find a match:
+The :ansplugin:`ansible.builtin.regex_search#filter` filter returns an empty string if it cannot find a match:
 
 .. code-block:: yaml+jinja
 
@@ -1834,7 +1838,7 @@ The ``regex_search`` filter returns an empty string if it cannot find a match:
 .. note::
 
 
-  The ``regex_search`` filter returns ``None`` when used in a Jinja expression (for example in conjunction with operators, other filters, and so on). See the two examples below.
+  The :ansplugin:`ansible.builtin.regex_search#filter` filter returns ``None`` when used in a Jinja expression (for example in conjunction with operators, other filters, and so on). See the two examples below.
 
   .. code-block:: Jinja
 
@@ -1843,9 +1847,9 @@ The ``regex_search`` filter returns an empty string if it cannot find a match:
     {{ 'ansible' | regex_search('foobar') is none }}
     # => True
 
-  This is due to historic behavior and the custom re-implementation of some of the Jinja internals in Ansible. Enable the ``jinja2_native`` setting if you want the ``regex_search`` filter to always return ``None`` if it cannot find a match. See :ref:`jinja2_faqs` for details.
+  This is due to historic behavior and the custom re-implementation of some of the Jinja internals in Ansible. Enable the ``jinja2_native`` setting if you want the :ansplugin:`ansible.builtin.regex_search#filter` filter to always return ``None`` if it cannot find a match. See :ref:`jinja2_faqs` for details.
 
-To extract all occurrences of regex matches in a string, use the ``regex_findall`` filter:
+To extract all occurrences of regex matches in a string, use the :ansplugin:`ansible.builtin.regex_findall#filter` filter:
 
 .. code-block:: yaml+jinja
 
@@ -1861,7 +1865,7 @@ To extract all occurrences of regex matches in a string, use the ``regex_findall
     {{ 'CAR\ntar\nfoo\nbar\n' | regex_findall('(?im)^.ar$') }}
     # => ['CAR', 'tar', 'bar']
 
-To replace text in a string with regex, use the ``regex_replace`` filter:
+To replace text in a string with regex, use the :ansplugin:`ansible.builtin.regex_replace#filter` filter:
 
 .. code-block:: yaml+jinja
 
@@ -1913,11 +1917,11 @@ To replace text in a string with regex, use the ``regex_replace`` filter:
       {{ hosts | map('regex_replace', '(.*)', '\\1:80') | list }}
 
 .. note::
-   Prior to ansible 2.0, if ``regex_replace`` filter was used with variables inside YAML arguments (as opposed to simpler 'key=value' arguments), then you needed to escape backreferences (for example, ``\\1``) with 4 backslashes (``\\\\``) instead of 2 (``\\``).
+   Prior to ansible 2.0, if :ansplugin:`ansible.builtin.regex_replace#filter` filter was used with variables inside YAML arguments (as opposed to simpler 'key=value' arguments), then you needed to escape backreferences (for example, ``\\1``) with 4 backslashes (``\\\\``) instead of 2 (``\\``).
 
 .. versionadded:: 2.0
 
-To escape special characters within a standard Python regex, use the ``regex_escape`` filter (using the default ``re_type='python'`` option):
+To escape special characters within a standard Python regex, use the :ansplugin:`ansible.builtin.regex_escape#filter` filter (using the default :ansopt:`ansible.builtin.regex_escape#filter:re_type='python'` option):
 
 .. code-block:: yaml+jinja
 
@@ -1926,7 +1930,7 @@ To escape special characters within a standard Python regex, use the ``regex_esc
 
 .. versionadded:: 2.8
 
-To escape special characters within a POSIX basic regex, use the ``regex_escape`` filter with the ``re_type='posix_basic'`` option:
+To escape special characters within a POSIX basic regex, use the :ansplugin:`ansible.builtin.regex_escape#filter` filter with the :ansopt:`ansible.builtin.regex_escape#filter:re_type='posix_basic'` option:
 
 .. code-block:: yaml+jinja
 
@@ -2014,7 +2018,7 @@ To get the root and extension of a path or file name (new in version 2.0):
     # with path == 'nginx.conf' the return would be ('nginx', '.conf')
     {{ path | splitext }}
 
-The ``splitext`` filter always returns a pair of strings. The individual components can be accessed by using the ``first`` and ``last`` filters:
+The :ansplugin:`ansible.builtin.splitext#filter` filter always returns a pair of strings. The individual components can be accessed by using the ``first`` and ``last`` filters:
 
 .. code-block:: yaml+jinja
 
@@ -2042,6 +2046,8 @@ To add quotes for shell usage:
     - name: Run a shell command
       ansible.builtin.shell: echo {{ string_value | quote }}
 
+(Documentation: :ansplugin:`ansible.builtin.quote#filter`)
+
 To concatenate a list into a string:
 
 .. code-block:: yaml+jinja
@@ -2063,12 +2069,16 @@ To work with Base64 encoded strings:
     {{ encoded | b64decode }}
     {{ decoded | string | b64encode }}
 
+(Documentation: :ansplugin:`ansible.builtin.b64encode#filter`)
+
 As of version 2.6, you can define the type of encoding to use, the default is ``utf-8``:
 
 .. code-block:: yaml+jinja
 
     {{ encoded | b64decode(encoding='utf-16-le') }}
     {{ decoded | string | b64encode(encoding='utf-16-le') }}
+
+(Documentation: :ansplugin:`ansible.builtin.b64decode#filter`)
 
 .. note:: The ``string`` filter is only required for Python 2 and ensures that text to encode is a unicode string. Without that filter before b64encode the wrong value will be encoded.
 

--- a/docs/docsite/rst/playbook_guide/playbooks_handlers.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_handlers.rst
@@ -187,7 +187,7 @@ Having a static include such as ``import_task`` as a handler results in that han
 Meta tasks as handlers
 ----------------------
 
-Since Ansible 2.14 :ref:`meta tasks <ansible_collections.ansible.builtin.meta_module>` are allowed to be used and notified as handlers. Note that however ``flush_handlers`` cannot be used as a handler to prevent unexpected behavior.
+Since Ansible 2.14 :ansplugin:`meta tasks <ansible.builtin.meta#module>` are allowed to be used and notified as handlers. Note that however ``flush_handlers`` cannot be used as a handler to prevent unexpected behavior.
 
 
 Limitations

--- a/docs/docsite/rst/playbook_guide/playbooks_privilege_escalation.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_privilege_escalation.rst
@@ -390,7 +390,7 @@ Since Ansible 2.3, ``become`` can be used on Windows hosts through the
 invocation arguments as ``become`` on a non-Windows host, so the setup and
 variable names are the same as what is defined in this document with the exception
 of ``become_user``. As there is no sensible default for ``become_user`` on Windows
-it is required when using ``become``. See :ref:`ansible.builtin.runas become plugin <ansible_collections.ansible.builtin.runas_become>` for details.
+it is required when using ``become``. See :ansplugin:`ansible.builtin.runas become plugin <ansible.builtin.runas#become>` for details.
 
 While ``become`` can be used to assume the identity of another user, there are other uses for
 it with Windows hosts. One important use is to bypass some of the

--- a/tests/checkers/rstcheck.py
+++ b/tests/checkers/rstcheck.py
@@ -19,6 +19,7 @@ def main():
         sys.executable,
         '-c', 'import rstcheck; rstcheck.main();',
         '--report', 'warning',
+        '--ignore-roles', 'ansplugin,ansopt,ansretval,ansval,ansenvvar,ansenvvarref',
         '--ignore-substitutions', ','.join(ignore_substitutions),
     ] + paths
 


### PR DESCRIPTION
Manual backport of #65 to stable-2.15.

Removes the update of the style guide, which explains `:ansplugin:`. Semantic markup docs shouldn't appear in the `stable-2.15` docs (but it can be used to improve the documentation).