### PR TITLE
Bump antsibull-docs to 2.3.1

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,4 +5,4 @@ sphinx == 5.3.0
 sphinx-notfound-page
 sphinx-ansible-theme
 rstcheck < 6  # rstcheck 6.x has problem with rstcheck.core triggered by include files w/ sphinx directives https://github.com/rstcheck/rstcheck-core/issues/3
-antsibull-docs == 2.3.0  # currently approved version
+antsibull-docs == 2.3.1  # currently approved version


### PR DESCRIPTION
Fixes problem with option/return value anchors with Safari and other WebKit-based browsers.

Ref: https://github.com/ansible-community/antsibull-docs/issues/188