### PR TITLE
update japanese versions

### DIFF
--- a/docs/docsite/sphinx_conf/core_lang_conf.py
+++ b/docs/docsite/sphinx_conf/core_lang_conf.py
@@ -207,9 +207,9 @@ html_context = {
     'github_root_dir': 'devel/lib/ansible',
     'github_cli_version': 'devel/lib/ansible/cli/',
     'current_version': version,
-    'latest_version': '2.14',
+    'latest_version': '2.15',
     # list specifically out of order to make latest work
-    'available_versions': ('2.14_ja', '2.13_ja', '2.12_ja',),
+    'available_versions': ('2.15_ja', '2.14_ja', '2.13_ja',),
 }
 
 # Add extra CSS styles to the resulting HTML pages


### PR DESCRIPTION
part of https://github.com/ansible/ansible-documentation/issues/76

Updates the japanese version switcher to 2.15, 2.14, and 2.13.

Will need backports to all three branches as well.