### PR TITLE
set VERSION to match the stable branch

### DIFF
--- a/docs/docsite/sphinx_conf/core_lang_conf.py
+++ b/docs/docsite/sphinx_conf/core_lang_conf.py
@@ -32,7 +32,7 @@ sys.path.insert(0, os.path.join('ansible', 'lib'))
 # the repository version needs to be the one that is loaded:
 sys.path.insert(0, os.path.abspath(os.path.join('..', '..', '..', 'lib')))
 
-VERSION = 'devel'
+VERSION = 'ja_2.15'
 AUTHOR = 'Ansible, Inc'
 
 


### PR DESCRIPTION
For Japanese translation. This only exists in stable-2.15.

part of https://github.com/ansible/ansible-documentation/issues/76