### PR TITLE
update install guide to inject binaries for argcomplete, fixes #184

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -65,7 +65,7 @@ Use ``pipx`` in your environment to install the Ansible package of your choice f
 
 .. code-block:: console
 
-    $ pipx install --include-deps ansible
+    $ pipx install --include-apps ansible
 
 If you prefer to install only the minimal ``ansible-core`` package, run:
 

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -65,7 +65,7 @@ Use ``pipx`` in your environment to install the Ansible package of your choice f
 
 .. code-block:: console
 
-    $ pipx install --include-apps ansible
+    $ pipx install --include-deps ansible
 
 If you prefer to install only the minimal ``ansible-core`` package, run:
 
@@ -99,7 +99,13 @@ To install additional python dependencies that may be needed, with the example o
 
 .. code-block:: console
 
-    $ pipx inject --include-binaries ansible argcomplete
+    $ pipx inject ansible argcomplete
+
+If the additional python dependency needed includes commands that need to be executed on their own from the shell, `--include-apps` should be included to make those commands accessible.
+
+.. code-block:: console
+
+    $ pipx inject --include-apps ansible argcomplete
 
 Installing and upgrading Ansible with pip
 =========================================
@@ -273,7 +279,7 @@ If you chose the ``pipx`` install instructions:
 
 .. code-block:: console
 
-    $ pipx inject ansible argcomplete
+    $ pipx inject --include-apps ansible argcomplete
 
 Or, if you chose the ``pip`` install instructions:
 

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -99,7 +99,7 @@ To install additional python dependencies that may be needed, with the example o
 
 .. code-block:: console
 
-    $ pipx inject ansible argcomplete
+    $ pipx inject --include-binaries ansible argcomplete
 
 Installing and upgrading Ansible with pip
 =========================================

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -101,7 +101,7 @@ To install additional python dependencies that may be needed, with the example o
 
     $ pipx inject ansible argcomplete
 
-If the additional python dependency needed includes commands that need to be executed on their own from the shell, `--include-apps` should be included to make those commands accessible.
+Include the ``--include-apps`` option to make apps in the additional python dependency available on your PATH. This allows you to execute commands for those apps from the shell.
 
 .. code-block:: console
 


### PR DESCRIPTION
By default, pipx does not include binaries for injected dependencies in the path.

So, the command suggested a few moments after, `activate-global-python-argcomplete` will not work as that binary is not in the path.

By telling the pipx inject command to `--include-binaries`, it will be added to the path.