### PR TITLE
Fix "Edit on GitHub" links for CLI programs

### DIFF
--- a/docs/docsite/.templates/breadcrumbs.html
+++ b/docs/docsite/.templates/breadcrumbs.html
@@ -15,7 +15,7 @@
               <br>
 
             {% elif check_meta and pagename.startswith('cli') and meta.get('source', None) %}
-              <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode or "blob" }}/{{ github_cli_version }}{{ meta.get('source', '') }}?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
+              <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_cli_repo }}/{{ theme_vcs_pageview_mode or "blob" }}/{{ github_cli_version }}/{{ meta.get('source', '') }}?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
             {% elif (not 'list_of' in pagename) and (not 'category' in pagename) %}
               <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode or "blob" }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ page_source_suffix }}?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
             {% endif %}

--- a/docs/docsite/sphinx_conf/2.10_conf.py
+++ b/docs/docsite/sphinx_conf/2.10_conf.py
@@ -156,7 +156,8 @@ html_context = {
     'github_version': 'devel/docs/docsite/rst/',
     'github_module_version': 'devel/lib/ansible/modules/',
     'github_root_dir': 'devel/lib/ansible',
-    'github_cli_version': 'devel/lib/ansible/cli/',
+    'github_cli_repo': 'ansible',
+    'github_cli_version': 'devel',
     'current_version': version,
     'latest_version': '2.10',
     # list specifically out of order to make latest work

--- a/docs/docsite/sphinx_conf/all_conf.py
+++ b/docs/docsite/sphinx_conf/all_conf.py
@@ -152,7 +152,8 @@ html_context = {
     'github_version': 'devel/docs/docsite/rst/',
     'github_module_version': 'devel/lib/ansible/modules/',
     'github_root_dir': 'devel/lib/ansible',
-    'github_cli_version': 'devel/lib/ansible/cli/',
+    'github_cli_repo': 'ansible',
+    'github_cli_version': 'devel',
     'current_version': version,
     'latest_version': 'devel',
     # list specifically out of order to make latest work

--- a/docs/docsite/sphinx_conf/ansible_conf.py
+++ b/docs/docsite/sphinx_conf/ansible_conf.py
@@ -162,7 +162,8 @@ html_context = {
     'github_version': 'devel/docs/docsite/rst/',
     'github_module_version': 'devel/lib/ansible/modules/',
     'github_root_dir': 'devel/lib/ansible',
-    'github_cli_version': 'devel/lib/ansible/cli/',
+    'github_cli_repo': 'ansible',
+    'github_cli_version': 'devel',
     'current_version': version,
     'latest_version': '8',
     # list specifically out of order to make latest work

--- a/docs/docsite/sphinx_conf/core_conf.py
+++ b/docs/docsite/sphinx_conf/core_conf.py
@@ -205,7 +205,8 @@ html_context = {
     'github_version': 'devel/docs/docsite/rst/',
     'github_module_version': 'devel/lib/ansible/modules/',
     'github_root_dir': 'devel/lib/ansible',
-    'github_cli_version': 'devel/lib/ansible/cli/',
+    'github_cli_repo': 'ansible',
+    'github_cli_version': 'devel',
     'current_version': version,
     'latest_version': '2.15',
     # list specifically out of order to make latest work

--- a/docs/docsite/sphinx_conf/core_lang_conf.py
+++ b/docs/docsite/sphinx_conf/core_lang_conf.py
@@ -205,7 +205,8 @@ html_context = {
     'github_version': 'devel/docs/docsite/rst/',
     'github_module_version': 'devel/lib/ansible/modules/',
     'github_root_dir': 'devel/lib/ansible',
-    'github_cli_version': 'devel/lib/ansible/cli/',
+    'github_cli_repo': 'ansible',
+    'github_cli_version': 'devel',
     'current_version': version,
     'latest_version': '2.15',
     # list specifically out of order to make latest work

--- a/docs/templates/cli_rst.j2
+++ b/docs/templates/cli_rst.j2
@@ -1,4 +1,4 @@
-:source: {{ cli }}.py
+:source: {{ source }}
 
 {% set name = cli_name -%}
 {% set name_slug = cli_name -%}

--- a/hacking/build_library/build_ansible/command_plugins/generate_man.py
+++ b/hacking/build_library/build_ansible/command_plugins/generate_man.py
@@ -129,7 +129,7 @@ def opts_docs(cli_class_name, cli_module_name):
     # base/common cli info
     cli_options = opt_doc_list(cli.parser)
     docs = {
-        'cli': cli_module_name,
+        'source': f'lib/ansible/cli/{cli_module_name}.py',
         'cli_name': cli_name,
         'usage': cli.parser.format_usage(),
         'short_desc': cli.parser.description,
@@ -289,7 +289,6 @@ class GenerateMan(Command):
             # add rest to vars
             tvars = allvars[cli_name]
             tvars['cli_bin_name_list'] = cli_bin_name_list
-            tvars['cli'] = cli_name
             if '-i' in tvars['option_names']:
                 tvars['inventory'] = True
                 print('uses inventory')


### PR DESCRIPTION
This fixes the "Edit on GitHub" links for CLI programs.

It also moves the responsibility for generating the source file path into `generate_man.py`, instead of having part of it defined by the Sphinx configuration and the template.