### PR TITLE
Exclude internal options from man pages and docs

### DIFF
--- a/hacking/build_library/build_ansible/command_plugins/generate_man.py
+++ b/hacking/build_library/build_ansible/command_plugins/generate_man.py
@@ -56,6 +56,8 @@ def get_options(optlist):
 
     opts = []
     for opt in optlist:
+        if opt.help == argparse.SUPPRESS:
+            continue
         res = {
             'desc': opt.help,
             'options': opt.option_strings


### PR DESCRIPTION
This matches the changes in https://github.com/ansible/ansible/pull/81360