### PR TITLE
Fix#129

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_configuration.rst
+++ b/docs/docsite/rst/installation_guide/intro_configuration.rst
@@ -30,12 +30,12 @@ as a ``.rpmnew`` file (or other) as appropriate in the case of updates.
 If you installed Ansible from pip or from source, you may want to create this file in order to override
 default settings in Ansible.
 
-To generate an example config file (a "disabled" one with all default settings, commented out):
+You can generate an Ansible configuration file, ``ansible.cfg``, that lists all default settings as follows:
 .. code-block:: console
     
     $ ansible-config init --disabled > ansible.cfg
 
-To generate a more complete example file, include existing plugins:
+Include available plugins to create a more complete Ansible configuration as follows:
 .. code-block:: console
     
     $ ansible-config init --disabled -t all > ansible.cfg

--- a/docs/docsite/rst/installation_guide/intro_configuration.rst
+++ b/docs/docsite/rst/installation_guide/intro_configuration.rst
@@ -30,7 +30,15 @@ as a ``.rpmnew`` file (or other) as appropriate in the case of updates.
 If you installed Ansible from pip or from source, you may want to create this file in order to override
 default settings in Ansible.
 
-An `example file is available on GitHub <https://github.com/ansible/ansible/blob/devel/examples/ansible.cfg>`_.
+To generate an example config file (a "disabled" one with all default settings, commented out):
+.. code-block:: console
+    
+    $ ansible-config init --disabled > ansible.cfg
+
+To generate a more complete example file, include existing plugins:
+.. code-block:: console
+    
+    $ ansible-config init --disabled -t all > ansible.cfg
 
 For more details and a full listing of available configurations go to :ref:`configuration_settings<ansible_configuration_settings>`. Starting with Ansible version 2.4, you can use the :ref:`ansible-config` command line utility to list your available options and inspect the current values.
 


### PR DESCRIPTION
Configuring Ansible: Link to example, target does not exist 
Fixes #129 

As suggested,

Deleted the line https://github.com/ansible/ansible-documentation/blob/devel/docs/docsite/rst/installation_guide/intro_configuration.rst?plain=1#L33

Added the following:
1. To generate an example config file (a "disabled" one with all default settings, commented out):
$ ansible-config init --disabled > ansible.cfg
2. To generate a more complete example file, include existing plugins:
$ ansible-config init --disabled -t all > ansible.cfg