### PR TITLE
ci labeler: print PR event information

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -19,12 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     name: "Label Issue/PR"
     steps:
-      # TODO: Find a better way to show this information that doesn't present
-      # shell injection problems
-      #
-      # - name: Print event information
-      #   run: |
-      #     echo '${{ toJSON(github.event) }}'
+      - name: Print event information
+        env:
+          event_json: "${{ toJSON(github.event) }}"
+        run: |
+          echo "${event_json}"
       - name: Checkout parent repository
         uses: actions/checkout@v3
       - name: Install Python 3.11


### PR DESCRIPTION
Using an environment variable prevents quoting and injection issues.

This helps with debugging and such.