### PR TITLE
ci labeler: allow running via workflow_dispatch

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,6 +7,17 @@
   issues:
     types:
       - opened
+  workflow_dispatch:
+    inputs:
+      type:
+        required: true
+        type: choice
+        options:
+          - issue
+          - pr
+      number:
+        required: true
+        type: number
 
 name: "Triage Issues and PRs"
 
@@ -35,14 +46,14 @@ jobs:
           python -m venv venv
           ./venv/bin/pip install -r hacking/pr_labeler/requirements.txt
       - name: "Run the issue labeler"
-        if: "github.event.issue"
+        if: "github.event.issue || inputs.type == 'issue'"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run:
-          ./venv/bin/python hacking/pr_labeler/label.py issue ${{ github.event.issue.number }}
+          ./venv/bin/python hacking/pr_labeler/label.py issue ${{ github.event.issue.number || inputs.number }}
       - name: "Run the PR labeler"
-        if: "! github.event.issue"
+        if: "github.event.pull_request || inputs.type == 'pr'"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run:
-          ./venv/bin/python hacking/pr_labeler/label.py pr ${{ github.event.number }}
+          ./venv/bin/python hacking/pr_labeler/label.py pr ${{ github.event.number || inputs.number }}


### PR DESCRIPTION
In some cases, it may be necessary to forcibly re-run the triager for an issue.