### PR TITLE
[stable-2.14] labeler: retrieve author_association from event data and other cleanup

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -48,12 +48,14 @@ jobs:
       - name: "Run the issue labeler"
         if: "github.event.issue || inputs.type == 'issue'"
         env:
+          event_json: "${{ toJSON(github.event) }}"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run:
           ./venv/bin/python hacking/pr_labeler/label.py issue ${{ github.event.issue.number || inputs.number }}
       - name: "Run the PR labeler"
         if: "github.event.pull_request || inputs.type == 'pr'"
         env:
+          event_json: "${{ toJSON(github.event) }}"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run:
           ./venv/bin/python hacking/pr_labeler/label.py pr ${{ github.event.number || inputs.number }}

--- a/hacking/pr_labeler/label.py
+++ b/hacking/pr_labeler/label.py
@@ -45,7 +45,7 @@ def get_repo(authed: bool = True) -> tuple[github.Github, github.Repository.Repo
     return gclient, repo
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass()
 class LabelerCtx:
     client: github.Github
     repo: github.Repository.Repository
@@ -70,7 +70,7 @@ class LabelerCtx:
         return frozenset(labels)
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass()
 class IssueLabelerCtx(LabelerCtx):
     issue: github.Issue.Issue
 
@@ -79,7 +79,7 @@ class IssueLabelerCtx(LabelerCtx):
         return self.issue
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass()
 class PRLabelerCtx(LabelerCtx):
     pr: github.PullRequest.PullRequest
 

--- a/hacking/pr_labeler/label.py
+++ b/hacking/pr_labeler/label.py
@@ -160,8 +160,11 @@ def new_contributor_welcome(ctx: IssueOrPrCtx) -> None:
     # This contributor has already been welcomed!
     if "new_contributor" in ctx.previously_labeled:
         return
-    log(ctx, "author_association is", ctx.member.raw_data["author_association"])
-    if ctx.member.raw_data["author_association"] not in {
+    author_association = ctx.event_member.get(
+        "author_association", ctx.member.raw_data["author_association"]
+    )
+    log(ctx, "author_association is", author_association)
+    if author_association not in {
         "FIRST_TIMER",
         "FIRST_TIME_CONTRIBUTOR",
     }:


### PR DESCRIPTION
- labeler: remove global get_previously_labeled()
- labeler: make LabelerCtx un-frozen
- labeler: pass Github Action event data to script
- labeler: retrieve author_association from event data
