### PR TITLE
EE guides: add run_community_ee_image.rst

### DIFF
--- a/docs/docsite/rst/getting_started_ee/build_execution_environment.rst
+++ b/docs/docsite/rst/getting_started_ee/build_execution_environment.rst
@@ -21,6 +21,10 @@ To build your first EE:
   cat > execution-environment.yml<<EOF
   version: 3
 
+  images:
+    base_image:
+      name: ghcr.io/ansible/community-ee:latest 
+
   dependencies:
     galaxy:
       collections:

--- a/docs/docsite/rst/getting_started_ee/build_execution_environment.rst
+++ b/docs/docsite/rst/getting_started_ee/build_execution_environment.rst
@@ -23,9 +23,13 @@ To build your first EE:
 
   images:
     base_image:
-      name: ghcr.io/ansible/community-ee:latest 
+      name: quay.io/fedora/fedora:latest
 
   dependencies:
+    ansible_core:
+      package_pip: ansible-core
+    ansible_runner:
+      package_pip: ansible-runner
     galaxy:
       collections:
       - name: community.postgresql

--- a/docs/docsite/rst/getting_started_ee/index.rst
+++ b/docs/docsite/rst/getting_started_ee/index.rst
@@ -31,3 +31,4 @@ The resulting container image represents an Ansible control node that contains t
    setup_environment
    build_execution_environment
    run_execution_environment
+   run_community_ee_image

--- a/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
+++ b/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
@@ -3,14 +3,15 @@
 Running Ansible with the community EE image
 ===========================================
 
-You can run ansible without the need to build a custom EE. 
-Use the ``community-ee-minimal`` image that includes only ``ansible-core``.
+You can run ansible without the need to build a custom EE using community images.
+Use the ``community-ee-minimal`` image that includes only ``ansible-core`` or
+the ``community-ee-base`` image that also includes several base collections.
 
-Run the following command to see the ``ansible.builtin`` collection version which is a part of ``ansible-core``:
+Run the following command to see the collections included in the ``community-ee-base`` image:
 
 .. code-block:: bash
 
-  ansible-navigator collections --execution-environment-image ghcr.io/ansible-community/community-ee-minimal:latest
+  ansible-navigator collections --execution-environment-image ghcr.io/ansible-community/community-ee-base:latest
 
 Run the following Ansible ad-hoc command against localhost inside the ``community-ee-minimal`` container:
 

--- a/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
+++ b/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
@@ -6,7 +6,7 @@ Running a playbook using the community EE image
 There is the ``community-ee`` image built with ``ansible-core`` and a set of popular collections
 which you can use to run your playbooks without building your custom EE.
 
-Run the following command to see the included collections.
+Run the following command to see the collections available in the ``community-ee`` image:
 
 .. code-block:: bash
 

--- a/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
+++ b/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
@@ -38,7 +38,7 @@ Now, create a simple test playbook and run it against localhost inside the conta
 
   ansible-navigator run test_localhost.yml --execution-environment-image ghcr.io/ansible/community-ee:latest --mode stdout
 
-See the :ref:`Running your EE guide<running_execution_environments_remote_target>` for an example how to run your playbook against a remote target.
+See the :ref:`Running your EE guide<running_execution_environments_remote_target>` for an example of how to run your playbook against a remote target.
 
 What to read next
 -----------------

--- a/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
+++ b/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
@@ -12,25 +12,11 @@ Run the following command to see the included collections.
 
   ansible-navigator collections --execution-environment-image ghcr.io/ansible/community-ee:latest
 
-To try out the EE, create a simple test playbook and run it against localhost inside the container.
-
-.. code-block:: yaml
-
-  cat > test_localhost.yml<<EOF
-  - name: Gather and print local facts
-    hosts: localhost
-    become: yes
-    gather_facts: yes
-    tasks:
-
-    - name: Print facts
-      ansible.builtin.debug:
-        var: ansible_facts
-  EOF
+To try out the EE, run the following ad hoc command against localhost inside the container.
 
 .. code-block:: bash
 
-  ansible-navigator run test_localhost.yml --execution-environment-image ghcr.io/ansible/community-ee:latest --mode stdout
+  ansible-navigator exec "ansible localhost -m setup" --execution-environment-image ghcr.io/ansible/community-ee:latest --mode stdout
 
 What to read next
 -----------------

--- a/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
+++ b/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
@@ -44,5 +44,5 @@ What to read next
 -----------------
 
 * :ref:`Building your first execution environment <building_execution_environments>`
-* `Ansible Navigator official documentation <https://ansible-navigator.readthedocs.io/>`_
+* `Ansible Navigator documentation <https://ansible-navigator.readthedocs.io/>`_
 * :ref:`The list of tools for EE<ansible_tooling_for_ee>`

--- a/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
+++ b/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
@@ -3,7 +3,7 @@
 Running a playbook with the community EE image
 ===============================================
 
-You can run playbooks without the need to build a custom EE. 
+You can run ansible without the need to build a custom EE. 
 Use the ``community-ee`` image that includes ``ansible-core`` and a set of Ansible community collections.
 
 Run the following command to see the collections available in the ``community-ee`` image:

--- a/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
+++ b/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
@@ -3,8 +3,8 @@
 Running a playbook with the community EE image
 ===============================================
 
-There is the ``community-ee`` image built with ``ansible-core`` and a set of popular collections
-which you can use to run your playbooks without building your custom EE.
+You can run playbooks without the need to build a custom EE. 
+Use the ``community-ee`` image that includes ``ansible-core`` and a set of Ansible community collections.
 
 Run the following command to see the collections available in the ``community-ee`` image:
 

--- a/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
+++ b/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
@@ -43,6 +43,6 @@ See the :ref:`Running your EE guide<running_execution_environments_remote_target
 What to read next
 -----------------
 
-* :ref:`Building your first execution environment <building_execution_environments>`
+* :ref:`Building your first execution environment<building_execution_environments>`
 * `Ansible Navigator documentation <https://ansible-navigator.readthedocs.io/>`_
 * :ref:`The list of tools for EE<ansible_tooling_for_ee>`

--- a/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
+++ b/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
@@ -1,6 +1,6 @@
 .. _running_community_ee_image:
 
-Running a playbook using the community EE image
+Running a playbook with the community EE image
 ===============================================
 
 There is the ``community-ee`` image built with ``ansible-core`` and a set of popular collections

--- a/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
+++ b/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
@@ -43,6 +43,6 @@ See the :ref:`Running your EE guide<running_execution_environments_remote_target
 What to read next
 -----------------
 
-* :ref:`Building your first EE guide<building_execution_environments>`
+* :ref:`Building your first execution environment <building_execution_environments>`
 * `Ansible Navigator official documentation <https://ansible-navigator.readthedocs.io/>`_
 * :ref:`The list of tools for EE<ansible_tooling_for_ee>`

--- a/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
+++ b/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
@@ -4,19 +4,19 @@ Running Ansible with the community EE image
 ===========================================
 
 You can run ansible without the need to build a custom EE. 
-Use the ``community-ee`` image that includes ``ansible-core`` and a set of Ansible community collections.
+Use the ``community-ee-minimal`` image that includes only ``ansible-core``.
 
-Run the following command to see the collections available in the ``community-ee`` image:
-
-.. code-block:: bash
-
-  ansible-navigator collections --execution-environment-image ghcr.io/ansible/community-ee:latest
-
-Run the following Ansible ad-hoc command against localhost inside the ``community-ee`` container:
+Run the following command to see the ``ansible.builtin`` collection version which is a part of ``ansible-core``:
 
 .. code-block:: bash
 
-  ansible-navigator exec "ansible localhost -m setup" --execution-environment-image ghcr.io/ansible/community-ee:latest --mode stdout
+  ansible-navigator collections --execution-environment-image ghcr.io/ansible-community/community-ee-minimal:latest
+
+Run the following Ansible ad-hoc command against localhost inside the ``community-ee-minimal`` container:
+
+.. code-block:: bash
+
+  ansible-navigator exec "ansible localhost -m setup" --execution-environment-image ghcr.io/ansible-community/community-ee-minimal:latest --mode stdout
 
 Now, create a simple test playbook and run it against localhost inside the container:
 
@@ -36,7 +36,7 @@ Now, create a simple test playbook and run it against localhost inside the conta
 
 .. code-block:: bash
 
-  ansible-navigator run test_localhost.yml --execution-environment-image ghcr.io/ansible/community-ee:latest --mode stdout
+  ansible-navigator run test_localhost.yml --execution-environment-image ghcr.io/ansible-community/community-ee-minimal:latest --mode stdout
 
 See the :ref:`Running your EE guide<running_execution_environments_remote_target>` for an example of how to run your playbook against a remote target.
 

--- a/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
+++ b/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
@@ -1,0 +1,40 @@
+.. _running_community_ee_image:
+
+Running a playbook using the community EE image
+===============================================
+
+There is the ``community-ee`` image built with ``ansible-core`` and a set of popular collections
+which you can use to run your playbooks without building your custom EE.
+
+Run the following command to see the included collections.
+
+.. code-block:: bash
+
+  ansible-navigator collections --execution-environment-image ghcr.io/ansible/community-ee:latest
+
+To try out the EE, create a simple test playbook and run it against localhost inside the container.
+
+.. code-block:: yaml
+
+  cat > test_localhost.yml<<EOF
+  - name: Gather and print local facts
+    hosts: localhost
+    become: yes
+    gather_facts: yes
+    tasks:
+
+    - name: Print facts
+      ansible.builtin.debug:
+        var: ansible_facts
+  EOF
+
+.. code-block:: bash
+
+  ansible-navigator run test_localhost.yml --execution-environment-image ghcr.io/ansible/community-ee:latest --mode stdout
+
+What to read next
+-----------------
+
+* :ref:`Building your first EE guide<building_execution_environments>`
+* `Ansible Navigator official documentation <https://ansible-navigator.readthedocs.io/>`_
+* :ref:`The list of tools for EE<ansible_tooling_for_ee>`

--- a/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
+++ b/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
@@ -12,7 +12,7 @@ Run the following command to see the collections available in the ``community-ee
 
   ansible-navigator collections --execution-environment-image ghcr.io/ansible/community-ee:latest
 
-To try out the EE, run the following ad hoc command against localhost inside the container.
+Run the following Ansible ad-hoc command against localhost inside the ``community-ee`` container:
 
 .. code-block:: bash
 

--- a/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
+++ b/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
@@ -1,7 +1,7 @@
 .. _running_community_ee_image:
 
-Running a playbook with the community EE image
-===============================================
+Running Ansible with the community EE image
+===========================================
 
 You can run ansible without the need to build a custom EE. 
 Use the ``community-ee`` image that includes ``ansible-core`` and a set of Ansible community collections.

--- a/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
+++ b/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
@@ -18,6 +18,28 @@ Run the following Ansible ad-hoc command against localhost inside the ``communit
 
   ansible-navigator exec "ansible localhost -m setup" --execution-environment-image ghcr.io/ansible/community-ee:latest --mode stdout
 
+Now, create a simple test playbook and run it against localhost inside the container:
+
+.. code-block:: yaml
+
+  cat > test_localhost.yml<<EOF
+  - name: Gather and print local facts
+    hosts: localhost
+    become: yes
+    gather_facts: yes
+    tasks:
+
+    - name: Print facts
+      ansible.builtin.debug:
+        var: ansible_facts
+  EOF
+
+.. code-block:: bash
+
+  ansible-navigator run test_localhost.yml --execution-environment-image ghcr.io/ansible/community-ee:latest --mode stdout
+
+See the :ref:`Running your EE guide<running_execution_environments_remote_target>` for an example how to run your playbook against a remote target.
+
 What to read next
 -----------------
 

--- a/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
+++ b/docs/docsite/rst/getting_started_ee/run_community_ee_image.rst
@@ -40,9 +40,12 @@ Now, create a simple test playbook and run it against localhost inside the conta
 
 See the :ref:`Running your EE guide<running_execution_environments_remote_target>` for an example of how to run your playbook against a remote target.
 
-What to read next
------------------
+Ready to learn how to build an execution environment in a few easy steps?
+Proceed to the :ref:`Building your first EE<building_execution_environments>`.
 
-* :ref:`Building your first execution environment<building_execution_environments>`
-* `Ansible Navigator documentation <https://ansible-navigator.readthedocs.io/>`_
-* :ref:`The list of tools for EE<ansible_tooling_for_ee>`
+.. seealso::
+
+   `Ansible Navigator documentation <https://ansible-navigator.readthedocs.io/>`_
+       Learn more about the ansible-navigator utility.
+   :ref:`The list of tools for EE<ansible_tooling_for_ee>`
+       See the list of tools you can use execution environments with.

--- a/docs/docsite/rst/getting_started_ee/run_execution_environment.rst
+++ b/docs/docsite/rst/getting_started_ee/run_execution_environment.rst
@@ -10,10 +10,6 @@ using ``ansible-navigator``.
 
   There are other tools besides ``ansible-navigator`` you can run EEs with.
 
-.. note::
-
-  To try an EE without building a custom one, substitute ``postgresql_ee`` image used in this document with the ``ghcr.io/ansible/community-ee:latest`` community image.
-
 Run against localhost
 ---------------------
 

--- a/docs/docsite/rst/getting_started_ee/run_execution_environment.rst
+++ b/docs/docsite/rst/getting_started_ee/run_execution_environment.rst
@@ -97,7 +97,7 @@ What to read next
 
 * More about the `EE definition file <https://ansible-builder.readthedocs.io/en/stable/definition/>`_ and available options
 * `Ansible Builder CLI usage <https://ansible-builder.readthedocs.io/en/stable/usage/>`_
-* `Ansible Navigator official documentation <https://ansible-navigator.readthedocs.io/>`_
+* `Ansible Navigator documentation <https://ansible-navigator.readthedocs.io/>`_
 * :ref:`Running community EE guide<run_community_ee_image>`
 * `Running a local container registry for EE <https://forum.ansible.com/t/running-local-container-registry-for-execution-environments/206>`_.
 * :ref:`The list of tools for EE<ansible_tooling_for_ee>`

--- a/docs/docsite/rst/getting_started_ee/run_execution_environment.rst
+++ b/docs/docsite/rst/getting_started_ee/run_execution_environment.rst
@@ -10,6 +10,10 @@ using ``ansible-navigator``.
 
   There are other tools besides ``ansible-navigator`` you can run EEs with.
 
+.. note::
+
+  To try an EE without building a custom one, substitute ``postgresql_ee`` image used in this document with the ``ghcr.io/ansible/community-ee:latest`` community image.
+
 Run against localhost
 ---------------------
 

--- a/docs/docsite/rst/getting_started_ee/run_execution_environment.rst
+++ b/docs/docsite/rst/getting_started_ee/run_execution_environment.rst
@@ -10,6 +10,10 @@ using ``ansible-navigator``.
 
   There are other tools besides ``ansible-navigator`` you can run EEs with.
 
+.. note::
+
+  If you only need to try out EEs without building your custom one, you can simply substitute ``postgresql_ee`` image used in this document with the ``ghcr.io/ansible/community-ee:latest`` community image.
+
 Run against localhost
 ---------------------
 
@@ -89,8 +93,9 @@ Before you start, ensure you have the following:
 What to read next
 -----------------
 
-* More about the `EE definition file <https://ansible-builder.readthedocs.io/en/stable/definition/>`_ and available options.
-* `Ansible Builder CLI usage <https://ansible-builder.readthedocs.io/en/stable/usage/>`_.
-* `Ansible Navigator official documentation <https://ansible-navigator.readthedocs.io/>`_.
+* More about the `EE definition file <https://ansible-builder.readthedocs.io/en/stable/definition/>`_ and available options
+* `Ansible Builder CLI usage <https://ansible-builder.readthedocs.io/en/stable/usage/>`_
+* `Ansible Navigator official documentation <https://ansible-navigator.readthedocs.io/>`_
+* :ref:`Running community EE guide<run_community_ee_image>`
 * `Running a local container registry for EE <https://forum.ansible.com/t/running-local-container-registry-for-execution-environments/206>`_.
-* :ref:`The list of tools for EE<ansible_tooling_for_ee>`.
+* :ref:`The list of tools for EE<ansible_tooling_for_ee>`

--- a/docs/docsite/rst/getting_started_ee/run_execution_environment.rst
+++ b/docs/docsite/rst/getting_started_ee/run_execution_environment.rst
@@ -12,7 +12,7 @@ using ``ansible-navigator``.
 
 .. note::
 
-  If you only need to try out EEs without building your custom one, you can simply substitute ``postgresql_ee`` image used in this document with the ``ghcr.io/ansible/community-ee:latest`` community image.
+  To try an EE without building a custom one, substitute ``postgresql_ee`` image used in this document with the ``ghcr.io/ansible/community-ee:latest`` community image.
 
 Run against localhost
 ---------------------

--- a/docs/docsite/rst/getting_started_ee/run_execution_environment.rst
+++ b/docs/docsite/rst/getting_started_ee/run_execution_environment.rst
@@ -42,6 +42,8 @@ Run against localhost
 You may notice the facts being gathered are about the container and not the developer machine.
 This is because the ansible playbook was run inside the container.
 
+.. _running_execution_environments_remote_target:
+
 Run against a remote target
 ---------------------------
 

--- a/docs/docsite/rst/getting_started_ee/run_execution_environment.rst
+++ b/docs/docsite/rst/getting_started_ee/run_execution_environment.rst
@@ -92,12 +92,17 @@ Before you start, ensure you have the following:
 
   ansible-navigator run test_remote.yml -i inventory --execution-environment-image postgresql_ee:latest --mode stdout --pull-policy missing --enable-prompts -u student -k -K
 
-What to read next
------------------
+.. seealso::
 
-* More about the `EE definition file <https://ansible-builder.readthedocs.io/en/stable/definition/>`_ and available options
-* `Ansible Builder CLI usage <https://ansible-builder.readthedocs.io/en/stable/usage/>`_
-* `Ansible Navigator documentation <https://ansible-navigator.readthedocs.io/>`_
-* :ref:`Running community EE guide<run_community_ee_image>`
-* `Running a local container registry for EE <https://forum.ansible.com/t/running-local-container-registry-for-execution-environments/206>`_.
-* :ref:`The list of tools for EE<ansible_tooling_for_ee>`
+   `Execution Environment Definition <https://ansible-builder.readthedocs.io/en/stable/definition/>`_
+       More about execution environment definition file and available options.
+   `Ansible Builder CLI usage <https://ansible-builder.readthedocs.io/en/stable/usage/>`_
+       Find out more about Ansible Builder's command-line arguments.
+   `Ansible Navigator documentation <https://ansible-navigator.readthedocs.io/>`_
+       Learn more about the ansible-navigator utility.
+   :ref:`The list of tools for EE<ansible_tooling_for_ee>`
+       See the list of tools you can use execution environments with.
+   :ref:`Running community EE guide<run_community_ee_image>`
+       Learn more about running the community-provided execution environment.
+   `Running a local container registry for EE <https://forum.ansible.com/t/running-local-container-registry-for-execution-environments/206>`_
+       Learn how to quickly set up a local container registry for your execution environments.

--- a/docs/docsite/rst/getting_started_ee/setup_environment.rst
+++ b/docs/docsite/rst/getting_started_ee/setup_environment.rst
@@ -38,5 +38,8 @@ If you want to build EEs without testing, install only ``ansible-builder``:
   ansible-navigator --version
   ansible-builder --version
 
-Ready to build your first EE?
-Proceed to :ref:`Building your first EE<building_execution_environments>`
+Ready to build an EE in a few easy steps?
+Proceed to the :ref:`Building your first EE guide<building_execution_environments>`.
+
+Do you want to run a playbook without building a custom EE?
+Proceed to the :ref:`Running community EE guide<run_community_ee_image>`.

--- a/docs/docsite/rst/getting_started_ee/setup_environment.rst
+++ b/docs/docsite/rst/getting_started_ee/setup_environment.rst
@@ -42,4 +42,4 @@ Ready to build an EE in a few easy steps?
 Proceed to the :ref:`Building your first EE <building_execution_environments>`.
 
 Want to try an EE without having to build one?
-Proceed to the :ref:`Running community EE guide<run_community_ee_image>`.
+Proceed to the :ref:`Running the community EE <run_community_ee_image>`.

--- a/docs/docsite/rst/getting_started_ee/setup_environment.rst
+++ b/docs/docsite/rst/getting_started_ee/setup_environment.rst
@@ -41,5 +41,5 @@ If you want to build EEs without testing, install only ``ansible-builder``:
 Ready to build an EE in a few easy steps?
 Proceed to the :ref:`Building your first EE guide<building_execution_environments>`.
 
-Do you want to run a playbook without building a custom EE?
+Want to try an EE without having to build one?
 Proceed to the :ref:`Running community EE guide<run_community_ee_image>`.

--- a/docs/docsite/rst/getting_started_ee/setup_environment.rst
+++ b/docs/docsite/rst/getting_started_ee/setup_environment.rst
@@ -39,7 +39,7 @@ If you want to build EEs without testing, install only ``ansible-builder``:
   ansible-builder --version
 
 Ready to build an EE in a few easy steps?
-Proceed to the :ref:`Building your first EE <building_execution_environments>`.
+Proceed to the :ref:`Building your first EE<building_execution_environments>`.
 
 Want to try an EE without having to build one?
-Proceed to the :ref:`Running the community EE <run_community_ee_image>`.
+Proceed to the :ref:`Running the community EE<run_community_ee_image>`.

--- a/docs/docsite/rst/getting_started_ee/setup_environment.rst
+++ b/docs/docsite/rst/getting_started_ee/setup_environment.rst
@@ -39,7 +39,7 @@ If you want to build EEs without testing, install only ``ansible-builder``:
   ansible-builder --version
 
 Ready to build an EE in a few easy steps?
-Proceed to the :ref:`Building your first EE guide<building_execution_environments>`.
+Proceed to the :ref:`Building your first EE <building_execution_environments>`.
 
 Want to try an EE without having to build one?
 Proceed to the :ref:`Running community EE guide<run_community_ee_image>`.

--- a/docs/docsite/sphinx_conf/core_conf.py
+++ b/docs/docsite/sphinx_conf/core_conf.py
@@ -131,6 +131,7 @@ exclude_patterns = [
     'getting_started_ee/build_execution_environment.rst',
     'getting_started_ee/index.rst',
     'getting_started_ee/introduction.rst',
+    'getting_started_ee/run_community_ee_image.rst',
     'getting_started_ee/run_execution_environment.rst',
     'getting_started_ee/setup_environment.rst',
     'porting_guides/porting_guides.rst',

--- a/docs/docsite/sphinx_conf/core_lang_conf.py
+++ b/docs/docsite/sphinx_conf/core_lang_conf.py
@@ -131,6 +131,7 @@ exclude_patterns = [
     'getting_started_ee/build_execution_environment.rst',
     'getting_started_ee/index.rst',
     'getting_started_ee/introduction.rst',
+    'getting_started_ee/run_community_ee_image.rst',
     'getting_started_ee/run_execution_environment.rst',
     'getting_started_ee/setup_environment.rst',
     'porting_guides/porting_guides.rst',


### PR DESCRIPTION
EE guides: add run_community_ee_image.rst

Rationale: in case users want just try it w/o building a custom one