### PR TITLE
Fix sanity test page titles

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/no-unicode-literals.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/no-unicode-literals.rst
@@ -1,4 +1,4 @@
-no-unicode_literals
+no-unicode-literals
 ===================
 
 The use of :code:`from __future__ import unicode_literals` has been deemed an anti-pattern.  The

--- a/docs/docsite/rst/dev_guide/testing/sanity/release-names.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/release-names.rst
@@ -1,4 +1,4 @@
-Release names
+release-names
 =============
 
 Verifies that the most recent release name has been added to ``./github/RELEASE_NAMES.yml``

--- a/docs/docsite/rst/dev_guide/testing/sanity/runtime-metadata.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/runtime-metadata.rst
@@ -1,5 +1,5 @@
-runtime-metadata.yml
-====================
+runtime-metadata
+================
 
 Validates the schema for:
 


### PR DESCRIPTION
The titles should exactly match the name of the sanity test.