### PR TITLE
Use a dedicated version helper for the docs build (#80345)

### DIFF
--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -45,12 +45,12 @@ DOC_PLUGINS ?= become cache callback cliconf connection httpapi inventory lookup
 
 PYTHON ?= python
 # fetch version from project release.py as single source-of-truth
-VERSION := $(shell $(PYTHON) ../../packaging/release/versionhelper/version_helper.py --raw || echo error)
+VERSION := $(shell $(PYTHON) ./version_helper.py --raw || echo error)
 ifeq ($(findstring error,$(VERSION)), error)
 $(error "version_helper failed")
 endif
 
-MAJOR_VERSION := $(shell $(PYTHON) ../../packaging/release/versionhelper/version_helper.py --majorversion || echo error)
+MAJOR_VERSION := $(shell $(PYTHON) ./version_helper.py --majorversion || echo error)
 ifeq ($(findstring error,$(MAJOR_VERSION)), error)
 $(error "version_helper failed to determine major version")
 endif

--- a/docs/docsite/version_helper.py
+++ b/docs/docsite/version_helper.py
@@ -1,0 +1,30 @@
+"""Simple helper for printing ansible-core version numbers."""
+import argparse
+import pathlib
+import sys
+
+from packaging.version import Version
+
+
+def main() -> None:
+    """Main program entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--raw', action='store_true')
+    group.add_argument('--majorversion', action='store_true')
+    args = parser.parse_args()
+
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent.parent / 'lib'))
+
+    from ansible.release import __version__
+
+    version = Version(__version__)
+
+    if args.raw:
+        print(version)
+    elif args.majorversion:
+        print(f'{version.major}.{version.minor}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Backport of https://github.com/ansible/ansible/pull/80345

This removes the dependency on the release version helper in the docs-build sanity test.

(cherry picked from commit 0cfdf0ad59689ce9b149e8d56b4e30bc876398b6)