### PR TITLE
installation_guide/intro_installation.rst: improve the doc

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -47,8 +47,8 @@ Selecting an Ansible package and version to install
 
 Ansible's community packages are distributed in two ways:
 
-* ``ansible-core``: a minimalist language and runtime package containing a set of :ref:`plugins_in_ansible.builtin`.
 * ``ansible``: a much larger "batteries included" package, which adds a community-curated selection of :ref:`Ansible Collections <collections>` for automating a wide variety of devices.
+* ``ansible-core``: a minimalist language and runtime package containing a set of :ref:`plugins_in_ansible.builtin`.
 
 Choose the package that fits your needs.
 The following instructions use ``ansible`` as a package name, but you can substitute ``ansible-core`` if you prefer to start with the minimal package and separately install only the Ansible Collections you require.
@@ -101,23 +101,24 @@ You may need to perform some additional configuration before you are able to run
 Installing Ansible
 ------------------
 
-Use ``pip`` in your selected Python environment to install the minimal ``ansible-core`` package for the current user:
+Use ``pip`` in your selected Python environment to install the full Ansible package for the current user:
+
+.. code-block:: console
+
+    $ python3 -m pip install --user ansible
+
+
+You can install the minimal ``ansible-core`` package for the current user:
 
 .. code-block:: console
 
     $ python3 -m pip install --user ansible-core
 
-You can install a specific version of ``ansible-core`` if you need:
+Alternately, you can install a specific version of ``ansible-core``:
 
 .. code-block:: console
 
     $ python3 -m pip install --user ansible-core==2.12.3
-
-Alternatively, you can install the full "batteries-included" Ansible package for the current user:
-
-.. code-block:: console
-
-    $ python3 -m pip install --user ansible
 
 .. _pip_upgrade:
 
@@ -146,23 +147,23 @@ These instructions will not go over the steps to install ``pipx``; if those inst
 Installing Ansible
 ------------------
 
-Use ``pipx`` in your environment to install the minimal ``ansible-core`` package:
+Use ``pipx`` in your environment to install the full Ansible package:
 
 .. code-block:: console
 
-    $ pipx install ansible-core
+    $ pipx install ansible
 
-You can install a specific version of ``ansible-core`` if you need:
+You can install the minimal ``ansible-core`` package:
+
+.. code-block:: console
+
+    $ pipx install --include-deps ansible-core
+
+Alternately, you can install a specific version of ``ansible-core``:
 
 .. code-block:: console
 
     $ pipx install ansible-core==2.12.3
-
-Alternatively, you can install the full Ansible package:
-
-.. code-block:: console
-
-    $ pipx install --include-deps ansible
 
 .. _pipx_upgrade:
 

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -141,6 +141,55 @@ Installing and upgrading Ansible with pipx
 
 On some systems, it may not be possible to install Ansible with ``pip``, due to decisions made by the operating system developers. In such cases, ``pipx`` is a widely available alternative.
 
+These instructions will not go over the steps to install ``pipx``; if those instructions are needed, please continue to the `pipx installation instructions`_ for more information.
+
+.. _pipx installation instructions: https://pypa.github.io/pipx/installation/
+
+.. _pipx_install:
+
+Installing Ansible
+------------------
+
+Use ``pipx`` in your environment to install the minimal ``ansible-core`` package:
+
+.. code-block:: console
+
+    $ pipx install ansible-core
+
+You can install a specific version of ``ansible-core`` if you need:
+
+.. code-block:: console
+
+    $ pipx install ansible-core==2.12.3
+
+Alternatively, you can install the full Ansible package:
+
+.. code-block:: console
+
+    $ pipx install --include-deps ansible
+
+.. _pipx_upgrade:
+
+Upgrading Ansible
+-----------------
+
+To upgrade an existing Ansible installation to the latest released version:
+
+.. code-block:: console
+
+    $ pipx upgrade ansible
+
+.. _pipx_inject:
+
+Installing Extra Python Dependencies
+------------------------------------
+
+To install additional python dependencies that may be needed, with the example of installing the ``argcomplete`` python package as described below:
+
+.. code-block:: console
+
+    $ pipx inject ansible argcomplete
+
 Installing for development
 ==========================
 

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -141,55 +141,6 @@ Installing and upgrading Ansible with pipx
 
 On some systems, it may not be possible to install Ansible with ``pip``, due to decisions made by the operating system developers. In such cases, ``pipx`` is a widely available alternative.
 
-These instructions will not go over the steps to install ``pipx``; if those instructions are needed, please continue to the `pipx installation instructions`_ for more information.
-
-.. _pipx installation instructions: https://pypa.github.io/pipx/installation/
-
-.. _pipx_install:
-
-Installing Ansible
-------------------
-
-Use ``pipx`` in your environment to install the minimal ``ansible-core`` package:
-
-.. code-block:: console
-
-    $ pipx install ansible-core
-
-You can install a specific version of ``ansible-core`` if you need:
-
-.. code-block:: console
-
-    $ pipx install ansible-core==2.12.3
-
-Alternatively, you can install the full Ansible package:
-
-.. code-block:: console
-
-    $ pipx install --include-deps ansible
-
-.. _pipx_upgrade:
-
-Upgrading Ansible
------------------
-
-To upgrade an existing Ansible installation to the latest released version:
-
-.. code-block:: console
-
-    $ pipx upgrade ansible
-
-.. _pipx_inject:
-
-Installing Extra Python Dependencies
-------------------------------------
-
-To install additional python dependencies that may be needed, with the example of installing the ``argcomplete`` python package as described below:
-
-.. code-block:: console
-
-    $ pipx inject ansible argcomplete
-
 Installing for development
 ==========================
 
@@ -295,17 +246,17 @@ For more information about installation and configuration, see the `argcomplete 
 Installing ``argcomplete``
 --------------------------
 
-If you chose the ``pipx`` install instructions:
-
-.. code-block:: console
-
-    $ pipx inject ansible argcomplete
-
-Or, if you chose the ``pip`` install instructions:
+If you chose the ``pip``:
 
 .. code-block:: console
 
     $ python3 -m pip install --user argcomplete
+
+If you chose the ``pipx``:
+
+.. code-block:: console
+
+    $ pipx inject ansible argcomplete
 
 Configuring ``argcomplete``
 ---------------------------

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -107,7 +107,6 @@ Use ``pip`` in your selected Python environment to install the full Ansible pack
 
     $ python3 -m pip install --user ansible
 
-
 You can install the minimal ``ansible-core`` package for the current user:
 
 .. code-block:: console

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -47,8 +47,8 @@ Selecting an Ansible package and version to install
 
 Ansible's community packages are distributed in two ways:
 
-* ``ansible``: a much larger "batteries included" package, which adds a community-curated selection of :ref:`Ansible Collections <collections>` for automating a wide variety of devices.
 * ``ansible-core``: a minimalist language and runtime package containing a set of :ref:`plugins_in_ansible.builtin`.
+* ``ansible``: a much larger "batteries included" package, which adds a community-curated selection of :ref:`Ansible Collections <collections>` for automating a wide variety of devices.
 
 Choose the package that fits your needs.
 The following instructions use ``ansible`` as a package name, but you can substitute ``ansible-core`` if you prefer to start with the minimal package and separately install only the Ansible Collections you require.

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -5,7 +5,9 @@
 Installing Ansible
 ******************
 
-Ansible is an agentless automation tool that you install on a single host (referred to as the control node). From the control node, Ansible can manage an entire fleet of machines and other devices (referred to as managed nodes) remotely with SSH, Powershell remoting, and numerous other transports, all from a simple command-line interface with no databases or daemons required.
+Ansible is an agentless automation tool that you install on a single host (referred to as the control node).
+
+From the control node, Ansible can manage an entire fleet of machines and other devices (referred to as managed nodes) remotely with SSH, Powershell remoting, and numerous other transports, all from a simple command-line interface with no databases or daemons required.
 
 .. contents::
   :local:
@@ -22,12 +24,13 @@ For your *control* node (the machine that runs Ansible), you can use nearly any 
 Managed node requirements
 =========================
 
-The *managed* node (the machine that Ansible is managing) does not require Ansible to be installed, but requires Python 2.7, or Python 3.5 - 3.11 to run Ansible library code.
-The managed node also needs a user account that can SSH to the node with an interactive POSIX shell.
+The *managed* node (the machine that Ansible is managing) does not require Ansible to be installed, but requires Python 2.7, or Python 3.5 - 3.11 to run Ansible-generated Python code.
+
+The managed node also needs a user account that can connect through SSH to the node with an interactive POSIX shell.
 
 .. note::
 
-   Network modules are an exception and do not require Python on the managed device.  See :ref:`network_modules`.
+   There can be exceptions in module requirements. For example, network modules do not require Python on the managed device. See documentation for modules you use.
 
 .. _node_requirements_summary:
 
@@ -43,16 +46,96 @@ You can find details about control and managed node requirements for each Ansibl
 Selecting an Ansible package and version to install
 ====================================================
 
-Ansible's community packages are distributed in two ways: a minimalist language and runtime package called ``ansible-core``, and a much larger "batteries included" package called ``ansible``, which adds a community-curated selection of :ref:`Ansible Collections <collections>` for automating a wide variety of devices. Choose the package that fits your needs; The following instructions  use ``ansible``, but  you can substitute ``ansible-core``  if you prefer to start with a more minimal package and separately install only the Ansible Collections you require. The ``ansible`` or ``ansible-core`` packages may be available in your operating systems package manager, and you are free to install these packages with your preferred method. These installation instructions only cover the officially supported means of installing the python package with ``pip``.
+Ansible's community packages are distributed in two ways:
+
+* ``ansible-core``: a minimalist language and runtime package containing a set of :ref:`builtin modules and plugins<https://docs.ansible.com/ansible/latest/collections/ansible/builtin/index.html>`_.
+* ``ansible``: a much larger "batteries included" package, which adds a community-curated selection of :ref:`Ansible Collections <collections>` for automating a wide variety of devices.
+
+Choose the package that fits your needs.
+
+The following instructions use ``ansible`` as a package name, but you can substitute ``ansible-core`` if you prefer to start with the minimal package and separately install only the Ansible Collections you require.
+
+The ``ansible`` or ``ansible-core`` packages may be available in your operating systems package manager, and you are free to install these packages with your preferred method. These installation instructions only cover the officially supported means of installing the python package with ``pip``.
 
 See the :ref:`Ansible package release status table<ansible_changelogs>` for the ``ansible-core`` version included in the package.
+
+Installing and upgrading Ansible with pip
+=========================================
+
+Locating Python
+---------------
+
+Locate and remember the path to the Python interpreter you wish to use to run Ansible. The following instructions refer to this Python  as ``python3``.
+
+For example, if you have determined that you want the Python at ``/usr/bin/python3.9`` to be the one that you will install Ansible under, specify that instead of ``python3``.
+
+Ensuring ``pip`` is available
+-----------------------------
+
+To verify whether ``pip`` is already installed for your preferred Python:
+
+.. code-block:: console
+
+    $ python3 -m pip -V
+
+If all is well, you should see something like the following:
+
+.. code-block:: console
+
+    $ python3 -m pip -V
+    pip 21.0.1 from /usr/lib/python3.9/site-packages/pip (python 3.9)
+
+If so, ``pip`` is available, and you can move on to the :ref:`next step <pip_install>`.
+
+If you see an error like ``No module named pip``, you will need to install ``pip`` under your chosen Python interpreter before proceeding.
+
+This may mean installing an additional OS package (for example, ``python3-pip``), or installing the latest ``pip`` directly from the Python Packaging Authority by running the following:
+
+.. code-block:: console
+
+    $ curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+    $ python3 get-pip.py --user
+
+You may need to perform some additional configuration before you are able to run Ansible. See the Python documentation on `installing to the user site`_ for more information.
+
+.. _installing to the user site: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. _pip_install:
+
+Installing Ansible
+------------------
+
+Use ``pip`` in your selected Python environment to install the Ansible package of your choice for the current user:
+
+.. code-block:: console
+
+    $ python3 -m pip install --user ansible
+
+Alternately, you can install a specific version of ``ansible-core`` in this Python environment:
+
+.. code-block:: console
+
+    $ python3 -m pip install --user ansible-core==2.12.3
+
+.. _pip_upgrade:
+
+Upgrading Ansible
+-----------------
+
+To upgrade an existing Ansible installation in this Python environment to the latest released version, simply add ``--upgrade`` to the command above:
+
+.. code-block:: console
+
+    $ python3 -m pip install --upgrade --user ansible
+
+.. _development_install:
 
 Installing and upgrading Ansible with pipx
 ==========================================
 
-On some systems, it may not be possible to install Ansible with ``pip``, due to decisions made by the operating system. In such cases, ``pipx`` is a widely available alternative.
+On some systems, it may not be possible to install Ansible with ``pip``, due to decisions made by the operating system developers. In such cases, ``pipx`` is a widely available alternative.
 
-These instructions will not go over the steps to install ``pipx``; If those instructions are needed please continue to the `pipx installation instructions`_ for more information.
+These instructions will not go over the steps to install ``pipx``; if those instructions are needed, please continue to the `pipx installation instructions`_ for more information.
 
 .. _pipx installation instructions: https://pypa.github.io/pipx/installation/
 
@@ -101,73 +184,6 @@ To install additional python dependencies that may be needed, with the example o
 
     $ pipx inject ansible argcomplete
 
-Installing and upgrading Ansible with pip
-=========================================
-
-Locating Python
----------------
-
-Locate and remember the path to the Python interpreter you wish to use to run Ansible. The following instructions refer to this Python  as ``python3``. For example, if you've determined that you want the Python at ``/usr/bin/python3.9`` to be the one that you'll install Ansible under, specify that instead of ``python3``.
-
-Ensuring ``pip`` is available
------------------------------
-
-To verify whether ``pip`` is already installed for your preferred Python:
-
-.. code-block:: console
-
-    $ python3 -m pip -V
-
-If all is well, you should see something like the following:
-
-.. code-block:: console
-
-    $ python3 -m pip -V
-    pip 21.0.1 from /usr/lib/python3.9/site-packages/pip (python 3.9)
-
-If so, ``pip`` is available, and you can move on to the :ref:`next step <pip_install>`.
-
-If you see an error like ``No module named pip``, you'll need to install ``pip`` under your chosen Python interpreter before proceeding. This may mean installing an additional OS package (for example, ``python3-pip``), or installing the latest ``pip`` directly from the Python Packaging Authority by running the following:
-
-.. code-block:: console
-
-    $ curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-    $ python3 get-pip.py --user
-
-You may need to perform some additional configuration before you are able to run Ansible. See the Python documentation on `installing to the user site`_ for more information.
-
-.. _installing to the user site: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
-
-.. _pip_install:
-
-Installing Ansible
-------------------
-
-Use ``pip`` in your selected Python environment to install the Ansible package of your choice for the current user:
-
-.. code-block:: console
-
-    $ python3 -m pip install --user ansible
-
-Alternately, you can install a specific version of ``ansible-core`` in this Python environment:
-
-.. code-block:: console
-
-    $ python3 -m pip install --user ansible-core==2.12.3
-
-.. _pip_upgrade:
-
-Upgrading Ansible
------------------
-
-To upgrade an existing Ansible installation in this Python environment to the latest released version, simply add ``--upgrade`` to the command above:
-
-.. code-block:: console
-
-    $ python3 -m pip install --upgrade --user ansible
-
-.. _development_install:
-
 Installing for development
 ==========================
 
@@ -177,7 +193,9 @@ If you are testing new features, fixing bugs, or otherwise working with the deve
 
     You should only install and run the ``devel`` branch if you are modifying ``ansible-core`` or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
 
-For more information on getting involved in the Ansible project, see the :ref:`ansible_community_guide`. For more information on creating Ansible modules and Collections, see the :ref:`developer_guide`.
+For more information on getting involved in the Ansible project, see the :ref:`ansible_community_guide`.
+
+For more information on creating Ansible modules and Collections, see the :ref:`developer_guide`.
 
 .. _from_pip_devel:
 
@@ -262,7 +280,9 @@ To check the version of the ``ansible`` package that has been installed:
 Adding Ansible command shell completion
 =======================================
 
-You can add shell completion of the Ansible command line utilities by installing an optional dependency called ``argcomplete``. ``argcomplete`` supports bash, and has limited support for zsh and tcsh.
+You can add shell completion of the Ansible command line utilities by installing an optional dependency called ``argcomplete``.
+
+``argcomplete`` supports bash, and has limited support for zsh and tcsh.
 
 For more information about installation and configuration, see the `argcomplete documentation <https://kislyuk.github.io/argcomplete/>`_.
 

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -48,7 +48,7 @@ Selecting an Ansible package and version to install
 
 Ansible's community packages are distributed in two ways:
 
-* ``ansible-core``: a minimalist language and runtime package containing a set of `builtin modules and plugins<https://docs.ansible.com/ansible/latest/collections/ansible/builtin/index.html>`_.
+* ``ansible-core``: a minimalist language and runtime package containing a set of `builtin modules and plugins <https://docs.ansible.com/ansible/latest/collections/ansible/builtin/index.html>`_.
 * ``ansible``: a much larger "batteries included" package, which adds a community-curated selection of :ref:`Ansible Collections <collections>` for automating a wide variety of devices.
 
 Choose the package that fits your needs.

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -105,19 +105,19 @@ You may need to perform some additional configuration before you are able to run
 Installing Ansible
 ------------------
 
-Use ``pip`` in your selected Python environment to install the ``ansible-core`` package for the current user:
+Use ``pip`` in your selected Python environment to install the minimal ``ansible-core`` package for the current user:
 
 .. code-block:: console
 
     $ python3 -m pip install --user ansible-core
 
-You can install a specific version of ``ansible-core`` in this Python environment:
+You can install a specific version of ``ansible-core`` if you need:
 
 .. code-block:: console
 
     $ python3 -m pip install --user ansible-core==2.12.3
 
-Alternatively, you can install the "batteries-included" Ansible package for the current user:
+Alternatively, you can install the full "batteries-included" Ansible package for the current user:
 
 .. code-block:: console
 
@@ -150,23 +150,23 @@ These instructions will not go over the steps to install ``pipx``; if those inst
 Installing Ansible
 ------------------
 
-Use ``pipx`` in your environment to install the Ansible package of your choice for the current user:
-
-.. code-block:: console
-
-    $ pipx install --include-deps ansible
-
-If you prefer to install only the minimal ``ansible-core`` package, run:
+Use ``pipx`` in your environment to install the minimal ``ansible-core`` package:
 
 .. code-block:: console
 
     $ pipx install ansible-core
 
-Alternately, you can install a specific version of ``ansible-core``:
+You can install a specific version of ``ansible-core`` if you need:
 
 .. code-block:: console
 
     $ pipx install ansible-core==2.12.3
+
+Alternatively, you can install the full Ansible package:
+
+.. code-block:: console
+
+    $ pipx install --include-deps ansible
 
 .. _pipx_upgrade:
 

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -48,7 +48,7 @@ Selecting an Ansible package and version to install
 
 Ansible's community packages are distributed in two ways:
 
-* ``ansible-core``: a minimalist language and runtime package containing a set of :ref:`builtin modules and plugins<https://docs.ansible.com/ansible/latest/collections/ansible/builtin/index.html>`_.
+* ``ansible-core``: a minimalist language and runtime package containing a set of `builtin modules and plugins<https://docs.ansible.com/ansible/latest/collections/ansible/builtin/index.html>`_.
 * ``ansible``: a much larger "batteries included" package, which adds a community-curated selection of :ref:`Ansible Collections <collections>` for automating a wide variety of devices.
 
 Choose the package that fits your needs.
@@ -105,17 +105,23 @@ You may need to perform some additional configuration before you are able to run
 Installing Ansible
 ------------------
 
-Use ``pip`` in your selected Python environment to install the Ansible package of your choice for the current user:
+Use ``pip`` in your selected Python environment to install the ``ansible-core`` package for the current user:
 
 .. code-block:: console
 
-    $ python3 -m pip install --user ansible
+    $ python3 -m pip install --user ansible-core
 
-Alternately, you can install a specific version of ``ansible-core`` in this Python environment:
+You can install a specific version of ``ansible-core`` in this Python environment:
 
 .. code-block:: console
 
     $ python3 -m pip install --user ansible-core==2.12.3
+
+Alternatively, you can install the "batteries-included" Ansible package for the current user:
+
+.. code-block:: console
+
+    $ python3 -m pip install --user ansible
 
 .. _pip_upgrade:
 

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -282,20 +282,20 @@ To check the version of the ``ansible`` package that has been installed:
 Adding Ansible command shell completion
 =======================================
 
-You can add shell completion of the Ansible command line utilities by installing an optional dependency called ``argcomplete``, which supports bash, and has limited support for zsh and tcsh.
+You can add shell completion of the Ansible command line utilities by installing an optional dependency called ``argcomplete``. It supports bash, and has limited support for zsh and tcsh.
 
 For more information about installation and configuration, see the `argcomplete documentation <https://kislyuk.github.io/argcomplete/>`_.
 
 Installing ``argcomplete``
 --------------------------
 
-If you chose the ``pip``:
+If you chose the ``pip`` installation instructions:
 
 .. code-block:: console
 
     $ python3 -m pip install --user argcomplete
 
-If you chose the ``pipx``:
+If you chose the ``pipx`` installation instructions:
 
 .. code-block:: console
 

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -25,7 +25,6 @@ Managed node requirements
 =========================
 
 The *managed* node (the machine that Ansible is managing) does not require Ansible to be installed, but requires Python 2.7, or Python 3.5 - 3.11 to run Ansible-generated Python code.
-
 The managed node also needs a user account that can connect through SSH to the node with an interactive POSIX shell.
 
 .. note::
@@ -52,7 +51,6 @@ Ansible's community packages are distributed in two ways:
 * ``ansible``: a much larger "batteries included" package, which adds a community-curated selection of :ref:`Ansible Collections <collections>` for automating a wide variety of devices.
 
 Choose the package that fits your needs.
-
 The following instructions use ``ansible`` as a package name, but you can substitute ``ansible-core`` if you prefer to start with the minimal package and separately install only the Ansible Collections you require.
 
 The ``ansible`` or ``ansible-core`` packages may be available in your operating systems package manager, and you are free to install these packages with your preferred method. For more information, see the :ref:`installing_distros` guide. These installation instructions only cover the officially supported means of installing the python packages with ``pip``.
@@ -66,7 +64,6 @@ Locating Python
 ---------------
 
 Locate and remember the path to the Python interpreter you wish to use to run Ansible. The following instructions refer to this Python  as ``python3``.
-
 For example, if you have determined that you want the Python at ``/usr/bin/python3.9`` to be the one that you will install Ansible under, specify that instead of ``python3``.
 
 Ensuring ``pip`` is available
@@ -88,7 +85,6 @@ If all is well, you should see something like the following:
 If so, ``pip`` is available, and you can move on to the :ref:`next step <pip_install>`.
 
 If you see an error like ``No module named pip``, you will need to install ``pip`` under your chosen Python interpreter before proceeding.
-
 This may mean installing an additional OS package (for example, ``python3-pip``), or installing the latest ``pip`` directly from the Python Packaging Authority by running the following:
 
 .. code-block:: console
@@ -286,9 +282,7 @@ To check the version of the ``ansible`` package that has been installed:
 Adding Ansible command shell completion
 =======================================
 
-You can add shell completion of the Ansible command line utilities by installing an optional dependency called ``argcomplete``.
-
-``argcomplete`` supports bash, and has limited support for zsh and tcsh.
+You can add shell completion of the Ansible command line utilities by installing an optional dependency called ``argcomplete``, which supports bash, and has limited support for zsh and tcsh.
 
 For more information about installation and configuration, see the `argcomplete documentation <https://kislyuk.github.io/argcomplete/>`_.
 

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -55,7 +55,7 @@ Choose the package that fits your needs.
 
 The following instructions use ``ansible`` as a package name, but you can substitute ``ansible-core`` if you prefer to start with the minimal package and separately install only the Ansible Collections you require.
 
-The ``ansible`` or ``ansible-core`` packages may be available in your operating systems package manager, and you are free to install these packages with your preferred method. These installation instructions only cover the officially supported means of installing the python package with ``pip``.
+The ``ansible`` or ``ansible-core`` packages may be available in your operating systems package manager, and you are free to install these packages with your preferred method. For more information, see the :ref:`installing_distros` guide. These installation instructions only cover the officially supported means of installing the python packages with ``pip``.
 
 See the :ref:`Ansible package release status table<ansible_changelogs>` for the ``ansible-core`` version included in the package.
 

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -47,7 +47,7 @@ Selecting an Ansible package and version to install
 
 Ansible's community packages are distributed in two ways:
 
-* ``ansible-core``: a minimalist language and runtime package containing a set of `builtin modules and plugins <https://docs.ansible.com/ansible/latest/collections/ansible/builtin/index.html>`_.
+* ``ansible-core``: a minimalist language and runtime package containing a set of :ref:`plugins_in_ansible.builtin`.
 * ``ansible``: a much larger "batteries included" package, which adds a community-curated selection of :ref:`Ansible Collections <collections>` for automating a wide variety of devices.
 
 Choose the package that fits your needs.

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -29,7 +29,7 @@ The managed node also needs a user account that can connect through SSH to the n
 
 .. note::
 
-   There can be exceptions in module requirements. For example, network modules do not require Python on the managed device. See documentation for modules you use.
+   There can be exceptions in module requirements. For example, network modules do not require Python on the managed device. See documentation for the modules you use.
 
 .. _node_requirements_summary:
 

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -57,6 +57,60 @@ The ``ansible`` or ``ansible-core`` packages may be available in your operating 
 
 See the :ref:`Ansible package release status table<ansible_changelogs>` for the ``ansible-core`` version included in the package.
 
+Installing and upgrading Ansible with pipx
+==========================================
+
+On some systems, it may not be possible to install Ansible with ``pip``, due to decisions made by the operating system developers. In such cases, ``pipx`` is a widely available alternative.
+
+These instructions will not go over the steps to install ``pipx``; if those instructions are needed, please continue to the `pipx installation instructions`_ for more information.
+
+.. _pipx installation instructions: https://pypa.github.io/pipx/installation/
+
+.. _pipx_install:
+
+Installing Ansible
+------------------
+
+Use ``pipx`` in your environment to install the full Ansible package:
+
+.. code-block:: console
+
+    $ pipx install ansible
+
+You can install the minimal ``ansible-core`` package:
+
+.. code-block:: console
+
+    $ pipx install --include-deps ansible-core
+
+Alternately, you can install a specific version of ``ansible-core``:
+
+.. code-block:: console
+
+    $ pipx install ansible-core==2.12.3
+
+.. _pipx_upgrade:
+
+Upgrading Ansible
+-----------------
+
+To upgrade an existing Ansible installation to the latest released version:
+
+.. code-block:: console
+
+    $ pipx upgrade ansible
+
+.. _pipx_inject:
+
+Installing Extra Python Dependencies
+------------------------------------
+
+To install additional python dependencies that may be needed, with the example of installing the ``argcomplete`` python package as described below:
+
+.. code-block:: console
+
+    $ pipx inject ansible argcomplete
+
 Installing and upgrading Ansible with pip
 =========================================
 
@@ -131,60 +185,6 @@ To upgrade an existing Ansible installation in this Python environment to the la
     $ python3 -m pip install --upgrade --user ansible
 
 .. _development_install:
-
-Installing and upgrading Ansible with pipx
-==========================================
-
-On some systems, it may not be possible to install Ansible with ``pip``, due to decisions made by the operating system developers. In such cases, ``pipx`` is a widely available alternative.
-
-These instructions will not go over the steps to install ``pipx``; if those instructions are needed, please continue to the `pipx installation instructions`_ for more information.
-
-.. _pipx installation instructions: https://pypa.github.io/pipx/installation/
-
-.. _pipx_install:
-
-Installing Ansible
-------------------
-
-Use ``pipx`` in your environment to install the full Ansible package:
-
-.. code-block:: console
-
-    $ pipx install ansible
-
-You can install the minimal ``ansible-core`` package:
-
-.. code-block:: console
-
-    $ pipx install --include-deps ansible-core
-
-Alternately, you can install a specific version of ``ansible-core``:
-
-.. code-block:: console
-
-    $ pipx install ansible-core==2.12.3
-
-.. _pipx_upgrade:
-
-Upgrading Ansible
------------------
-
-To upgrade an existing Ansible installation to the latest released version:
-
-.. code-block:: console
-
-    $ pipx upgrade ansible
-
-.. _pipx_inject:
-
-Installing Extra Python Dependencies
-------------------------------------
-
-To install additional python dependencies that may be needed, with the example of installing the ``argcomplete`` python package as described below:
-
-.. code-block:: console
-
-    $ pipx inject ansible argcomplete
 
 Installing for development
 ==========================
@@ -294,12 +294,6 @@ If you chose the ``pip`` installation instructions:
 .. code-block:: console
 
     $ python3 -m pip install --user argcomplete
-
-If you chose the ``pipx`` installation instructions:
-
-.. code-block:: console
-
-    $ pipx inject ansible argcomplete
 
 Configuring ``argcomplete``
 ---------------------------

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -289,6 +289,12 @@ For more information about installation and configuration, see the `argcomplete 
 Installing ``argcomplete``
 --------------------------
 
+If you chose the ``pipx`` installation instructions:
+
+.. code-block:: console
+
+    $ pipx inject ansible argcomplete
+
 If you chose the ``pip`` installation instructions:
 
 .. code-block:: console

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -75,13 +75,13 @@ Use ``pipx`` in your environment to install the full Ansible package:
 
 .. code-block:: console
 
-    $ pipx install ansible
+    $ pipx install --include-deps ansible
 
 You can install the minimal ``ansible-core`` package:
 
 .. code-block:: console
 
-    $ pipx install --include-deps ansible-core
+    $ pipx install ansible-core
 
 Alternately, you can install a specific version of ``ansible-core``:
 


### PR DESCRIPTION
installation_guide/intro_installation.rst: improve the doc:
- improve readability by splitting up stuff
- remove not working `See :ref:network_modules` ref
- put `ansible-core` installation example before `ansible` example.
- remove pipX examples. left only mentioning it. i think users can figure it out themselves w/o having the guide overwhelmed with it