### PR TITLE
Fix missing newline before a list

### DIFF
--- a/docs/docsite/rst/inventory_guide/intro_inventory.rst
+++ b/docs/docsite/rst/inventory_guide/intro_inventory.rst
@@ -12,6 +12,7 @@ The simplest inventory is a single file with a list of hosts and groups. The def
 You can specify a different inventory file at the command line using the ``-i <path>`` option or in configuration using ``inventory``.
 
 Ansible :ref:`inventory_plugins` support a range of formats and sources to make your inventory flexible and customizable. As your inventory expands, you may need more than a single file to organize your hosts and groups. Here are three options beyond the ``/etc/ansible/hosts`` file:
+
 - You can create a directory with multiple inventory files. See :ref:`inventory_directory`. These can use different formats (YAML, ini, and so on).
 - You can pull inventory dynamically. For example, you can use a dynamic inventory plugin to list resources in one or more cloud providers. See :ref:`intro_dynamic_inventory`.
 - You can use multiple sources for inventory, including both dynamic inventory and static files. See :ref:`using_multiple_inventory_sources`.


### PR DESCRIPTION
Without it, all list items appear one after another within the paragraph that's supposed to be introducing them.