### PR TITLE
WIP: Fix path to the OpenStack inventory plugin

### DIFF
--- a/docs/docsite/rst/inventory_guide/intro_dynamic_inventory.rst
+++ b/docs/docsite/rst/inventory_guide/intro_dynamic_inventory.rst
@@ -120,7 +120,7 @@ Inventory script example: OpenStack
 
 If you use an OpenStack-based cloud, instead of manually maintaining your own inventory file, you can use the ``openstack_inventory.py`` dynamic inventory to pull information about your compute instances directly from OpenStack.
 
-You can download the latest version of the OpenStack inventory script `here <https://raw.githubusercontent.com/openstack/ansible-collections-openstack/master/scripts/inventory/openstack_inventory.py>`_.
+You can download the latest version of the OpenStack inventory script `here <https://raw.githubusercontent.com/openstack/ansible-collections-openstack/master/plugins/inventory/openstack.py>`_.
 
 You can use the inventory script explicitly (by passing the `-i openstack_inventory.py` argument to Ansible) or implicitly (by placing the script at `/etc/ansible/hosts`).
 
@@ -131,7 +131,7 @@ Download the latest version of the OpenStack dynamic inventory script and make i
 
 .. code-block:: bash
 
-    wget https://raw.githubusercontent.com/openstack/ansible-collections-openstack/master/scripts/inventory/openstack_inventory.py
+    wget https://raw.githubusercontent.com/openstack/ansible-collections-openstack/master/plugins/inventory/openstack.py
     chmod +x openstack_inventory.py
 
 .. note::


### PR DESCRIPTION
The old path was removed with the following commit, right before the 2.0.0 release:

    commit 34017d511bea42c56a387a30dd2acb67f5e31de8
    Author: Jakob Meng <code@jakobmeng.de>
    Date:   Fri Jan 27 14:38:04 2023 +0100

        Dropped unmaintained, obsolete and broken inventory script

        This removes the old inventory script only. For a proper replacement,
        please use inventory plugin openstack.cloud.openstack.

        Change-Id: Ib677862c049b70f39630d56a147bd5537b12fb2b

Reasons for the WIP status:
 - A quick look at openstack.cloud.openstack's doc suggests one should be installing something from Galaxy[1].
 - I haven't tested it at the moment, I'm merely suggesting a possible trivial replacement, but more changes might be needed or welcome.

 1. https://docs.ansible.com/ansible/latest/collections/openstack/cloud/openstack_inventory.html