### PR TITLE
Use the correct short option for module path

### DIFF
--- a/docs/docsite/rst/command_guide/cheatsheet.rst
+++ b/docs/docsite/rst/command_guide/cheatsheet.rst
@@ -16,7 +16,7 @@ ansible-playbook
 
 .. code-block:: bash
 
-   ansible-playbook -i /path/to/my_inventory_file -u my_connection_user -k -f 3 -T 30 -t my_tag -m /path/to/my_modules -b -K my_playbook.yml
+   ansible-playbook -i /path/to/my_inventory_file -u my_connection_user -k -f 3 -T 30 -t my_tag -M /path/to/my_modules -b -K my_playbook.yml
 
 Loads ``my_playbook.yml`` from the current working directory and:
   - ``-i`` - uses ``my_inventory_file`` in the path provided for :ref:`inventory <intro_inventory>` to match the :ref:`pattern <intro_patterns>`.
@@ -25,7 +25,7 @@ Loads ``my_playbook.yml`` from the current working directory and:
   - ``-f`` - allocates 3 :ref:`forks <playbooks_strategies>`.
   - ``-T`` - sets a 30-second timeout.
   - ``-t`` - runs only tasks marked with the :ref:`tag <tags>` ``my_tag``.
-  - ``-m`` - loads :ref:`local modules <developing_locally>` from ``/path/to/my/modules``.
+  - ``-M`` - loads :ref:`local modules <developing_locally>` from ``/path/to/my/modules``.
   - ``-b`` - executes with elevated privileges (uses :ref:`become <become>`).
   - ``-K`` - prompts the user for the become password.
 


### PR DESCRIPTION
ansible has -m as the short option for --module-name.

ansible and ansible-playbook have -M as the short option for --module-path.