### PR TITLE
Fix filters item2dicts example using `tags` instead of `fruits`

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_filters.rst
@@ -221,7 +221,7 @@ In this example, you must pass the :ansopt:`ansible.builtin.items2dict#filter:ke
 
 .. code-block:: yaml+jinja
 
-    {{ tags | items2dict(key_name='fruit', value_name='color') }}
+    {{ fruits | items2dict(key_name='fruit', value_name='color') }}
 
 If you do not pass these arguments, or do not pass the correct values for your list, you will see ``KeyError: key`` or ``KeyError: my_typo``.
 


### PR DESCRIPTION
Small detail that should not really make anyone trip if they read carefully enough, just found it annoying