### PR TITLE
Add example /usr/bin/env python as Python interpreter

### DIFF
--- a/docs/docsite/rst/reference_appendices/interpreter_discovery.rst
+++ b/docs/docsite/rst/reference_appendices/interpreter_discovery.rst
@@ -49,3 +49,5 @@ auto_silent
 You can still set ``ansible_python_interpreter`` to a specific path at any
 variable level (for example, in host_vars, in vars files, in playbooks, and so on).
 Setting a specific path completely disables automatic interpreter discovery; Ansible always uses the path specified.
+
+.. seealso:: :ref:`python_3_support` for ``ansible_python_interpreter`` usage examples.

--- a/docs/docsite/rst/reference_appendices/python_3_support.rst
+++ b/docs/docsite/rst/reference_appendices/python_3_support.rst
@@ -68,6 +68,12 @@ Using Python 3 on the managed machines with commands and playbooks
     $ ansible localhost-py3 -m ping
     $ ansible-playbook sample-playbook.yml
 
+* To use the first Python found on ``PATH`` or if the Python interpreter path is not known in advance, you can use ``/usr/bin/env python`` such as:
+
+.. code-block:: shell
+
+    ansible_python_interpreter="/usr/bin/env python"
+
 
 Note that you can also use the `-e` command line option to manually
 set the python interpreter when you run a command.   This can be useful if you want to test whether

--- a/docs/docsite/rst/reference_appendices/python_3_support.rst
+++ b/docs/docsite/rst/reference_appendices/python_3_support.rst
@@ -1,3 +1,5 @@
+.. _python_3_support:
+
 ================
 Python 3 Support
 ================


### PR DESCRIPTION
I was looking for a way to use Python interpreter from an environment variable or directly from `PATH` rather than specifying absolute path as `ansible_python_interpreter`. For instance, I'm creating NixOS instance in Cloud and path to Python is hard to know in advance, I'd rather use the one from `PATH`.

Found out via https://github.com/ansible/ansible/issues/6345#issuecomment-181999529 one could use 

```
ansible_python_interpreter: '/usr/bin/env python'
```

And though it would be worth adding an example in doc :)
