### PR TITLE
Fix reference to single quoted style.

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_filters.rst
@@ -930,7 +930,7 @@ To print out the ports from cluster1 in a comma separated string:
 
 .. note:: In the example above, quoting literals using backticks avoids escaping quotes and maintains readability.
 
-You can use YAML `single quote escaping <https://yaml.org/spec/current.html#id2534365>`_:
+You can use YAML `single quote escaping <https://yaml.org/spec/1.2.2/#single-quoted-style>`_:
 
 .. code-block:: yaml+jinja
 


### PR DESCRIPTION
Unfortunately the way the redirection is implemented doesn't permit linking to a specific anchor while retaining the `current` indirection. Replace the link to point at the current version of the spec (1.2.2), using the correct anchor.

----

That one I'm not really sure about, since that means hardcoding a version. That being said, linking to the current version but without a working anchor means a strange experience (especially with an overlong document).