### PR TITLE
Add seealso with a ref to Navigator to the CLI tools page

### DIFF
--- a/docs/docsite/rst/command_guide/index.rst
+++ b/docs/docsite/rst/command_guide/index.rst
@@ -19,3 +19,10 @@ Ansible provides ad hoc commands and several utilities for performing various op
    intro_adhoc
    command_line_tools
    cheatsheet
+
+.. seealso::
+
+   `Ansible Navigator <https://ansible.readthedocs.io/projects/navigator/>`_
+       A command-line tool and a TUI that provides a convenient user interface for most
+       of the native Ansible command-line utilities and allows to run Ansible automation content
+       inside containers (`execution environments <https://docs.ansible.com/ansible/devel/getting_started_ee/index.html>`_)

--- a/docs/docsite/rst/command_guide/index.rst
+++ b/docs/docsite/rst/command_guide/index.rst
@@ -25,4 +25,4 @@ Ansible provides ad hoc commands and several utilities for performing various op
    `Ansible Navigator <https://ansible.readthedocs.io/projects/navigator/>`_
        A command-line tool and a TUI that provides a convenient user interface for most
        of the native Ansible command-line utilities and allows to run Ansible automation content
-       inside containers (:ref:`execution environments <getting_started_ee_index>`_)
+       inside containers (:ref:`execution environments <getting_started_ee_index>`)

--- a/docs/docsite/rst/command_guide/index.rst
+++ b/docs/docsite/rst/command_guide/index.rst
@@ -25,4 +25,4 @@ Ansible provides ad hoc commands and several utilities for performing various op
    `Ansible Navigator <https://ansible.readthedocs.io/projects/navigator/>`_
        A command-line tool and a TUI that provides a convenient user interface for most
        of the native Ansible command-line utilities and allows to run Ansible automation content
-       inside containers (`execution environments <https://docs.ansible.com/ansible/devel/getting_started_ee/index.html>`_)
+       inside containers (:ref:`execution environments <getting_started_ee_index>`_)

--- a/docs/docsite/rst/command_guide/index.rst
+++ b/docs/docsite/rst/command_guide/index.rst
@@ -25,4 +25,4 @@ Ansible provides ad hoc commands and several utilities for performing various op
    `Ansible Navigator <https://ansible.readthedocs.io/projects/navigator/>`_
        A command-line tool and a TUI that provides a convenient user interface for most
        of the native Ansible command-line utilities and allows to run Ansible automation content
-       inside containers (:ref:`execution environments <getting_started_ee_index>`)
+       inside containers (`execution environments <https://docs.ansible.com/ansible/devel/getting_started_ee/index.html>`_)


### PR DESCRIPTION
As navigator is officially supported and provides a common interface for running almost all of the tools listed there + allows to run content like playbooks inside containers,
i think it's worth putting a seealso with Navigator reference in the bottom of the doc