### PR TITLE
Host core docs on readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,23 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# RTD API version
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: >-
+      3.11
+  # Build with make coredocs
+  commands:
+    - python -m venv "${READTHEDOCS_VIRTUALENV_PATH}"
+    - >-
+      "${READTHEDOCS_VIRTUALENV_PATH}"/bin/python -m pip install --exists-action=w -r tests/requirements.in -c tests/requirements.txt
+    - >-
+      "${READTHEDOCS_VIRTUALENV_PATH}"/bin/python docs/bin/clone-core.py
+    - >-
+      make coredocs
+      -C docs/docsite
+      BUILDDIR="${READTHEDOCS_OUTPUT}"
+      PYTHON="${READTHEDOCS_VIRTUALENV_PATH}"/bin/python


### PR DESCRIPTION
This PR introduces a `.readthedocs.yaml` configuration that builds core docs on Read The Docs and partially resolves to https://github.com/ansible/ansible-documentation/issues/377