### PR TITLE
[stable-2.14] getting_started_playbook: improve the doc

### DIFF
--- a/docs/docsite/rst/getting_started/get_started_playbook.rst
+++ b/docs/docsite/rst/getting_started/get_started_playbook.rst
@@ -22,11 +22,7 @@ Module
 In the previous section, you used the ``ansible`` command to ping hosts in your inventory.
 Now let's create a playbook that pings your hosts and also prints a "Hello world" message.
 
-Complete the following steps:
-
-#. Open a terminal window on your control node.
-#. Create a new playbook file named ``playbook.yaml`` in any directory and open it for editing.
-#. Add the following content to ``playbook.yaml``:
+#. Create a file named ``playbook.yaml`` in your ``ansible_quickstart`` directory, that you created earlier, with the following content:
 
    .. literalinclude:: yaml/first_playbook.yaml
       :language: yaml

--- a/docs/docsite/rst/getting_started/yaml/first_playbook.yaml
+++ b/docs/docsite/rst/getting_started/yaml/first_playbook.yaml
@@ -3,6 +3,7 @@
   tasks:
    - name: Ping my hosts
      ansible.builtin.ping:
+
    - name: Print message
      ansible.builtin.debug:
        msg: Hello world


### PR DESCRIPTION
Manual backport of https://github.com/ansible/ansible-documentation/pull/253

Looks like something wasn't backported or needs to be backported before ^.
Feel free to close this PR if needed or merge.