### PR TITLE
[2.15] [issues #78]Update collection requirements links (#306)

### DIFF
--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -485,7 +485,7 @@ Requirements for collections to be included in the Ansible Package
 To be included in the `ansible` package, collections must meet the following criteria:
 
 * :ref:`Development conventions <module_dev_conventions>`.
-* `Collection requirements <https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst>`_ (this document).
+* `Collection requirements <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html>`_ (this document).
 
   * The `Collection Inclusion Criteria Checklist <https://github.com/ansible-collections/overview/blob/main/collection_checklist.md>`_ covers most of the criteria from this document.
 * :ref:`Ansible documentation format <module_documenting>` and the :ref:`style guide <style-guide>`.

--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -140,7 +140,7 @@ The `Ansible Community Steering Committee <https://docs.ansible.com/ansible/deve
 Create a new issue in the `repository <https://github.com/ansible-community/community-topics/issues>`_ if you want to discuss an idea that impacts any of the following:
 
 * Ansible Community
-* Community collection best practices and `requirements <https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst>`_
+* Community collection best practices and `requirements <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html>`_
 * `Community collection inclusion policy <https://github.com/ansible-collections/ansible-inclusion/blob/main/README.md>`_
 * `The Community governance <https://docs.ansible.com/ansible/devel/community/steering/community_steering_committee.html>`_
 * Other proposals of importance that need the Committee or overall Ansible community attention

--- a/docs/docsite/rst/dev_guide/developing_collections_migrating.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_migrating.rst
@@ -13,7 +13,7 @@ When you move content from one collection to another, for example to extract a s
 Migrating content
 =================
 
-Before you start migrating content from one collection to another, look at `Ansible Collection Checklist <https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst>`_.
+Before you start migrating content from one collection to another, look at `Ansible Collection Requirements <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html>`_.
 
 To migrate content from one collection to another, if the collections are parts of `Ansible distribution <https://github.com/ansible-community/ansible-build-data/blob/main/2.10/ansible.in>`_:
 

--- a/docs/docsite/rst/dev_guide/testing/sanity/import.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/import.rst
@@ -132,7 +132,7 @@ Ansible allows the following unchecked imports from these specific directories:
 * collections:
 
   * For ``plugins/modules/`` and ``plugins/module_utils/``, unchecked imports are only allowed from the Python standard library;
-  * For other directories in ``plugins/`` (see `the community collection requirements <https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst#modules-plugins>`_ for a list), unchecked imports are only allowed from the Python standard library, from public dependencies of ansible-core, and from ansible-core itself.
+  * For other directories in ``plugins/`` (see `the community collection requirements <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html#modules-plugins>`_ for a list), unchecked imports are only allowed from the Python standard library, from public dependencies of ansible-core, and from ansible-core itself.
 
 Public dependencies of ansible-core are:
 


### PR DESCRIPTION
Backport of #306 to stable-2.15.

I removed the change to docs/docsite/rst/locales/ja/LC_MESSAGES/dev_guide.po since that had a lot of conflicts.
