### PR TITLE
limit sphinx to `< 7.2.0` in requirements-relaxed

### DIFF
--- a/tests/constraints-base.in
+++ b/tests/constraints-base.in
@@ -1,3 +1,4 @@
 # Known limitations for indirect/transitive dependencies.
 
 rstcheck < 6  # rstcheck 6.x has problem with rstcheck.core triggered by include files w/ sphinx directives https://github.com/rstcheck/rstcheck-core/issues/3
+sphinx < 7.2.0 # https://github.com/readthedocs/sphinx-notfound-page/issues/219


### PR DESCRIPTION
limit sphinx to `< 7.2.0` in requirements-relaxed

7.2.0 breaks sphinx-notfound-page. This commit sets a general constraint
that applies to the testing requirements (requirements-relaxed).

Relates: https://github.com/ansible/ansible-documentation/issues/327