### PR TITLE
pr_labeler: add nag comment for issues and PRs without description

### DIFF
--- a/hacking/pr_labeler/data/no_body_nag.md
+++ b/hacking/pr_labeler/data/no_body_nag.md
@@ -1,0 +1,7 @@
+Thanks for your contribution, @{{ ctx.member.user.login }}! Please make sure that your {{ ctx.TYPE }} has a filled out description.
+{% if ctx.TYPE == "pull request" %}
+PR descriptions provide important context and allow other developers and our future selves to understand a change's rationale and what it actually fixes or accomplishes.
+{% else %}
+Issue descriptions are important so others can fully understand and reproduce the issue.
+{% endif %}
+<!--- boilerplate: no_body_nag --->

--- a/hacking/pr_labeler/data/no_body_nag.md
+++ b/hacking/pr_labeler/data/no_body_nag.md
@@ -1,4 +1,4 @@
-Thanks for your contribution, @{{ ctx.member.user.login }}! Please make sure that your {{ ctx.TYPE }} has a filled out description.
+Thanks for your contribution, @{{ ctx.member.user.login }}! Please make sure that your {{ ctx.TYPE }} includes sufficient and meaningful details in the description.
 {% if ctx.TYPE == "pull request" %}
 PR descriptions provide important context and allow other developers and our future selves to understand a change's rationale and what it actually fixes or accomplishes.
 {% else %}

--- a/hacking/pr_labeler/label.py
+++ b/hacking/pr_labeler/label.py
@@ -62,6 +62,7 @@ class LabelerCtx:
     repo: github.Repository.Repository
     dry_run: bool
     event_info: dict[str, Any]
+    issue: github.Issue.Issue
 
     @property
     def member(self) -> IssueOrPr:
@@ -88,8 +89,6 @@ class LabelerCtx:
 
 @dataclasses.dataclass()
 class IssueLabelerCtx(LabelerCtx):
-    issue: github.Issue.Issue
-
     @property
     def member(self) -> IssueOrPr:
         return self.issue
@@ -200,6 +199,7 @@ def process_pr(
         pr=pr,
         dry_run=dry_run,
         event_info=get_event_info(),
+        issue=pr.as_issue(),
     )
     if pr.state != "open":
         log(ctx, "Refusing to process closed ticket")

--- a/hacking/pr_labeler/requirements.txt
+++ b/hacking/pr_labeler/requirements.txt
@@ -1,3 +1,4 @@
 codeowners
+jinja2
 pygithub
 typer

--- a/tests/typing.txt
+++ b/tests/typing.txt
@@ -30,6 +30,10 @@ filelock==3.12.2
     # via virtualenv
 idna==3.4
     # via requests
+jinja2==3.1.2
+    # via -r tests/../hacking/pr_labeler/requirements.txt
+markupsafe==2.1.3
+    # via jinja2
 mypy==1.5.1
     # via -r tests/typing.in
 mypy-extensions==1.0.0


### PR DESCRIPTION
This PR updates the automatic issue and PR triager to leave nag comments if a PR or issue is missing a description. PRs created by bots are skipped. This was discussed in #333. The first two commits of the PR are prereqs for the the commit that actually implements the nag comment.

Implements: https://github.com/ansible/ansible-documentation/issues/333