### PR TITLE
noxfile: run typing session as part of lint session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -51,6 +51,7 @@ def typing(session: nox.Session):
 
 @nox.session
 def lint(session: nox.Session):
+    session.notify("typing")
     session.notify("static")
     session.notify("formatters")
 


### PR DESCRIPTION
`nox -e lint` runs the `static` and `formatters` sessions, but it does
not run `nox -e typing` due to an oversight in the initial PR.
