### PR TITLE
Fixes the error for ansible-doc in the tutorial

### DIFF
--- a/examples/scripts/my_test.py
+++ b/examples/scripts/my_test.py
@@ -30,8 +30,8 @@ options:
         type: bool
 # Specify this value according to your collection
 # in format of namespace.collection.doc_fragment_name
-#extends_documentation_fragment:
-#    - my_namespace.my_collection.my_doc_fragment_name
+# extends_documentation_fragment:
+#     - my_namespace.my_collection.my_doc_fragment_name
 
 author:
     - Your Name (@yourGitHubHandle)

--- a/examples/scripts/my_test.py
+++ b/examples/scripts/my_test.py
@@ -30,8 +30,8 @@ options:
         type: bool
 # Specify this value according to your collection
 # in format of namespace.collection.doc_fragment_name
-extends_documentation_fragment:
-    - my_namespace.my_collection.my_doc_fragment_name
+#extends_documentation_fragment:
+#    - my_namespace.my_collection.my_doc_fragment_name
 
 author:
     - Your Name (@yourGitHubHandle)


### PR DESCRIPTION
I picked
https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_general.html as an entrypoint to start developing my first ansible module.

I now have a module, where all the tests work except for the generation of the documentation.

The link to testing_documentation.html in the
"Testing your newly-created module" section redirects to a page that gives you the ansible-doc command to test your module's docs.

Here the ansible-doc command fails with an
"unknown doc_fragment(s)" error message
that I found difficult to interpret.

I think that the commented lines in this commit make ansible try to look at documentation fragments that do not exist at this stage of development.

It would probably be better to keep it commented out as a reference to a more advanced stage of development of the module,
while maintaining the tutorial fully-functional.