### PR TITLE
Update sphinx to 7.2.5 and remove constraint

### DIFF
--- a/tests/constraints-base.in
+++ b/tests/constraints-base.in
@@ -1,4 +1,3 @@
 # Known limitations for indirect/transitive dependencies.
 
 rstcheck < 6  # rstcheck 6.x has problem with rstcheck.core triggered by include files w/ sphinx directives https://github.com/rstcheck/rstcheck-core/issues/3
-sphinx < 7.2.0 # https://github.com/readthedocs/sphinx-notfound-page/issues/219

--- a/tests/constraints.in
+++ b/tests/constraints.in
@@ -1,5 +1,5 @@
 # This constraints file contains pins for the stable, tested versions of sphinx
 # and antsibull-docs that production builds rely upon.
 
-sphinx == 6.2.1
+sphinx == 7.2.5
 antsibull-docs == 2.3.1  # currently approved version

--- a/tests/requirements-relaxed.txt
+++ b/tests/requirements-relaxed.txt
@@ -113,9 +113,8 @@ six==1.16.0
     # via twiggy
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==7.1.2
+sphinx==7.2.5
     # via
-    #   -c tests/constraints-base.in
     #   -r tests/requirements-relaxed.in
     #   antsibull-docs
     #   sphinx-ansible-theme

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -115,9 +115,8 @@ six==1.16.0
     # via twiggy
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==6.2.1
+sphinx==7.2.5
     # via
-    #   -c tests/constraints-base.in
     #   -c tests/constraints.in
     #   -r tests/requirements-relaxed.in
     #   antsibull-docs


### PR DESCRIPTION
Reverts "limit sphinx to `< 7.2.0` in requirements-relaxed (#329)"

The new version of sphinx-not-found-page restores compatibility with
newer sphinx versions, so we no longer need to limit it in
constraints-base.in

The production `requirements.txt` file will be constrained to `sphinx ==
7.2.5` until we manually change the pin in constraints.in.

The requirements-relaxed.txt file for local testing will continue
updating to the latest sphinx version in the weekly requirements update
PRs.

Ref: https://github.com/ansible/ansible-documentation/pull/351#discussion_r1319378099

