### PR TITLE
nox pip-compile: allow passing custom posargs

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -67,11 +67,19 @@ requirements_files = list(
 def pip_compile(session: nox.Session, req: str):
     # .pip-tools.toml was introduced in v7
     session.install("pip-tools >= 7")
+
+    # Use --upgrade by default unless a user passes -P.
+    args = list(session.posargs)
+    if not any(
+        arg.startswith("-P") or arg.startswith("--upgrade-package") for arg in args
+    ):
+        args.append("--upgrade")
+
     # fmt: off
     session.run(
         "pip-compile",
-        "--upgrade",
         "--output-file", f"tests/{req}.txt",
+        *args,
         f"tests/{req}.in",
     )
     # fmt: on


### PR DESCRIPTION
Example:

``` shell
nox -e pip-compile-3.10(requirements-relaxed) -- -P sphinx
```

will only update the sphinx pin and leave all other packages.