### PR TITLE
[stable-2.15] readthedocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,23 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# RTD API version
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: >-
+      3.10
+  # Build with make coredocs
+  commands:
+    - python -m venv "${READTHEDOCS_VIRTUALENV_PATH}"
+    - >-
+      "${READTHEDOCS_VIRTUALENV_PATH}"/bin/python -m pip install --exists-action=w -r tests/requirements.in -c tests/requirements.txt
+    - >-
+      "${READTHEDOCS_VIRTUALENV_PATH}"/bin/python docs/bin/clone-core.py
+    - >-
+      make coredocs
+      -C docs/docsite
+      BUILDDIR="${READTHEDOCS_OUTPUT}"
+      PYTHON="${READTHEDOCS_VIRTUALENV_PATH}"/bin/python


### PR DESCRIPTION
readthedocs ci will always fail on backports to stable branches unless they contain a readthedocs configuration. The error message is quite clear: "A configuration file was not found. Make sure you have a conf.py file in your repository."

I went ahead and merged https://github.com/ansible/ansible-documentation/commit/6b0db6e85ffade4caad4c5e99afca2de90539f42 even though the RTD check failed. I don't want the readthedocs evaluation to get in the way of "docs.ansible.com" but I also don't like merging PRs with broken ci checks either.

@samccann You can see the active versions on the server-side here: https://readthedocs.org/projects/stage-ansible-core/versions/

@gotmax23 @felixfontein @acozine Would you like me to add you as an admin to this readthedocs project? I think we're at a good point to start getting more thoughts from the steering committee. Please let me know when you're ready.
