### PR TITLE
[stable-2.16] Update ansible-core branch indicator file

### DIFF
--- a/docs/ansible-core-branch.txt
+++ b/docs/ansible-core-branch.txt
@@ -1,1 +1,1 @@
-devel
+stable-2.16


### PR DESCRIPTION
Right now the stable-2.16 docs are built with ansible-core **devel** since the branch indicator file hasn't been updated after branching.