### PR TITLE
Add label to 'collections:' keyword

### DIFF
--- a/docs/docsite/rst/collections_guide/collections_using_playbooks.rst
+++ b/docs/docsite/rst/collections_guide/collections_using_playbooks.rst
@@ -57,6 +57,8 @@ Within a role, you can control which collections Ansible searches for the tasks 
      - my_namespace.second_collection
      - other_namespace.other_collection
 
+.. _collections_keyword:
+
 Using ``collections`` in playbooks
 ----------------------------------
 


### PR DESCRIPTION
Right now it is not possible to `:ref:` the `collections:` keyword. Needed to fix #345.