### PR TITLE
[stable-2.14] Bump docs build dependencies, including upgrading antsibull-docs to 2.4.0

### DIFF
--- a/tests/constraints.in
+++ b/tests/constraints.in
@@ -2,4 +2,4 @@
 resolvelib < 0.9.0
 sphinx == 4.2.0
 rstcheck < 4  # match version used in other sanity tests
-antsibull-docs == 1.7.3  # currently approved version
+antsibull-docs == 2.4.0  # currently approved version

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,10 +4,12 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements.txt --strip-extras requirements.in
 #
-aiofiles==23.1.0
+aiofiles==23.2.1
     # via antsibull-core
 aiohttp==3.8.5
-    # via antsibull-core
+    # via
+    #   antsibull-core
+    #   antsibull-docs
 aiosignal==1.3.1
     # via aiohttp
 alabaster==0.7.13
@@ -16,13 +18,15 @@ ansible-pygments==0.1.1
     # via
     #   antsibull-docs
     #   sphinx-ansible-theme
-antsibull-core==1.6.0
+antsibull-core==2.1.0
     # via antsibull-docs
-antsibull-docs==1.7.3
+antsibull-docs==2.4.0
     # via
     #   -c constraints.in
     #   -r requirements.in
-async-timeout==4.0.2
+antsibull-docs-parser==1.0.0
+    # via antsibull-docs
+async-timeout==4.0.3
     # via aiohttp
 asyncio-pool==0.6.0
     # via antsibull-docs
@@ -30,6 +34,8 @@ attrs==23.1.0
     # via aiohttp
 babel==2.12.1
     # via sphinx
+build==1.0.3
+    # via antsibull-core
 certifi==2023.7.22
     # via requests
 charset-normalizer==3.2.0
@@ -67,19 +73,25 @@ packaging==23.1
     # via
     #   antsibull-core
     #   antsibull-docs
+    #   build
     #   sphinx
 perky==0.9.2
     # via antsibull-core
-pydantic==1.10.12
-    # via antsibull-core
+pydantic==1.10.13
+    # via
+    #   antsibull-core
+    #   antsibull-docs
 pygments==2.16.1
     # via
     #   ansible-pygments
     #   sphinx
+pyproject-hooks==1.0.0
+    # via build
 pyyaml==6.0.1
     # via
     #   -r requirements.in
     #   antsibull-core
+    #   antsibull-docs
 requests==2.31.0
     # via sphinx
 resolvelib==0.8.1
@@ -92,7 +104,9 @@ rstcheck==3.5.0
     #   -r requirements.in
     #   antsibull-docs
 semantic-version==2.10.0
-    # via antsibull-core
+    # via
+    #   antsibull-core
+    #   antsibull-docs
 sh==1.14.3
     # via antsibull-core
 six==1.16.0
@@ -112,7 +126,7 @@ sphinx-ansible-theme==0.9.1
     # via -r requirements.in
 sphinx-notfound-page==0.8.3
     # via -r requirements.in
-sphinx-rtd-theme==1.2.2
+sphinx-rtd-theme==1.3.0
     # via sphinx-ansible-theme
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
@@ -128,15 +142,21 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
+tomli==2.0.1
+    # via
+    #   build
+    #   pyproject-hooks
 twiggy==0.5.1
-    # via antsibull-core
-typing-extensions==4.7.1
+    # via
+    #   antsibull-core
+    #   antsibull-docs
+typing-extensions==4.8.0
     # via pydantic
-urllib3==2.0.4
+urllib3==2.0.5
     # via requests
 yarl==1.9.2
     # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==68.0.0
+setuptools==68.2.2
     # via sphinx


### PR DESCRIPTION
Simiar to #445, but for stable-2.14.