### PR TITLE
[stable-2.13] Bump docs build dependencies, including upgrading antsibull-docs to 2.4.0

### DIFF
--- a/docs/docsite/rst/user_guide/collections_using.rst
+++ b/docs/docsite/rst/user_guide/collections_using.rst
@@ -428,6 +428,8 @@ Within a role, you can control which collections Ansible searches for the tasks 
      - my_namespace.second_collection
      - other_namespace.other_collection
 
+.. _collections_keyword:
+
 Using ``collections`` in playbooks
 ----------------------------------
 

--- a/tests/constraints.in
+++ b/tests/constraints.in
@@ -2,4 +2,4 @@
 resolvelib < 0.9.0
 sphinx == 4.2.0
 rstcheck == 3.3.1
-antsibull-docs == 1.0.0
+antsibull-docs == 2.4.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,10 +4,12 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements.txt --strip-extras requirements.in
 #
-aiofiles==23.2.0
+aiofiles==23.2.1
     # via antsibull-core
 aiohttp==3.8.5
-    # via antsibull-core
+    # via
+    #   antsibull-core
+    #   antsibull-docs
 aiosignal==1.3.1
     # via aiohttp
 alabaster==0.7.13
@@ -16,13 +18,15 @@ ansible-pygments==0.1.1
     # via
     #   antsibull-docs
     #   sphinx-ansible-theme
-antsibull-core==1.6.0
+antsibull-core==2.1.0
     # via antsibull-docs
-antsibull-docs==1.0.0
+antsibull-docs==2.4.0
     # via
     #   -c constraints.in
     #   -r requirements.in
-async-timeout==4.0.2
+antsibull-docs-parser==1.0.0
+    # via antsibull-docs
+async-timeout==4.0.3
     # via aiohttp
 asyncio-pool==0.6.0
     # via antsibull-docs
@@ -30,6 +34,8 @@ attrs==23.1.0
     # via aiohttp
 babel==2.12.1
     # via sphinx
+build==1.0.3
+    # via antsibull-core
 certifi==2023.7.22
     # via requests
 charset-normalizer==3.2.0
@@ -52,7 +58,7 @@ idna==3.4
     #   yarl
 imagesize==1.4.1
     # via sphinx
-jinja2==3.0.3
+jinja2==3.1.2
     # via
     #   -r requirements.in
     #   antsibull-docs
@@ -66,19 +72,26 @@ multidict==6.0.4
 packaging==23.1
     # via
     #   antsibull-core
+    #   antsibull-docs
+    #   build
     #   sphinx
 perky==0.9.2
     # via antsibull-core
-pydantic==1.10.12
-    # via antsibull-core
+pydantic==1.10.13
+    # via
+    #   antsibull-core
+    #   antsibull-docs
 pygments==2.16.1
     # via
     #   ansible-pygments
     #   sphinx
+pyproject-hooks==1.0.0
+    # via build
 pyyaml==6.0.1
     # via
     #   -r requirements.in
     #   antsibull-core
+    #   antsibull-docs
 requests==2.31.0
     # via sphinx
 resolvelib==0.8.1
@@ -91,7 +104,9 @@ rstcheck==3.3.1
     #   -r requirements.in
     #   antsibull-docs
 semantic-version==2.10.0
-    # via antsibull-core
+    # via
+    #   antsibull-core
+    #   antsibull-docs
 sh==1.14.3
     # via antsibull-core
 six==1.16.0
@@ -111,7 +126,7 @@ sphinx-ansible-theme==0.9.1
     # via -r requirements.in
 sphinx-notfound-page==0.8.3
     # via -r requirements.in
-sphinx-rtd-theme==1.2.2
+sphinx-rtd-theme==1.3.0
     # via sphinx-ansible-theme
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
@@ -129,15 +144,21 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 straight-plugin==1.5.0
     # via -r requirements.in
+tomli==2.0.1
+    # via
+    #   build
+    #   pyproject-hooks
 twiggy==0.5.1
-    # via antsibull-core
-typing-extensions==4.7.1
+    # via
+    #   antsibull-core
+    #   antsibull-docs
+typing-extensions==4.8.0
     # via pydantic
-urllib3==2.0.4
+urllib3==2.0.5
     # via requests
 yarl==1.9.2
     # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==68.0.0
+setuptools==68.2.2
     # via sphinx


### PR DESCRIPTION
Simiar to #445, but for stable-2.13.