### PR TITLE
Bump antsibull-docs to 2.5.0

### DIFF
--- a/tests/constraints.in
+++ b/tests/constraints.in
@@ -2,4 +2,4 @@
 # and antsibull-docs that production builds rely upon.
 
 sphinx == 7.2.5
-antsibull-docs == 2.4.0  # currently approved version
+antsibull-docs == 2.5.0  # currently approved version

--- a/tests/requirements-relaxed.txt
+++ b/tests/requirements-relaxed.txt
@@ -20,7 +20,7 @@ ansible-pygments==0.1.1
     #   sphinx-ansible-theme
 antsibull-core==2.1.0
     # via antsibull-docs
-antsibull-docs==2.4.0
+antsibull-docs==2.5.0
     # via -r tests/requirements-relaxed.in
 antsibull-docs-parser==1.0.0
     # via antsibull-docs

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -20,7 +20,7 @@ ansible-pygments==0.1.1
     #   sphinx-ansible-theme
 antsibull-core==2.1.0
     # via antsibull-docs
-antsibull-docs==2.4.0
+antsibull-docs==2.5.0
     # via
     #   -c tests/constraints.in
     #   -r tests/requirements-relaxed.in


### PR DESCRIPTION
The 2.5.0 release uses correct URLs for the new Ansible Galaxy codebase.

Compare the "community.general collection" link at the top of the info box between these two links:
- https://ansible.fontein.de/collections/community/general/ufw_module.html
- https://docs.ansible.com/ansible/devel/collections/community/general/ufw_module.html