### PR TITLE
Fix for Replace for instance with for example #461

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules.rst
@@ -25,7 +25,7 @@ The functionality you want may be too large for a single module. If you want to 
 
 * Each module should have a concise and well defined functionality. Basically, follow the UNIX philosophy of doing one thing well.
 
-* A module should not require that a user know all the underlying options of an API/tool to be used. For instance, if the legal values for a required module parameter cannot be documented, that's a sign that the module would be rejected.
+* A module should not require that a user know all the underlying options of an API/tool to be used. For example, if the legal values for a required module parameter cannot be documented, that's a sign that the module would be rejected.
 
 * Modules should typically encompass much of the logic for interacting with a resource. A lightweight wrapper around an API that does not contain much logic would likely cause users to offload too much logic into a playbook, and for this reason the module would be rejected. Instead try creating multiple modules for interacting with smaller individual pieces of the API.
 

--- a/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
@@ -17,7 +17,7 @@ Especially if you want to contribute your module(s) to an existing Ansible Colle
 
 * Each module should have a concise and well-defined functionality. Basically, follow the UNIX philosophy of doing one thing well.
 * Do not add ``get``, ``list`` or ``info`` state options to an existing module - create a new ``_info`` or ``_facts`` module.
-* Modules should not require that a user know all the underlying options of an API/tool to be used. For instance, if the legal values for a required module option cannot be documented, the module does not belong in Ansible Core.
+* Modules should not require that a user know all the underlying options of an API/tool to be used. For example, if the legal values for a required module option cannot be documented, the module does not belong in Ansible Core.
 * Modules should encompass much of the logic for interacting with a resource. A lightweight wrapper around a complex API forces users to offload too much logic into their playbooks. If you want to connect Ansible to a complex API, :ref:`create multiple modules <developing_modules_in_groups>` that interact with smaller individual pieces of the API.
 * Avoid creating a module that does the work of other modules; this leads to code duplication and divergence, and makes things less uniform, unpredictable and harder to maintain. Modules should be the building blocks. If you are asking 'how can I have a module execute other modules' ... you want to write a role.
 

--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -51,7 +51,7 @@ After the shebang and UTF-8 coding, add a `copyright line <https://www.linuxfoun
     # Copyright: Contributors to the Ansible project
     # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-Additions to the module (for instance, rewrites) are not permitted to add additional copyright lines other than the default copyright statement if missing:
+Additions to the module (for example, rewrites) are not permitted to add additional copyright lines other than the default copyright statement if missing:
 
 .. code-block:: python
 

--- a/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
@@ -200,7 +200,7 @@ the managed machine.
   remote host, although the :ref:`module_common <flow_executor_module_common>`
   code described in the next section decides which format
   those will take.
-* It handles any special cases regarding modules (for instance, async
+* It handles any special cases regarding modules (for example, async
   execution, or complications around Windows modules that must have the same names as Python modules, so that internal calling of modules from other Action Plugins work.)
 
 Much of this functionality comes from the `BaseAction` class,

--- a/docs/docsite/rst/dev_guide/developing_python_3.rst
+++ b/docs/docsite/rst/dev_guide/developing_python_3.rst
@@ -280,7 +280,7 @@ Prefix byte strings with ``b_``
 
 Since mixing text and bytes types leads to tracebacks we want to be clear
 about what variables hold text and what variables hold bytes.  We do this by
-prefixing any variable holding bytes with ``b_``.  For instance:
+prefixing any variable holding bytes with ``b_``.  For example:
 
 .. code-block:: python
 

--- a/docs/docsite/rst/dev_guide/style_guide/spelling_word_choice.rst
+++ b/docs/docsite/rst/dev_guide/style_guide/spelling_word_choice.rst
@@ -303,7 +303,7 @@ Use the pronoun "who" as a subject. Use the pronoun "whom" as a direct object, a
 
 Will
 ^^^^
-Do not use future tense unless it is absolutely necessary. For instance, do not use the sentence, "The next section will describe the process in more detail." Instead, use the sentence, "The next section describes the process in more detail."
+Do not use future tense unless it is absolutely necessary. For example, do not use the sentence, "The next section will describe the process in more detail." Instead, use the sentence, "The next section describes the process in more detail."
 
 Wish
 ^^^^

--- a/docs/docsite/rst/galaxy/dev_guide.rst
+++ b/docs/docsite/rst/galaxy/dev_guide.rst
@@ -66,7 +66,7 @@ Container enabled
 -----------------
 
 If you are creating a Container Enabled role, pass ``--type container`` to ``ansible-galaxy init``. This will create the same directory structure as above, but populate it
-with default files appropriate for a Container Enabled role. For instance, the README.md has a slightly different structure, the *.travis.yml* file tests
+with default files appropriate for a Container Enabled role. For example, the README.md has a slightly different structure, the *.travis.yml* file tests
 the role using `Ansible Container <https://github.com/ansible/ansible-container>`_, and the meta directory includes a *container.yml* file.
 
 Using a custom role skeleton

--- a/docs/docsite/rst/inventory_guide/intro_inventory.rst
+++ b/docs/docsite/rst/inventory_guide/intro_inventory.rst
@@ -737,7 +737,7 @@ Example: One inventory per environment
 
 If you need to manage multiple environments it's sometimes prudent to
 have only hosts of a single environment defined per inventory. This
-way, it is harder to, for instance, accidentally change the state of
+way, it is harder to, for example, accidentally change the state of
 nodes inside the "test" environment when you actually wanted to update
 some "staging" servers.
 
@@ -785,7 +785,7 @@ Example: Group by function
 
 In the previous section you already saw an example for using groups in
 order to cluster hosts that have the same function. This allows you,
-for instance, to define firewall rules inside a playbook or role
+for example, to define firewall rules inside a playbook or role
 affecting only database servers:
 
 .. code-block:: yaml

--- a/docs/docsite/rst/network/user_guide/network_working_with_command_output.rst
+++ b/docs/docsite/rst/network/user_guide/network_working_with_command_output.rst
@@ -47,7 +47,7 @@ until either the condition is satisfied or the number of retries has
 expired (by default, this is 10 retries at 1 second intervals).
 
 The commands module can also evaluate more than one set of command
-results in an interface.  For instance:
+results in an interface.  For example:
 
 .. code-block:: yaml
 

--- a/docs/docsite/rst/playbook_guide/guide_rolling_upgrade.rst
+++ b/docs/docsite/rst/playbook_guide/guide_rolling_upgrade.rst
@@ -257,7 +257,7 @@ The ``pre_tasks`` keyword just lets you list tasks to run before the roles are c
 
 The ``delegate_to`` and ``loop`` arguments, used together, cause Ansible to loop over each monitoring server and load balancer, and perform that operation (delegate that operation) on the monitoring or load balancing server, "on behalf" of the webserver. In programming terms, the outer loop is the list of web servers, and the inner loop is the list of monitoring servers.
 
-Note that the HAProxy step looks a little complicated.  We're using HAProxy in this example because it's freely available, though if you have (for instance) an F5 or Netscaler in your infrastructure (or maybe you have an AWS Elastic IP setup?), you can use Ansible modules  to communicate with them instead.  You might also wish to use other monitoring modules instead of nagios, but this just shows the main goal of the 'pre tasks' section -- take the server out of monitoring, and take it out of rotation.
+Note that the HAProxy step looks a little complicated.  We're using HAProxy in this example because it's freely available, though if you have (for example) an F5 or Netscaler in your infrastructure (or maybe you have an AWS Elastic IP setup?), you can use Ansible modules  to communicate with them instead.  You might also wish to use other monitoring modules instead of nagios, but this just shows the main goal of the 'pre tasks' section -- take the server out of monitoring, and take it out of rotation.
 
 The next step simply re-applies the proper roles to the web servers. This will cause any configuration management declarations in ``web`` and ``base-apache`` roles to be applied to the web servers, including an update of the web application code itself. We don't have to do it this way--we could instead just purely update the web application, but this is a good example of how roles can be used to reuse tasks:
 
@@ -308,7 +308,7 @@ Depending on your environment, you might be deploying continuously to a test env
 
 For integration with Continuous Integration systems, you can easily trigger playbook runs using the ``ansible-playbook`` command line tool, or, if you're using AWX, the ``tower-cli`` command or the built-in REST API.  (The tower-cli command 'joblaunch' will spawn a remote job over the REST API and is pretty slick).
 
-This should give you a good idea of how to structure a multi-tier application with Ansible, and orchestrate operations upon that app, with the eventual goal of continuous delivery to your customers. You could extend the idea of the rolling upgrade to lots of different parts of the app; maybe add front-end web servers along with application servers, for instance, or replace the SQL database with something like MongoDB or Riak. Ansible gives you the capability to easily manage complicated environments and automate common operations.
+This should give you a good idea of how to structure a multi-tier application with Ansible, and orchestrate operations upon that app, with the eventual goal of continuous delivery to your customers. You could extend the idea of the rolling upgrade to lots of different parts of the app; maybe add front-end web servers along with application servers, for example, or replace the SQL database with something like MongoDB or Riak. Ansible gives you the capability to easily manage complicated environments and automate common operations.
 
 .. seealso::
 

--- a/docs/docsite/rst/playbook_guide/playbooks_prompts.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_prompts.rst
@@ -48,7 +48,7 @@ If you have a variable that changes infrequently, you can provide a default valu
 Hashing values supplied by ``vars_prompt``
 ------------------------------------------
 
-You can hash the entered value so you can use it, for instance, with the user module to define a password:
+You can hash the entered value so you can use it, for example, with the user module to define a password:
 
 .. code-block:: yaml
 

--- a/docs/docsite/rst/playbook_guide/playbooks_reuse.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_reuse.rst
@@ -153,7 +153,7 @@ Each approach to re-using distributed Ansible artifacts has advantages and limit
 Re-using tasks as handlers
 ==========================
 
-You can also use includes and imports in the :ref:`handlers` section of a playbook. For instance, if you want to define how to restart Apache, you only have to do that once for all of your playbooks. You might make a ``restarts.yml`` file that looks like:
+You can also use includes and imports in the :ref:`handlers` section of a playbook. For example, if you want to define how to restart Apache, you only have to do that once for all of your playbooks. You might make a ``restarts.yml`` file that looks like:
 
 .. code-block:: yaml
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
@@ -56,7 +56,7 @@ Noteworthy module changes
 * The :ref:`file_module` now emits a deprecation warning when ``src`` is specified with a state
   other than ``hard`` or ``link`` as it is only supposed to be useful with those.  This could have
   an effect on people who were depending on a buggy interaction between src and other state's to
-  place files into a subdirectory.  For instance::
+  place files into a subdirectory.  For example::
 
     $ ansible localhost -m file -a 'path=/var/lib src=/tmp/ state=directory'
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
@@ -39,9 +39,9 @@ or greater to manage those hosts from.
 One thing that this does affect is the ability to use :command:`/usr/bin/ansible-pull` to manage
 a host which has Python-2.6.  ``ansible-pull`` runs on the host being managed but it is a controller
 script, not a module so it will need an updated Python.  Actively developed Linux distros which ship
-with Python-2.6 have some means to install newer Python versions (For instance, you can install
+with Python-2.6 have some means to install newer Python versions (For example, you can install
 Python-2.7 through an SCL on RHEL-6) but you may need to also install Python bindings for many common
-modules to work (For RHEL-6, for instance, selinux bindings and yum would have to be installed for
+modules to work (For RHEL-6, for example, selinux bindings and yum would have to be installed for
 the updated Python install).
 
 The decision to drop Python-2.6 support on the controller was made because many dependent libraries
@@ -108,7 +108,7 @@ Expedited Deprecation: Use of ``__file__`` in ``AnsibleModule``
 
 .. note:: The use of the ``__file__`` variable is deprecated in Ansible 2.7 and **will be eliminated in Ansible 2.8**. This is much quicker than our usual 4-release deprecation cycle.
 
-We are deprecating the use of the ``__file__`` variable to refer to the file containing the currently-running code. This common Python technique for finding a filesystem path does not always work (even in vanilla Python). Sometimes a Python module can be imported from a virtual location (like inside of a zip file). When this happens, the ``__file__`` variable will reference a virtual location pointing to inside of the zip file. This can cause problems if, for instance, the code was trying to use ``__file__`` to find the directory containing the python module to write some temporary information.
+We are deprecating the use of the ``__file__`` variable to refer to the file containing the currently-running code. This common Python technique for finding a filesystem path does not always work (even in vanilla Python). Sometimes a Python module can be imported from a virtual location (like inside of a zip file). When this happens, the ``__file__`` variable will reference a virtual location pointing to inside of the zip file. This can cause problems if, for example, the code was trying to use ``__file__`` to find the directory containing the python module to write some temporary information.
 
 Before the introduction of AnsiBallZ in Ansible 2.1, using ``__file__`` worked in ``AnsibleModule`` sometimes, but any module that used it would fail when pipelining was turned on (because the module would be piped into the python interpreter's standard input, so ``__file__`` wouldn't contain a file path). AnsiBallZ unintentionally made using ``__file__`` work, by always creating a temporary file for ``AnsibleModule`` to reside in.
 

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -62,7 +62,7 @@ How do I handle different machines needing different user accounts or ports to l
 
 Setting inventory variables in the inventory file is the easiest way.
 
-For instance, suppose these hosts have different usernames and ports:
+For example, suppose these hosts have different usernames and ports:
 
 .. code-block:: ini
 
@@ -225,7 +225,7 @@ If you want to run under Python 3 instead of Python 2 you may want to change tha
     $ source ./ansible/bin/activate
     $ pip install ansible
 
-If you need to use any libraries which are not available through pip (for instance, SELinux Python
+If you need to use any libraries which are not available through pip (for example, SELinux Python
 bindings on systems such as Red Hat Enterprise Linux or Fedora that have SELinux enabled), then you
 need to install them into the virtualenv. There are two methods:
 
@@ -236,7 +236,7 @@ need to install them into the virtualenv. There are two methods:
 
       $ virtualenv ansible --system-site-packages
 
-* Copy those files in manually from the system. For instance, for SELinux bindings you might do:
+* Copy those files in manually from the system. For example, for SELinux bindings you might do:
 
   .. code-block:: shell
 
@@ -461,7 +461,7 @@ file with a list of servers. To do this, you can just access the "$groups" dicti
         {{ host }}
     {% endfor %}
 
-If you need to access facts about these hosts, for instance, the IP address of each hostname,
+If you need to access facts about these hosts, for example, the IP address of each hostname,
 you need to make sure that the facts have been populated. For example, make sure you have a play that talks to db_servers:
 
 .. code-block:: yaml

--- a/docs/docsite/rst/reference_appendices/glossary.rst
+++ b/docs/docsite/rst/reference_appendices/glossary.rst
@@ -161,7 +161,7 @@ when a term comes up on the mailing list.
     Globbing
         Globbing is a way to select lots of hosts based on wildcards, rather
         than the name of the host specifically, or the name of the group they
-        are in.  For instance, it is possible to select ``ww*`` to match all
+        are in.  For example, it is possible to select ``ww*`` to match all
         hosts starting with ``www``.   This concept is pulled directly from
         :program:`Func`, one of Michael DeHaan's (an Ansible Founder) earlier
         projects.  In addition to basic globbing, various set operations are
@@ -225,7 +225,7 @@ when a term comes up on the mailing list.
         more than lists of :term:`plays`) can include other lists of plays,
         and task lists can externalize lists of :term:`tasks` in other files,
         and similarly with :term:`handlers`.  Includes can be parameterized,
-        which means that the loaded file can pass variables.  For instance, an
+        which means that the loaded file can pass variables.  For example, an
         included play for setting up a WordPress blog may take a parameter
         called ``user`` and that play could be included more than once to
         create a blog for both ``alice`` and ``bob``.
@@ -273,7 +273,7 @@ when a term comes up on the mailing list.
     Limit Groups
         By passing ``--limit somegroup`` to :command:`ansible` or
         :command:`ansible-playbook`, the commands can be limited to a subset
-        of :term:`hosts <Host>`.  For instance, this can be used to run
+        of :term:`hosts <Host>`.  For example, this can be used to run
         a :term:`playbook <playbooks>` that normally targets an entire set of
         servers to one particular server.
 
@@ -322,7 +322,7 @@ when a term comes up on the mailing list.
     Multi-Tier
         The concept that IT systems are not managed one system at a time, but
         by interactions between multiple systems and groups of systems in
-        well defined orders.  For instance, a web server may need to be
+        well defined orders.  For example, a web server may need to be
         updated before a database server and pieces on the web server may
         need to be updated after *THAT* database server and various load
         balancers and monitoring servers may need to be contacted.  Ansible
@@ -409,7 +409,7 @@ when a term comes up on the mailing list.
         infinite number of variable names you can use for registration.
 
     Resource Model
-        Ansible modules work in terms of resources.   For instance, the
+        Ansible modules work in terms of resources.   For example, the
         :ref:`file module <file_module>` will select a particular file and ensure
         that the attributes of that resource match a particular model. As an
         example, we might wish to change the owner of :file:`/etc/motd` to
@@ -473,7 +473,7 @@ when a term comes up on the mailing list.
     Tags
         Ansible allows tagging resources in a :term:`playbook <playbooks>`
         with arbitrary keywords, and then running only the parts of the
-        playbook that correspond to those keywords.  For instance, it is
+        playbook that correspond to those keywords.  For example, it is
         possible to have an entire OS configuration, and have certain steps
         labeled ``ntp``, and then run just the ``ntp`` steps to reconfigure
         the time server information on a remote host.

--- a/docs/docsite/rst/scenario_guides/guide_aci.rst
+++ b/docs/docsite/rst/scenario_guides/guide_aci.rst
@@ -51,7 +51,7 @@ Using the ACI modules
 ---------------------
 The Ansible ACI modules provide a user-friendly interface to managing your ACI environment using Ansible playbooks.
 
-For instance ensuring that a specific tenant exists, is done using the following Ansible task using the aci_tenant module:
+For example ensuring that a specific tenant exists, is done using the following Ansible task using the aci_tenant module:
 
 .. code-block:: yaml
 
@@ -457,7 +457,7 @@ The aci_rest module accepts the native XML and JSON payloads, but additionally a
 
 When you're making modifications, you can use the POST or DELETE methods, whereas doing just queries require the GET method.
 
-For instance, if you would like to ensure a specific tenant exists on ACI, these below four examples are functionally identical:
+For example, if you would like to ensure a specific tenant exists on ACI, these below four examples are functionally identical:
 
 **XML** (Native ACI REST)
 

--- a/docs/docsite/rst/scenario_guides/vmware_rest_scenarios/vm_info.rst
+++ b/docs/docsite/rst/scenario_guides/vmware_rest_scenarios/vm_info.rst
@@ -69,7 +69,7 @@ ______
 List the SCSI adapter(s) of a specific VM
 _________________________________________
 
-Here for instance, we list the SCSI adapter(s) of the VM:
+Here for example, we list the SCSI adapter(s) of the VM:
 
 .. literalinclude:: task_outputs/List_the_SCSI_adapter_of_a_given_VM.task.yaml
 

--- a/docs/docsite/rst/tips_tricks/sample_setup.rst
+++ b/docs/docsite/rst/tips_tricks/sample_setup.rst
@@ -88,7 +88,7 @@ This layout gives you more flexibility for larger environments, as well as a tot
 Sample group and host variables
 -------------------------------
 
-These sample group and host files with variables contain the values that apply to each machine or a group of machines. For instance, the data center in Atlanta has its own NTP servers. As a result, when setting up the ``ntp.conf`` file, you could use similar code as in this example:
+These sample group and host files with variables contain the values that apply to each machine or a group of machines. For example, the data center in Atlanta has its own NTP servers. As a result, when setting up the ``ntp.conf`` file, you could use similar code as in this example:
 
   .. code-block:: yaml
 


### PR DESCRIPTION
- **Issue** : Replace for instance with for example #461
- **Files updated:**
ansible-documentation\docs\docsite\rst\dev_guide\developing_modules.rst
ansible-documentation\docs\docsite\rst\dev_guide\developing_modules_best_practices.rst
ansible-documentation\docs\docsite\rst\dev_guide\developing_modules_documenting.rst
ansible-documentation\docs\docsite\rst\dev_guide\developing_program_flow_modules.rst
ansible-documentation\docs\docsite\rst\dev_guide\developing_python_3.rst 
ansible-documentation\docs\docsite\rst\dev_guide\style_guide\spelling_word_choice.rst
ansible-documentation\docs\docsite\rst\galaxy\dev_guide.rst 
ansible-documentation\docs\docsite\rst\inventory_guide\intro_inventory.rst 
ansible-documentation\docs\docsite\rst\network\user_guide\network_working_with_command_output.rst 
ansible-documentation\docs\docsite\rst\playbook_guide\guide_rolling_upgrade.rst 
ansible-documentation\docs\docsite\rst\playbook_guide\playbooks_prompts.rst 
ansible-documentation\docs\docsite\rst\playbook_guide\playbooks_reuse.rst 
ansible-documentation\docs\docsite\rst\porting_guides\porting_guide_2.6.rst 
ansible-documentation\docs\docsite\rst\porting_guides\porting_guide_2.7.rst 
ansible-documentation\docs\docsite\rst\reference_appendices\faq.rst 
ansible-documentation\docs\docsite\rst\reference_appendices\glossary.rst 
ansible-documentation\docs\docsite\rst\scenario_guides\guide_aci.rst 
ansible-documentation\docs\docsite\rst\scenario_guides\vmware_rest_scenarios\vm_info.rst 
ansible-documentation\docs\docsite\rst\tips_tricks\sample_setup.rst 