### PR TITLE
[2.14] bump antsibull-docs to 2.5

### DIFF
--- a/tests/constraints.in
+++ b/tests/constraints.in
@@ -2,4 +2,4 @@
 resolvelib < 0.9.0
 sphinx == 4.2.0
 rstcheck < 4  # match version used in other sanity tests
-antsibull-docs == 2.4.0  # currently approved version
+antsibull-docs == 2.5.0  # currently approved version

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -20,7 +20,7 @@ ansible-pygments==0.1.1
     #   sphinx-ansible-theme
 antsibull-core==2.1.0
     # via antsibull-docs
-antsibull-docs==2.4.0
+antsibull-docs==2.5.0
     # via
     #   -c constraints.in
     #   -r requirements.in


### PR DESCRIPTION
Similar to https://github.com/ansible/ansible-documentation/pull/480 but for stable-2.14