### PR TITLE
pr_labeler: add warning for porting_guides changes

### DIFF
--- a/hacking/pr_labeler/data/porting_guide_changes.md
+++ b/hacking/pr_labeler/data/porting_guide_changes.md
@@ -1,8 +1,8 @@
-The following files are automatically generated and should not be modified outside of the ansible release process:
+The following files are automatically generated and should not be modified outside of the Ansible release process:
 
 {% for file in changed_files %}
 - {{ file }}
 {% endfor %}
 
-Please double check your changes.
+Please double-check your changes.
 <!--- boilerplate: porting_guide_changes --->

--- a/hacking/pr_labeler/data/porting_guide_changes.md
+++ b/hacking/pr_labeler/data/porting_guide_changes.md
@@ -1,0 +1,8 @@
+The following files are automatically generated and should not be modified outside of the ansible release process:
+
+{% for file in changed_files %}
+- {{ file }}
+{% endfor %}
+
+Please double check your changes.
+<!--- boilerplate: porting_guide_changes --->

--- a/hacking/pr_labeler/label.py
+++ b/hacking/pr_labeler/label.py
@@ -246,6 +246,7 @@ def process_pr(
     pr_number: int,
     dry_run: bool = False,
     authed_dry_run: bool = False,
+    force_process_closed: bool = False,
 ) -> None:
     global_args = click_ctx.ensure_object(GlobalArgs)
 
@@ -266,7 +267,7 @@ def process_pr(
         event_info=get_event_info(),
         issue=pr.as_issue(),
     )
-    if pr.state != "open":
+    if not force_process_closed and pr.state != "open":
         log(ctx, "Refusing to process closed ticket")
         return
 
@@ -282,6 +283,7 @@ def process_issue(
     issue_number: int,
     dry_run: bool = False,
     authed_dry_run: bool = False,
+    force_process_closed: bool = False,
 ) -> None:
     global_args = click_ctx.ensure_object(GlobalArgs)
 
@@ -300,7 +302,7 @@ def process_issue(
         dry_run=dry_run,
         event_info=get_event_info(),
     )
-    if issue.state != "open":
+    if not force_process_closed and issue.state != "open":
         log(ctx, "Refusing to process closed ticket")
         return
 

--- a/hacking/pr_labeler/label.py
+++ b/hacking/pr_labeler/label.py
@@ -243,8 +243,13 @@ def no_body_nag(ctx: IssueOrPrCtx) -> None:
 
 def warn_porting_guide_change(ctx: PRLabelerCtx) -> None:
     """
-    Complain if a user outside of the Release Management WG changes porting_guide
+    Complain if a non-bot user outside of the Release Management WG changes
+    porting_guide
     """
+    user = ctx.pr.user.login
+    if user.endswith("[bot]"):
+        return
+
     # If the API token does not have permisisons to view teams in the ansible
     # org, fall back to an empty list.
     members = []
@@ -252,7 +257,7 @@ def warn_porting_guide_change(ctx: PRLabelerCtx) -> None:
         members = get_team_members(ctx, "release-management-wg")
     except github.UnknownObjectException:
         log(ctx, "Failed to get members of @ansible/release-management-wg")
-    if ctx.pr.user.login in members:
+    if user in members:
         return
 
     matches: list[str] = []

--- a/hacking/pr_labeler/label.py
+++ b/hacking/pr_labeler/label.py
@@ -166,7 +166,10 @@ def create_boilerplate_comment(ctx: IssueOrPrCtx, name: str, **kwargs) -> None:
         if comment.body.splitlines()[-1] == last:
             log(ctx, name, "boilerplate was already commented")
             return
-    log(ctx, "Templating", name, "boilerplate")
+    msg = f"Templating {name} boilerplate"
+    if kwargs:
+        msg += f" with {kwargs}"
+    log(ctx, msg)
     create_comment(ctx, tmpl)
 
 


### PR DESCRIPTION
This adds a warning message when PRs are created that edit
porting_guides by someone outside of the Release Management WG. These
files are automatically generated during the ansible release process and
should not be modified.

Fixes: https://github.com/ansible/ansible-documentation/issues/503