### PR TITLE
Update sanity test docs for devel

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/ansible-test-future-boilerplate.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/ansible-test-future-boilerplate.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 ansible-test-future-boilerplate
 ===============================
 

--- a/docs/docsite/rst/dev_guide/testing/sanity/boilerplate.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/boilerplate.rst
@@ -1,11 +1,8 @@
-:orphan:
-
 boilerplate
 ===========
 
-Most Python files should include the following boilerplate:
+Python files should include the following boilerplate:
 
 .. code-block:: python
 
-    from __future__ import (absolute_import, division, print_function)
-    __metaclass__ = type
+    from __future__ import annotations

--- a/docs/docsite/rst/dev_guide/testing/sanity/future-import-boilerplate.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/future-import-boilerplate.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 future-import-boilerplate
 =========================
 

--- a/docs/docsite/rst/dev_guide/testing/sanity/index.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/index.rst
@@ -16,11 +16,9 @@ For information on how to run these tests, see :ref:`sanity testing guide <testi
    changelog
    compile
    empty-init
-   future-import-boilerplate
    ignores
    import
    line-endings
-   metaclass-boilerplate
    no-assert
    no-basestring
    no-dict-iteritems
@@ -50,8 +48,8 @@ Additional tests are available when testing Ansible Core:
    :maxdepth: 1
 
    ansible-requirements
-   ansible-test-future-boilerplate
    bin-symlinks
+   boilerplate
    integration-aliases
    mypy
    no-unwanted-files

--- a/docs/docsite/rst/dev_guide/testing/sanity/metaclass-boilerplate.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/metaclass-boilerplate.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 metaclass-boilerplate
 =====================
 


### PR DESCRIPTION
Orphaned obsolete sanity tests and added a new `boilerplate` test which reuses the name of a previously removed test.