### PR TITLE
Add Arch installation instructions in the installation_distros documentation

### DIFF
--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -163,7 +163,7 @@ standalone packages that users can install alongside ``ansible-core``.
 See the `Arch Linux Packages index <https://archlinux.org/packages/?sort=&q=ansible>`_
 for a full list of Ansible packages in Arch Linux.
 
-Please `open a bug <https://bugs.archlinux.org/>`_ to reach the package maintainers.
+Please `file a bug <https://bugs.archlinux.org/>`__ to reach the package maintainers.
 
 .. _from_windows:
 

--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -143,6 +143,28 @@ For more details, see `this AskUbuntu post <https://askubuntu.com/a/1307181>`_.
 Also note that, for security reasons, we do NOT add the key to ``/etc/apt/trusted.gpg.d/``
 nor to ``/etc/apt/trusted.gpg`` where it would be allowed to sign releases from ANY repository.
 
+Installing Ansible on Arch Linux
+--------------------------------
+
+To install the full ``ansible`` package run:
+
+.. code-block:: bash
+
+    $ sudo pacman -S ansible
+
+To install the minimal ``ansible-core`` package run:
+
+.. code-block:: bash
+
+    $ sudo pacman -S ansible-core
+
+Several Ansible ecosystem packages are also available from the Arch Linux repositories as
+standalone packages that users can install alongside ``ansible-core``.
+See the `Arch Linux Packages index <https://archlinux.org/packages/?sort=&q=ansible>`_
+for a full list of Ansible packages in Arch Linux.
+
+Please `file a bug <https://bugs.archlinux.org/>`_ to reach the package maintainers.
+
 .. _from_windows:
 
 Installing Ansible on Windows

--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -163,7 +163,7 @@ standalone packages that users can install alongside ``ansible-core``.
 See the `Arch Linux Packages index <https://archlinux.org/packages/?sort=&q=ansible>`_
 for a full list of Ansible packages in Arch Linux.
 
-Please `file a bug <https://bugs.archlinux.org/>`_ to reach the package maintainers.
+Please `open a bug <https://bugs.archlinux.org/>`_ to reach the package maintainers.
 
 .. _from_windows:
 

--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -168,7 +168,7 @@ Please `file a bug <https://bugs.archlinux.org/>`_ to reach the package maintain
 .. _from_windows:
 
 Installing Ansible on Windows
-------------------------------
+-----------------------------
 
 You cannot use a Windows system for the Ansible control node. See :ref:`windows_faq_ansible`
 


### PR DESCRIPTION
Hi,

As per this [forum post](https://forum.ansible.com/t/are-these-distro-install-instructions-still-correct/1412), this PR aims to add Ansible's installation instructions for Arch Linux to the documentation.

I also noticed an extra hyphen under the Windows instruction's title that I allowed myself to remove :)

I remain available if any changes are required!