### PR TITLE
communication.rst: Add a link to the forum group list

### DIFF
--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -19,6 +19,8 @@ Forum
 
 The `Ansible Community Forum <https://forum.ansible.com>`_ is a single starting point for questions and help, development discussions, events, and much more. `Register <https://forum.ansible.com/signup?>`_ to join the community. Search by categories and tags to find interesting topics or start a new one; subscribe only to topics you need!
 
+Take a look at the `forum groups <https://forum.ansible.com/g>`_ and join ones that match your interests. Many of the groups will automatically subscribe you to related posts.
+
 .. _communication_irc:
 
 Real-time chat

--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -20,7 +20,7 @@ Forum
 The `Ansible Community Forum <https://forum.ansible.com>`_ is a single starting point for questions and help, development discussions, events, and much more. `Register <https://forum.ansible.com/signup?>`_ to join the community. Search by categories and tags to find interesting topics or start a new one; subscribe only to topics you need!
 
 Take a look at the `forum groups <https://forum.ansible.com/g>`_ and join ones that match your interests.
-In most cases joining a forum group automatically subscribes you to related posts.
+In most cases, joining a forum group automatically subscribes you to related posts.
 
 .. _communication_irc:
 

--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -19,7 +19,8 @@ Forum
 
 The `Ansible Community Forum <https://forum.ansible.com>`_ is a single starting point for questions and help, development discussions, events, and much more. `Register <https://forum.ansible.com/signup?>`_ to join the community. Search by categories and tags to find interesting topics or start a new one; subscribe only to topics you need!
 
-Take a look at the `forum groups <https://forum.ansible.com/g>`_ and join ones that match your interests. Many of the groups will automatically subscribe you to related posts.
+Take a look at the `forum groups <https://forum.ansible.com/g>`_ and join ones that match your interests.
+In most cases joining a forum group automatically subscribes you to related posts.
 
 .. _communication_irc:
 


### PR DESCRIPTION
As per [suggestion](https://forum.ansible.com/t/teams-community-building-blocks/182/29) on the forum.