### PR TITLE
[2.16] Renamed "user name" to "username" in .rst files (#536)

### DIFF
--- a/docs/docsite/rst/community/collection_contributors/collection_integration_updating.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_integration_updating.rst
@@ -43,7 +43,7 @@ We will add the following code to the file.
 .. code-block:: yaml
 
   # https://github.com/ansible-collections/community.postgresql/issues/NUM
-  - name: Test user name containing underscore
+  - name: Test username containing underscore
     community.postgresql.postgresql_user:
       name: underscored_user
     register: result

--- a/docs/docsite/rst/dev_guide/style_guide/basic_rules.rst
+++ b/docs/docsite/rst/dev_guide/style_guide/basic_rules.rst
@@ -57,7 +57,7 @@ When documenting menus or commands, it helps to **bold** what is important.
 For menu procedures, bold the menu names, button names, and so on to help the user find them on the GUI:
 
 1. On the **File** menu, click **Open**.
-2. Type a name in the **User Name** field.
+2. Type a name in the **username** field.
 3. In the **Open** dialog box, click **Save**.
 4. On the toolbar, click the **Open File** icon.
 

--- a/docs/docsite/rst/getting_started_ee/run_execution_environment.rst
+++ b/docs/docsite/rst/getting_started_ee/run_execution_environment.rst
@@ -80,7 +80,7 @@ Before you start, ensure you have the following:
         var: ansible_facts
   EOF
 
-4. Run the playbook inside the ``postgresql_ee`` EE. Replace ``student`` with the appropriate user name.
+4. Run the playbook inside the ``postgresql_ee`` EE. Replace ``student`` with the appropriate username. Some arguments in the command can be optional depending on your target host authentication method.
 
 .. code-block:: bash
 

--- a/docs/docsite/rst/inventory_guide/connection_details.rst
+++ b/docs/docsite/rst/inventory_guide/connection_details.rst
@@ -16,7 +16,7 @@ By default, Ansible uses native OpenSSH, because it supports ControlPersist (a p
 Setting a remote user
 ---------------------
 
-By default, Ansible connects to all remote devices with the user name you are using on the control node. If that user name does not exist on a remote device, you can set a different user name for the connection. If you just need to do some tasks as a different user, look at :ref:`become`. You can set the connection user in a playbook:
+By default, Ansible connects to all remote devices with the username you are using on the control node. If that username does not exist on a remote device, you can set a different username for the connection. If you just need to do some tasks as a different user, look at :ref:`become`. You can set the connection user in a playbook:
 
 .. code-block:: yaml
 

--- a/docs/docsite/rst/inventory_guide/intro_dynamic_inventory.rst
+++ b/docs/docsite/rst/inventory_guide/intro_dynamic_inventory.rst
@@ -145,7 +145,7 @@ Source an OpenStack RC file:
 
 .. note::
 
-    An OpenStack RC file contains the environment variables required by the client tools to establish a connection with the cloud provider, such as the authentication URL, user name, password and region name. For more information on how to download, create or source an OpenStack RC file, please refer to `Set environment variables using the OpenStack RC file <https://docs.openstack.org/user-guide/common/cli_set_environment_variables_using_openstack_rc.html>`_.
+    An OpenStack RC file contains the environment variables required by the client tools to establish a connection with the cloud provider, such as the authentication URL, username, password and region name. For more information on how to download, create or source an OpenStack RC file, please refer to `Set environment variables using the OpenStack RC file <https://docs.openstack.org/user-guide/common/cli_set_environment_variables_using_openstack_rc.html>`_.
 
 You can confirm the file has been successfully sourced by running a simple command, such as `nova list` and ensuring it returns no errors.
 

--- a/docs/docsite/rst/inventory_guide/intro_inventory.rst
+++ b/docs/docsite/rst/inventory_guide/intro_inventory.rst
@@ -587,7 +587,7 @@ ansible_host
 ansible_port
     The connection port number, if not the default (22 for ssh)
 ansible_user
-    The user name to use when connecting to the host
+    The username to use when connecting to the host
 ansible_password
     The password to use to authenticate to the host (never store this variable in plain text; always use a vault. See :ref:`tip_for_variables_and_vaults`)
 
@@ -688,7 +688,7 @@ This connector deploys the playbook directly into Docker containers using the lo
 ansible_host
     The name of the Docker container to connect to.
 ansible_user
-    The user name to operate within the container. The user must exist inside the container.
+    The username to operate within the container. The user must exist inside the container.
 ansible_become
     If set to ``true`` the ``become_user`` will be used to operate within the container.
 ansible_docker_extra_args

--- a/docs/docsite/rst/network/getting_started/first_inventory.rst
+++ b/docs/docsite/rst/network/getting_started/first_inventory.rst
@@ -359,7 +359,7 @@ If you prefer to type your ansible-vault password rather than store it in a file
 
 and type in the vault password for ``my_user``.
 
-The :option:`--vault-id <ansible-playbook --vault-id>` flag allows different vault passwords for different users or different levels of access. The output includes the user name ``my_user`` from your ``ansible-vault`` command and uses the YAML syntax ``key: value``:
+The :option:`--vault-id <ansible-playbook --vault-id>` flag allows different vault passwords for different users or different levels of access. The output includes the username ``my_user`` from your ``ansible-vault`` command and uses the YAML syntax ``key: value``:
 
 .. code-block:: yaml
 

--- a/docs/docsite/rst/playbook_guide/playbooks_privilege_escalation.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_privilege_escalation.rst
@@ -422,7 +422,7 @@ task:
 
 .. code-block:: yaml
 
-    - Check my user name
+    - Check my username
       ansible.windows.win_whoami:
       become: true
 

--- a/docs/docsite/rst/plugins/connection.rst
+++ b/docs/docsite/rst/plugins/connection.rst
@@ -45,7 +45,7 @@ Plugins are self-documenting. Each plugin should document its configuration opti
 :ref:`ansible_port<faq_setting_users_and_ports>`
     The ssh port number, for :ref:`ssh <ssh_connection>` and :ref:`paramiko_ssh <paramiko_connection>` it defaults to 22.
 :ref:`ansible_user<faq_setting_users_and_ports>`
-    The default user name to use for log in. Most plugins default to the 'current user running Ansible'.
+    The default username to use for log in. Most plugins default to the 'current user running Ansible'.
 
 Each plugin might also have a specific version of a variable that overrides the general version. For example, ``ansible_ssh_host`` for the :ref:`ssh <ssh_connection>` plugin.
 

--- a/docs/docsite/rst/reference_appendices/logging.rst
+++ b/docs/docsite/rst/reference_appendices/logging.rst
@@ -11,4 +11,4 @@ By default Ansible sends output about plays, tasks, and module arguments to your
 Protecting sensitive data with ``no_log``
 =========================================
 
-If you save Ansible output to a log, you expose any secret data in your Ansible output, such as passwords and user names. To keep sensitive values out of your logs, mark tasks that expose them with the ``no_log: True`` attribute. However, the ``no_log`` attribute does not affect debugging output, so be careful not to debug playbooks in a production environment. See :ref:`keep_secret_data` for an example.
+If you save Ansible output to a log, you expose any secret data in your Ansible output, such as passwords and usernames. To keep sensitive values out of your logs, mark tasks that expose them with the ``no_log: True`` attribute. However, the ``no_log`` attribute does not affect debugging output, so be careful not to debug playbooks in a production environment. See :ref:`keep_secret_data` for an example.

--- a/docs/docsite/rst/scenario_guides/guide_aci.rst
+++ b/docs/docsite/rst/scenario_guides/guide_aci.rst
@@ -198,7 +198,7 @@ Every Ansible ACI module accepts the following parameters that influence the mod
         Port to use for communication. (Defaults to ``443`` for HTTPS, and ``80`` for HTTP)
 
     username
-        User name used to log on to the APIC. (Defaults to ``admin``)
+        username used to log on to the APIC. (Defaults to ``admin``)
 
     password
         Password for ``username`` to log on to the APIC, using password-based authentication.


### PR DESCRIPTION
* Renamed "user name" to "username" in .rst files
* Updated docs/docsite/rst/dev_guide/style_guide/spelling_word_choice.rst - renamed "username" back to "user name" in line 274

(cherry picked from commit ea6b9779762f7aa3bdcabaf0f3c655669c219242)