### PR TITLE
Refs #340: Swap old 'CLA' for the DCO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # How to Contribute
 
-This project is [GPL-3.0 licensed](COPYING) and accepts contributions via
+The ansible-documention project is [GPL-3.0 licensed](COPYING) and accepts contributions via
 GitHub pull requests.
 
 ## Certificate of Origin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# How to Contribute
+
+This project is [GPL-3.0 licensed](COPYING) and accepts contributions via
+GitHub pull requests.
+
+## Certificate of Origin
+
+By contributing to this project you agree to the Developer Certificate of
+Origin (DCO). This document was created by the Linux Kernel community and is a
+simple statement that you, as a contributor, have the legal right to make the
+contribution. See the [DCO](DCO) file for details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ GitHub pull requests.
 
 ## Certificate of Origin
 
-By contributing to this project you agree to the Developer Certificate of
+By contributing to ansible-documentation, you agree to the Developer Certificate of
 Origin (DCO). This document was created by the Linux Kernel community and is a
 simple statement that you, as a contributor, have the legal right to make the
 contribution. See the [DCO](DCO) file for details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # How to Contribute
 
-The ansible-documention project is [GPL-3.0 licensed](COPYING) and accepts contributions via
+The ansible-documention project is [GPL-3.0 licensed](COPYING) and accepts contributions through
 GitHub pull requests.
 
 ## Certificate of Origin

--- a/DCO
+++ b/DCO
@@ -1,0 +1,37 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -321,8 +321,8 @@ These guidelines are the policy for inclusion in the Ansible package and are in 
 licensing and legal concerns that may otherwise affect your code.
 
 
-Contributor License Agreements (CLAs) and the DCO
-=================================================
+Contributor License Agreements
+==============================
 
 Collections MUST NOT require community contributors to sign any type of
 contributor license agreement (CLA) other than the
@@ -332,9 +332,6 @@ This requirement seeks to preserve the community's ownership over its contributi
 prevent unwelcome licensing changes that can occur when one entity
 owns the copyrights for an entire project,
 and lower barriers to contribution.
-
-You can find an example of how to inform contributors of the DCO in the ``ansible-documentation`` repository, see the `CONTRIBUTING <https://github.com/ansible/ansible-documentation/blob/devel/CONTRIBUTING>`_ and `DCO <https://github.com/ansible/ansible-documentation/blob/devel/DCO>`_ files.
-
 
 .. _coll_repo_management:
 

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -321,8 +321,8 @@ These guidelines are the policy for inclusion in the Ansible package and are in 
 licensing and legal concerns that may otherwise affect your code.
 
 
-Contributor License Agreements
-==============================
+Contributor License Agreements (CLAs) and the DCO
+=================================================
 
 Collections MUST NOT require community contributors to sign any type of
 contributor license agreement (CLA) other than the
@@ -332,6 +332,8 @@ This requirement seeks to preserve the community's ownership over its contributi
 prevent unwelcome licensing changes that can occur when one entity
 owns the copyrights for an entire project,
 and lower barriers to contribution.
+
+You can find an example of how to inform contributors of the DCO in the ``ansible-documentation`` repository, see the `CONTRIBUTING <https://github.com/ansible/ansible-documentation/blob/devel/CONTRIBUTING>`_ and `DCO <https://github.com/ansible/ansible-documentation/blob/devel/DCO>`_ files.
 
 
 .. _coll_repo_management:

--- a/docs/docsite/rst/community/contributor_license_agreement.rst
+++ b/docs/docsite/rst/community/contributor_license_agreement.rst
@@ -1,7 +1,0 @@
-.. _contributor_license_agreement:
-
-******************************
-Contributors License Agreement
-******************************
-
-By contributing you agree that these contributions are your own (or approved by your employer) and you grant a full, complete, irrevocable copyright license to all users and developers of the project, present and future, pursuant to the license of the project.

--- a/docs/docsite/rst/community/developer_certificate_of_origin.rst
+++ b/docs/docsite/rst/community/developer_certificate_of_origin.rst
@@ -1,0 +1,11 @@
+.. _developer_certificate_of_origin:
+
+*******************************
+Developer Certificate Of Origin
+*******************************
+
+By contributing to this project you agree to the Developer Certificate of
+Origin (DCO). This document was created by the Linux Kernel community and is a
+simple statement that you, as a contributor, have the legal right to make the
+contribution. See the `DCO file <https://github.com/ansible-documentation/blob/devel/DCO>`_
+file for details.

--- a/docs/docsite/rst/community/getting_started.rst
+++ b/docs/docsite/rst/community/getting_started.rst
@@ -10,7 +10,7 @@ Welcome and thank you for getting more involved with the Ansible community. Here
    :maxdepth: 2
 
    code_of_conduct
-   contributor_license_agreement
+   developer_certificate_of_origin
    communication
    how_can_I_help
 

--- a/docs/docsite/rst/dev_guide/ansible_index.rst
+++ b/docs/docsite/rst/dev_guide/ansible_index.rst
@@ -59,7 +59,7 @@ Find the task that best describes what you want to do:
 
   * I want to :ref:`understand how to contribute to Ansible <ansible_community_guide>`.
   * I want to :ref:`contribute my module or plugin <developing_modules_checklist>`.
-  * I want to :ref:`understand the DCO agreement <developer_certificate_of_origin>` for contributions to Ansible.
+  * I want to :ref:`understand the DCO agreement <developer_certificate_of_origin>` for contributions to the `Ansible Core <https://github.com/ansible/ansible>`_ and `Ansible Documentation <https://github.com/ansible/ansible-documentation>`_ repositories.
 
 If you prefer to read the entire guide, here's a list of the pages in order.
 

--- a/docs/docsite/rst/dev_guide/ansible_index.rst
+++ b/docs/docsite/rst/dev_guide/ansible_index.rst
@@ -59,7 +59,7 @@ Find the task that best describes what you want to do:
 
   * I want to :ref:`understand how to contribute to Ansible <ansible_community_guide>`.
   * I want to :ref:`contribute my module or plugin <developing_modules_checklist>`.
-  * I want to :ref:`understand the license agreement <contributor_license_agreement>` for contributions to Ansible.
+  * I want to :ref:`understand the DCO agreement <developer_certificate_of_origin>` for contributions to Ansible.
 
 If you prefer to read the entire guide, here's a list of the pages in order.
 

--- a/docs/docsite/rst/dev_guide/core_index.rst
+++ b/docs/docsite/rst/dev_guide/core_index.rst
@@ -56,7 +56,7 @@ Find the task that best describes what you want to do:
 
   * I want to :ref:`understand how to contribute to Ansible <ansible_community_guide>`.
   * I want to :ref:`contribute my module or plugin <developing_modules_checklist>`.
-  * I want to :ref:`understand the DCO agreement <developer_certificate_of_origin>` for contributions to the `Ansible Core <https://github.com/ansible/ansible>`_ and `Ansible Documention <https://github.com/ansible/ansible-documentation>`_ repositories.
+  * I want to :ref:`understand the DCO agreement <developer_certificate_of_origin>` for contributions to the `Ansible Core <https://github.com/ansible/ansible>`_ and `Ansible Documentation <https://github.com/ansible/ansible-documentation>`_ repositories.
 
 If you prefer to read the entire guide, here's a list of the pages in order.
 

--- a/docs/docsite/rst/dev_guide/core_index.rst
+++ b/docs/docsite/rst/dev_guide/core_index.rst
@@ -56,7 +56,7 @@ Find the task that best describes what you want to do:
 
   * I want to :ref:`understand how to contribute to Ansible <ansible_community_guide>`.
   * I want to :ref:`contribute my module or plugin <developing_modules_checklist>`.
-  * I want to :ref:`understand the DCO agreement <developer_certificate_of_origin>` for contributions to Ansible.
+  * I want to :ref:`understand the DCO agreement <developer_certificate_of_origin>` for contributions to the `Ansible Core <https://github.com/ansible/ansible>`_ and `Ansible Documention <https://github.com/ansible/ansible-documentation>`_ repositories.
 
 If you prefer to read the entire guide, here's a list of the pages in order.
 

--- a/docs/docsite/rst/dev_guide/core_index.rst
+++ b/docs/docsite/rst/dev_guide/core_index.rst
@@ -56,7 +56,7 @@ Find the task that best describes what you want to do:
 
   * I want to :ref:`understand how to contribute to Ansible <ansible_community_guide>`.
   * I want to :ref:`contribute my module or plugin <developing_modules_checklist>`.
-  * I want to :ref:`understand the license agreement <contributor_license_agreement>` for contributions to Ansible.
+  * I want to :ref:`understand the DCO agreement <developer_certificate_of_origin>` for contributions to Ansible.
 
 If you prefer to read the entire guide, here's a list of the pages in order.
 

--- a/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
@@ -20,7 +20,7 @@ To contribute a module to most Ansible collections, you must:
 * use proper :ref:`Python 3 syntax <developing_python_3>`
 * follow `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ Python style conventions - see :ref:`testing_pep8` for more information
 * license your module under the GPL license (GPLv3 or later)
-* understand the :ref:`DCO agreement <developer_certificate_of_origin>`, which applies to all contributions
+* understand the :ref:`DCO agreement <developer_certificate_of_origin>`, which applies to contributions to the `Ansible Core <https://github.com/ansible/ansible>`_ and `Ansible Documention <https://github.com/ansible/ansible-documentation>`_ repositories.
 * conform to Ansible's :ref:`formatting and documentation <developing_modules_documenting>` standards
 * include comprehensive :ref:`tests <developing_testing>` for your module
 * minimize module dependencies

--- a/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
@@ -20,7 +20,7 @@ To contribute a module to most Ansible collections, you must:
 * use proper :ref:`Python 3 syntax <developing_python_3>`
 * follow `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ Python style conventions - see :ref:`testing_pep8` for more information
 * license your module under the GPL license (GPLv3 or later)
-* understand the :ref:`license agreement <contributor_license_agreement>`, which applies to all contributions
+* understand the :ref:`DCO agreement <developer_certificate_of_origin>`, which applies to all contributions
 * conform to Ansible's :ref:`formatting and documentation <developing_modules_documenting>` standards
 * include comprehensive :ref:`tests <developing_testing>` for your module
 * minimize module dependencies

--- a/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
@@ -20,7 +20,7 @@ To contribute a module to most Ansible collections, you must:
 * use proper :ref:`Python 3 syntax <developing_python_3>`
 * follow `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ Python style conventions - see :ref:`testing_pep8` for more information
 * license your module under the GPL license (GPLv3 or later)
-* understand the :ref:`DCO agreement <developer_certificate_of_origin>`, which applies to contributions to the `Ansible Core <https://github.com/ansible/ansible>`_ and `Ansible Documention <https://github.com/ansible/ansible-documentation>`_ repositories.
+* understand the :ref:`DCO agreement <developer_certificate_of_origin>`, which applies to contributions to the `Ansible Core <https://github.com/ansible/ansible>`_ and `Ansible Documentation <https://github.com/ansible/ansible-documentation>`_ repositories.
 * conform to Ansible's :ref:`formatting and documentation <developing_modules_documenting>` standards
 * include comprehensive :ref:`tests <developing_testing>` for your module
 * minimize module dependencies


### PR DESCRIPTION
Per #340 this is the first part of the process to swap out the old CLA for the DCO. It:

- Adds the CONTRIBUTING and DCO files to the project root
  - this is the recommended way of informing people about the DCO
- removes the old CLA file
- replaces it with a new DCO doc that has the same content as CONTRIBUTING (and thus links to the DCO file in the root)
- Updates a couple of other files that mention the CLA to cover the DCO instead/as well

This is only the first part, we'll need the two root files (CONTRIBUTING & DCO) in other repos too.

I'm marking this as draft while we discuss if I missed anything :stuck_out_tongue: 