### PR TITLE
corrected cli for help

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/validate-modules.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/validate-modules.rst
@@ -20,7 +20,7 @@ Usage
 Help
 -----
 
-Type ``ansible-test sanity validate-modules -h`` to display help for using this sanity test.
+Type ``ansible-test sanity --test validate-modules -h`` to display help for using this sanity test.
 
 
 


### PR DESCRIPTION
This prevents an error, but it does not really matter as `-h`
will return generic help for ansible-test and not specific to  a test.

So running w/o `--test validate-modules` produces the same output,
keeping the full thing in case this changes in the future.