### PR TITLE
Use a working exponential backoff example

### DIFF
--- a/docs/docsite/rst/playbook_guide/complex_data_manipulation.rst
+++ b/docs/docsite/rst/playbook_guide/complex_data_manipulation.rst
@@ -27,15 +27,20 @@ Most programming languages have loops (``for``, ``while``, and so on) and list c
 
 .. _exponential_backoff:
 
-Use a loop to create exponential backoff for retries/until.
+Use a loop to create exponential backoff.
 
 .. code-block:: yaml
 
-    - name: retry ping 10 times with exponential backoff delay
-      ping:
-      retries: 10
-      delay: '{{item|int}}'
-      loop: '{{ range(1, 10)|map("pow", 2) }}'
+    - name: try wait_for_connection up to 10 times with exponential delay
+      ansible.builtin.wait_for_connection:
+        delay: '{{ item | int }}'
+        timeout: 1
+      loop: '{{ range(1, 11) | map("pow", 2) }}'
+      loop_control:
+        extended: true
+      ignore_errors: "{{ not ansible_loop.last }}"
+      register: result
+      when: result is not defined or result is failed
 
 
 .. _keys_from_dict_matching_list:


### PR DESCRIPTION
As pointed out in https://github.com/ansible/ansible/issues/81974#issuecomment-1762651823, the example in https://docs.ansible.com/ansible/latest/playbook_guide/complex_data_manipulation.html#loops-and-list-comprehensions of using exponential backoff with the `ping` module is broken.

My initial instinct was to just remove the broken example, but in context it appears that the point of it is to show how to use `map` with a filter. It's not possible to do exponential backoff with retries in a generic task, but we can demonstrate the same use of `map` and `pow` using an action that takes a delay.

Doing this in a reasonable way that would potentially be usable in a play does make the example quite complicated, so I'm still not sure it's worthwhile to keep. But I had already done the work to figure out a working example so here it is.