### PR TITLE
ci: use Github App token to authenticate

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -28,6 +28,7 @@ permissions:
 jobs:
   label_prs:
     runs-on: ubuntu-latest
+    environment: github-bot
     name: "Label Issue/PR"
     steps:
       - name: Print event information
@@ -35,6 +36,12 @@ jobs:
           event_json: "${{ toJSON(github.event) }}"
         run: |
           echo "${event_json}"
+      - name: Generate temp GITHUB_TOKEN
+        id: create_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.BOT_APP_ID }}
+          private_key: ${{ secrets.BOT_APP_KEY }}
       - name: Checkout parent repository
         uses: actions/checkout@v4
       - name: Install Python 3.11
@@ -56,6 +63,6 @@ jobs:
         if: "github.event.pull_request || inputs.type == 'pr'"
         env:
           event_json: "${{ toJSON(github.event) }}"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}
         run:
           ./venv/bin/python hacking/pr_labeler/label.py pr ${{ github.event.number || inputs.number }}

--- a/.github/workflows/pip-compile-dev.yml
+++ b/.github/workflows/pip-compile-dev.yml
@@ -23,10 +23,6 @@ name: "Refresh dev dependencies"
       - ".github/workflows/pip-compile-dev.yml"
       - "tests/*.in"
 
-permissions:
-  pull-requests: write
-  contents: write
-
 jobs:
   refresh:
     name: "Refresh dev dependencies"
@@ -41,3 +37,5 @@ jobs:
         'pip-compile-3.10(static)'
         'pip-compile-3.10(spelling)'
       reset-branch: "${{ inputs.reset-branch || false }}"
+    secrets: inherit
+    environment: github-bot

--- a/.github/workflows/pip-compile-docs.yml
+++ b/.github/workflows/pip-compile-docs.yml
@@ -23,10 +23,6 @@ name: "Refresh docs build dependencies"
       - ".github/workflows/pip-compile-docs.yml"
       - "tests/*.in"
 
-permissions:
-  pull-requests: write
-  contents: write
-
 jobs:
   refresh:
     name: "Refresh docs build dependencies"
@@ -37,3 +33,5 @@ jobs:
       pr-branch: "${{ inputs.pr-branch || 'pip-compile/devel/docs' }}"
       nox-args: "-e 'pip-compile-3.10(requirements)' 'pip-compile-3.10(requirements-relaxed)'"
       reset-branch: "${{ inputs.reset-branch || false }}"
+    secrets: inherit
+    environment: github-bot

--- a/.github/workflows/reusable-pip-compile.yml
+++ b/.github/workflows/reusable-pip-compile.yml
@@ -54,19 +54,23 @@ name: "Refresh pinned dependencies"
         type: boolean
         default: false
 
-permissions:
-  pull-requests: write
-  contents: write
-
 jobs:
   refresh:
     runs-on: ubuntu-latest
+    environment: github-bot
     steps:
+      - name: Generate temp GITHUB_TOKEN
+        id: create_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.BOT_APP_ID }}
+          private_key: ${{ secrets.BOT_APP_KEY }}
       - name: Check out repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: "${{ inputs.base-branch }}"
+          token: "${{ steps.create_token.outputs.token }}"
       - name: Fetch required contents of ansible-core
         run: |
           python docs/bin/clone-core.py
@@ -76,8 +80,7 @@ jobs:
           python-versions: "3.9"
       - name: Set up git committer
         run: |
-          git config user.name "Github Actions"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          hacking/get_bot_user.sh "ansible-documentation-bot" "Ansible Documentation Bot"
       - name: "Use a branch named ${{ inputs.pr-branch }}"
         id: branch
         run: |
@@ -99,7 +102,7 @@ jobs:
           nox ${{ inputs.nox-args }}
       - name: Push new dependency versions and create a PR
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}
         run: |
           set -x
           git diff || :

--- a/hacking/get_bot_user.sh
+++ b/hacking/get_bot_user.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/bash -x
+
+# Set Github committer to a bot user
+
+set -euo pipefail
+
+bot="${1}"
+name="${2-${1}}"
+path="https://api.github.com/users/${bot}%5Bbot%5D"
+user_id="$(curl -sS "${path}" | jq -r .id)"
+GIT="${GIT:-git}"
+
+${GIT} config user.name "${name}"
+${GIT} config user.email "${user_id}+${bot}@users.noreply.github.com"


### PR DESCRIPTION
This uses the new Ansible Documentation Bot Github app to authenticate with
the Github API instead of the limited token built in to Github Actions.
The app token allows creating automatic dependency update PRs that
trigger CI properly.
A github-bot environment to store the BOT_APP_ID and BOT_APP_KEY
secrets.

Fixes: https://github.com/ansible/ansible-documentation/issues/382

---

For now, I've marked this with `no_backport` so we can test it on devel for a
bit.
