### PR TITLE
ci pip-compile: remove environment key

### DIFF
--- a/.github/workflows/pip-compile-dev.yml
+++ b/.github/workflows/pip-compile-dev.yml
@@ -38,4 +38,3 @@ jobs:
         'pip-compile-3.10(spelling)'
       reset-branch: "${{ inputs.reset-branch || false }}"
     secrets: inherit
-    environment: github-bot

--- a/.github/workflows/pip-compile-docs.yml
+++ b/.github/workflows/pip-compile-docs.yml
@@ -34,4 +34,3 @@ jobs:
       nox-args: "-e 'pip-compile-3.10(requirements)' 'pip-compile-3.10(requirements-relaxed)'"
       reset-branch: "${{ inputs.reset-branch || false }}"
     secrets: inherit
-    environment: github-bot


### PR DESCRIPTION
We apparently need `secrets: inherit` in the caller but not `environment:`.
