### PR TITLE
[stable-2.16] Codespell ignore inv 2.16

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,5 @@
 [codespell]
-skip = _build,collections,*.po,_static,porting_guide*,style_guide
+skip = _build,collections,*.po,_static,porting_guide*,style_guide,*.inv
 count =
 check-filenames = true
 quiet-level = 3


### PR DESCRIPTION
We don't want to spell check these. We have removed the in-repo intersphinx inventories from devel, but they exist on older branches. There's no harm in also including the ignores on devel, and it makes sense to keep the configuration consistent.