### PR TITLE
ci pr_labeler: also use the app token for issues

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -21,10 +21,6 @@
 
 name: "Triage Issues and PRs"
 
-permissions:
-  issues: write
-  pull-requests: write
-
 jobs:
   label_prs:
     runs-on: ubuntu-latest
@@ -56,7 +52,7 @@ jobs:
         if: "github.event.issue || inputs.type == 'issue'"
         env:
           event_json: "${{ toJSON(github.event) }}"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}
         run:
           ./venv/bin/python hacking/pr_labeler/label.py issue ${{ github.event.issue.number || inputs.number }}
       - name: "Run the PR labeler"


### PR DESCRIPTION
`label.py pr` used the app token, but `label.py issue` still used the
old builtin GHA token. Oops!
