### PR TITLE
[stable-2.15] ci: use Github App token to authenticate

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -21,10 +21,6 @@
 
 name: "Triage Issues and PRs"
 
-permissions:
-  issues: write
-  pull-requests: write
-
 jobs:
   label_prs:
     runs-on: ubuntu-latest
@@ -56,7 +52,7 @@ jobs:
         if: "github.event.issue || inputs.type == 'issue'"
         env:
           event_json: "${{ toJSON(github.event) }}"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}
         run:
           ./venv/bin/python hacking/pr_labeler/label.py issue ${{ github.event.issue.number || inputs.number }}
       - name: "Run the PR labeler"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -28,6 +28,7 @@ permissions:
 jobs:
   label_prs:
     runs-on: ubuntu-latest
+    environment: github-bot
     name: "Label Issue/PR"
     steps:
       - name: Print event information
@@ -35,6 +36,12 @@ jobs:
           event_json: "${{ toJSON(github.event) }}"
         run: |
           echo "${event_json}"
+      - name: Generate temp GITHUB_TOKEN
+        id: create_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.BOT_APP_ID }}
+          private_key: ${{ secrets.BOT_APP_KEY }}
       - name: Checkout parent repository
         uses: actions/checkout@v4
       - name: Install Python 3.11
@@ -56,6 +63,6 @@ jobs:
         if: "github.event.pull_request || inputs.type == 'pr'"
         env:
           event_json: "${{ toJSON(github.event) }}"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}
         run:
           ./venv/bin/python hacking/pr_labeler/label.py pr ${{ github.event.number || inputs.number }}

--- a/hacking/get_bot_user.sh
+++ b/hacking/get_bot_user.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/bash -x
+
+# Set Github committer to a bot user
+
+set -euo pipefail
+
+bot="${1}"
+name="${2-${1}}"
+path="https://api.github.com/users/${bot}%5Bbot%5D"
+user_id="$(curl -sS "${path}" | jq -r .id)"
+GIT="${GIT:-git}"
+
+${GIT} config user.name "${name}"
+${GIT} config user.email "${user_id}+${bot}@users.noreply.github.com"

--- a/hacking/get_bot_user.sh
+++ b/hacking/get_bot_user.sh
@@ -11,4 +11,4 @@ user_id="$(curl -sS "${path}" | jq -r .id)"
 GIT="${GIT:-git}"
 
 ${GIT} config user.name "${name}"
-${GIT} config user.email "${user_id}+${bot}@users.noreply.github.com"
+${GIT} config user.email "${user_id}+${bot}[bot]@users.noreply.github.com"


### PR DESCRIPTION
This uses the new Ansible Documentation Bot Github app to authenticate with
the Github API instead of the limited token built in to Github Actions.
The app token allows creating automatic dependency update PRs that
trigger CI properly.
A github-bot environment to store the BOT_APP_ID and BOT_APP_KEY
secrets.

(cherry picked from commit https://github.com/ansible/ansible-documentation/commit/1efa06b8a68880f63fac0910d5171bfa8e7eeb2f)

Fixes: https://github.com/ansible/ansible-documentation/issues/382