### PR TITLE
pr_labeler: stop adding needs_triage labels to new PRs

### DIFF
--- a/hacking/pr_labeler/label.py
+++ b/hacking/pr_labeler/label.py
@@ -268,7 +268,6 @@ def process_pr(
         return
 
     handle_codeowner_labels(ctx)
-    add_label_if_new(ctx, "needs_triage")
     new_contributor_welcome(ctx)
     no_body_nag(ctx)
 


### PR DESCRIPTION
Fixes: https://github.com/ansible/ansible-documentation/issues/628
