### PR TITLE
get_bot_user: use correct username in committer email

### DIFF
--- a/hacking/get_bot_user.sh
+++ b/hacking/get_bot_user.sh
@@ -11,4 +11,4 @@ user_id="$(curl -sS "${path}" | jq -r .id)"
 GIT="${GIT:-git}"
 
 ${GIT} config user.name "${name}"
-${GIT} config user.email "${user_id}+${bot}@users.noreply.github.com"
+${GIT} config user.email "${user_id}+${bot}[bot]@users.noreply.github.com"


### PR DESCRIPTION
There is a small error in the Ansible Documentation Bot's committer
email used by the pip-compile jobs. There needs to be a `[bot]` suffix
in the username of a bot.
