### PR TITLE
Update shebang sanity test docs to match test

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/shebang.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/shebang.rst
@@ -4,12 +4,11 @@ shebang
 Most executable files should only use one of the following shebangs:
 
 - ``#!/bin/sh``
-- ``#!/bin/bash``
+- ``#!/bin/bash -eu``
+- ``#!/bin/bash -eux``
 - ``#!/usr/bin/make``
 - ``#!/usr/bin/env python``
 - ``#!/usr/bin/env bash``
-
-NOTE: For ``#!/bin/bash``, any of the options ``eux`` may also be used, such as ``#!/bin/bash -eux``.
 
 This does not apply to Ansible modules, which should not be executable and must always use ``#!/usr/bin/python``.
 


### PR DESCRIPTION
The `#!/bin/bash` shebang was removed in https://github.com/ansible/ansible/pull/50954, but the documentation was never updated to reflect the change.

Relates: https://github.com/ansible/ansible/issues/81983