### PR TITLE
documentation_contributions: use tests/checkers.py

### DIFF
--- a/docs/docsite/rst/community/documentation_contributions.rst
+++ b/docs/docsite/rst/community/documentation_contributions.rst
@@ -237,8 +237,8 @@ When you submit a documentation pull request, automated tests are run. Those sam
 .. code-block:: bash
 
   make clean -C docs/docsite
-  python tests/sanity.py docs-build
-  python tests/sanity.py rstcheck
+  python tests/checkers.py docs-build
+  python tests/checkers.py rstcheck
 
 It is recommended to run tests on a clean copy of the repository, which is the purpose of the ``make clean`` command.
 


### PR DESCRIPTION
tests/sanity.py was renamed to tests/checker.py in
https://github.com/ansible/ansible-documentation/pull/563, but I never
changed the documentation_contributions doc. Mea culpa.
