### PR TITLE
add nox make session and revamp contribution docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project includes a `nox` configuration to automate tests, checks, and other
 You can use these automated tests to help you verify changes before you submit a PR.
 You can manually
 [set up your environment](https://docs.ansible.com/ansible/latest/community/documentation_contributions.html#setting-up-your-environment-to-build-documentation-locally)
-if you prefer, but the `nox` configuration significantly simplifies this process.
+if you prefer, but `nox` is more straightforward and create an isolated environment for you.
 
 * Install `nox` using `python3 -m pip install nox` or your distribution's package manager.
 
@@ -29,8 +29,7 @@ if you prefer, but the `nox` configuration significantly simplifies this process
 
 The different Makefile targets used to build the documentation are outlined in
 [Building the documentation locally](https://docs.ansible.com/ansible/latest/community/documentation_contributions.html#building-the-documentation-locally).
-The `nox` configuration has a `make` session to automate setting up a docs build
-environment and running the Makefile.
+The `nox` configuration has a `make` session that creates a build environment and uses the Makefile to generate HTML.
 
 * Clone required parts of the `ansible/ansible` repository.
 
@@ -40,13 +39,13 @@ environment and running the Makefile.
 
   See [Periodically cloning Ansible core](https://docs.ansible.com/ansible/latest/community/documentation_contributions.html#periodically-cloning-ansible-core) for more information.
 
-* Run a minimal Ansible Core docs build.
+* Build minimal Ansible Core docs.
 
   ``` bash
   nox -s make
   ```
 
-* Run a specific Makefile target with options
+* Run a specific Makefile target:
 
   ``` bash
   nox -s make -- clean htmlsingle rst=community/documentation_contributions.rst

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ environment and running the Makefile.
 
 * Clone required parts of the `ansible/ansible` repository.
 
-  ```
+  ``` bash
   nox -s clone-core
   ```
 
@@ -42,13 +42,13 @@ environment and running the Makefile.
 
 * Run a minimal Ansible Core docs build.
 
-  ```
+  ``` bash
   nox -s make
   ```
 
 * Run a specific Makefile target with options
 
-  ```
+  ``` bash
   nox -s make -- clean htmlsingle rst=community/documentation_contributions.rst
   ```
 
@@ -58,7 +58,7 @@ The `nox` configuration also contains session to run automated docs checkers.
 
 * Ensure there are no syntax errors in the reStructuredText source files.
 
-  ```
+  ``` bash
   nox -s "checkers(rstcheck)"
   ```
 
@@ -66,7 +66,7 @@ The `nox` configuration also contains session to run automated docs checkers.
 
 * Verify the docs build.
 
-  ```
+  ``` bash
   nox -s "checkers(docs-build)"
   ```
 
@@ -76,7 +76,7 @@ The `nox` configuration also contains session to run automated docs checkers.
 
 * Lint, type check, and format Python scripts in this repository.
 
-  ```
+  ``` bash
   nox -s lint
   ```
 
@@ -86,19 +86,19 @@ Use [`codespell`](https://github.com/codespell-project/codespell) to check for c
 
 * Check spelling.
 
-  ```
+  ``` bash
   nox -s spelling
   ```
 
 * Correct any detected spelling errors.
 
-  ```
+  ``` bash
   nox -s spelling -- -w
   ```
 
 * Select an option when `codespell` suggests more than one word as a correction.
 
-  ```
+  ``` bash
   nox -s spelling -- -w -i 3
   ```
 
@@ -120,7 +120,7 @@ For more details about using unpinned and tested dependencies for doc builds, se
 
 Use the following `nox` session to update the dependency lock files in `tests/`.
 
-  ```
+  ``` bash
   nox -e pip-compile
   ```
 

--- a/README.md
+++ b/README.md
@@ -4,32 +4,33 @@ This repository holds the ReStructuredText (RST) source, and other files, for us
 
 > Documentation for modules and plugins that are officially supported by the Ansible Core engineering team is available in the [`ansible/ansible`](https://github.com/ansible/ansible) repository.
 
-## Building Ansible community documentation
-
-Follow the documentation to [set up your environment](https://docs.ansible.com/ansible/latest/community/documentation_contributions.html#setting-up-your-environment-to-build-documentation-locally) and then [build Ansible community documentation locally](https://docs.ansible.com/ansible/latest/community/documentation_contributions.html#building-the-documentation-locally)
-
 ## Verifying your pull request
 
 We welcome all contributions to Ansible community documentation.
 If you plan to submit a pull request with changes, you should [verify your PR](https://docs.ansible.com/ansible/latest/community/documentation_contributions.html#verifying-your-documentation-pr) to ensure it conforms with style guidelines and can build successfully.
 
-### Running automated tests
+### Setting up nox
 
 This project includes a `nox` configuration to automate tests, checks, and other functions.
 You can use these automated tests to help you verify changes before you submit a PR.
+You can manually
+[set up your environment](https://docs.ansible.com/ansible/latest/community/documentation_contributions.html#setting-up-your-environment-to-build-documentation-locally)
+if you prefer, but the `nox` configuration significantly simplifies this process.
 
-1. Install `nox` using `python3 -m pip install nox` or your distribution's package manager.
-2. Run `nox --list` from the repository root to view available sessions.
+* Install `nox` using `python3 -m pip install nox` or your distribution's package manager.
 
-Each `nox` session creates a temporary environment that installs all requirements and runs the test or check.
-This means you only need to run one command to perform the test accurately and consistently.
-The following are some of the `nox` sessions you can run:
+* Execute `nox` from the repository root with no arguments to run
+  all docs checkers, Python code checkers, and a minimal HTML docs build.
 
-* Run all available sessions.
+* Alternatively, you can run only certain tasks as outlined in the following sections.
+  Run `nox --list` to view available sessions.
 
-  ```
-  nox
-  ```
+### Building docs
+
+The different Makefile targets used to build the documentation are outlined in
+[Building the documentation locally](https://docs.ansible.com/ansible/latest/community/documentation_contributions.html#building-the-documentation-locally).
+The `nox` configuration has a `make` session to automate setting up a docs build
+environment and running the Makefile.
 
 * Clone required parts of the `ansible/ansible` repository.
 
@@ -38,6 +39,22 @@ The following are some of the `nox` sessions you can run:
   ```
 
   See [Periodically cloning Ansible core](https://docs.ansible.com/ansible/latest/community/documentation_contributions.html#periodically-cloning-ansible-core) for more information.
+
+* Run a minimal Ansible Core docs build.
+
+  ```
+  nox -s make
+  ```
+
+* Run a specific Makefile target with options
+
+  ```
+  nox -s make -- clean htmlsingle rst=community/documentation_contributions.rst
+  ```
+
+### Running automated tests
+
+The `nox` configuration also contains session to run automated docs checkers.
 
 * Ensure there are no syntax errors in the reStructuredText source files.
 
@@ -63,7 +80,7 @@ The following are some of the `nox` sessions you can run:
   nox -s lint
   ```
 
-## Checking spelling
+### Checking spelling
 
 Use [`codespell`](https://github.com/codespell-project/codespell) to check for common spelling mistakes in the documentation source.
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -165,10 +165,12 @@ def checkers(session: nox.Session, test: str):
 @nox.session
 def make(session: nox.Session):
     """
-    Run the docs build Makefile in an isolated environment
+    Generate HTML from documentation source using the Makefile
     """
     parser = _relaxed_parser(session)
-    parser.add_argument("make_args", nargs="*", help="Arguments to pass on to make")
+    parser.add_argument(
+        "make_args", nargs="*", help="Specify make targets as arguments"
+    )
     args = parser.parse_args(session.posargs)
 
     install(session, req="requirements-relaxed" if args.relaxed else "requirements")

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,7 +14,7 @@ LINT_FILES: tuple[str, ...] = (
     *iglob("docs/bin/*.py"),
 )
 PINNED = os.environ.get("PINNED", "true").lower() in {"1", "true"}
-nox.options.sessions = ("clone-core", "lint", "checkers")
+nox.options.sessions = ("clone-core", "lint", "checkers", "make")
 
 
 def install(session: nox.Session, *args, req: str, **kwargs):
@@ -172,5 +172,8 @@ def make(session: nox.Session):
     args = parser.parse_args(session.posargs)
 
     install(session, req="requirements-relaxed" if args.relaxed else "requirements")
-    make_args: list[str] = [f"PYTHON={_env_python(session)}", *(args.make_args or ())]
+    make_args: list[str] = [
+        f"PYTHON={_env_python(session)}",
+        *(args.make_args or ("clean", "coredocs")),
+    ]
     session.run("make", "-C", "docs/docsite", *make_args, external=True)


### PR DESCRIPTION
This PR adds a `make` session to the noxfile to automate running the docs build Makefile and revamps the README to document the process. It also updates the documentation_contributions docs to advise setting up a venv in the same way that `nox` does.
Note that this does not impact the existing Jenkins build process. That can continue calling the Makefile directly as it has up until now.


---



I know calling make via nox is a bit weird, but I think allowing to run
the Makefile in an isolated environment without having to manually
manage venvs and making it easy to choose between relaxed and stable
dependencies is quite useful.

We should eventually move away from the Makefile, but I think some level
of integration is better than nothing.
Translating the Makefile syntax and constructs into nox's Python syntax
and untangling all of the different Python scripts that preprocess the
documentation is a longer term project.