### PR TITLE
update urls for getting started with ees

### DIFF
--- a/docs/docsite/rst/collections_guide/collections_installing.rst
+++ b/docs/docsite/rst/collections_guide/collections_installing.rst
@@ -11,7 +11,7 @@ Installing collections in containers
 ------------------------------------
 
 You can install collections with their dependencies in containers known as Execution Environments.
-See `Getting started with Execution Environments <https://docs.ansible.com/ansible/devel/getting_started_ee/index.html>`_ for details.
+See `Getting started with Execution Environments <https://ansible.readthedocs.io/en/latest/getting_started_ee/index.html>`_ for details.
 
 Installing collections with ``ansible-galaxy``
 ----------------------------------------------

--- a/docs/docsite/rst/command_guide/index.rst
+++ b/docs/docsite/rst/command_guide/index.rst
@@ -25,5 +25,5 @@ Ansible provides ad hoc commands and several utilities for performing various op
    `Ansible Navigator <https://ansible.readthedocs.io/projects/navigator/>`_
        A command-line tool and a TUI that provides a convenient user interface for most
        of the native Ansible command-line utilities and allows to run Ansible automation content
-       inside containers (`Execution Environments <https://docs.ansible.com/ansible/devel/getting_started_ee/index.html>`_)
+       inside containers (`Execution Environments <https://ansible.readthedocs.io/en/latest/getting_started_ee/index.html>`_)
 

--- a/docs/docsite/rst/shared_snippets/basic_concepts.txt
+++ b/docs/docsite/rst/shared_snippets/basic_concepts.txt
@@ -2,7 +2,7 @@ Control node
 ============
 The machine from which you run the Ansible CLI tools (``ansible-playbook`` , ``ansible``, ``ansible-vault`` and others).
 You can use any computer that meets the software requirements as a control node - laptops, shared desktops, and servers can all run Ansible.
-You can also run Ansible in containers known as `Execution Environments <https://docs.ansible.com/ansible/devel/getting_started_ee/index.html>`_.
+You can also run Ansible in containers known as `Execution Environments <https://ansible.readthedocs.io/en/latest/getting_started_ee/index.html>`_.
 
 Multiple control nodes are possible, but Ansible itself does not coordinate across them, see ``AAP`` for such features.
 

--- a/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
+++ b/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
@@ -127,7 +127,7 @@ These tips apply to using Ansible, rather than to Ansible artifacts.
 Use Execution Environments
 --------------------------
 
-Reduce complexity with portable container images known as `Execution Environments <https://docs.ansible.com/ansible/devel/getting_started_ee/index.html>`_.
+Reduce complexity with portable container images known as `Execution Environments <https://ansible.readthedocs.io/en/latest/getting_started_ee/index.html>`_.
 
 Try it in staging first
 -----------------------


### PR DESCRIPTION
Updates all links for Getting Started with Execution Environments to https://ansible.readthedocs.io/en/latest/getting_started_ee/index.html

Follows up on https://github.com/ansible/ansible-documentation/pull/617