### PR TITLE
ci: avoid interpolating inputs into run: scripts

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -53,12 +53,14 @@ jobs:
         env:
           event_json: "${{ toJSON(github.event) }}"
           GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}
-        run:
-          ./venv/bin/python hacking/pr_labeler/label.py issue ${{ github.event.issue.number || inputs.number }}
+          number: "${{ github.event.issue.number || inputs.number }}"
+        run: |
+          ./venv/bin/python hacking/pr_labeler/label.py issue "${number}"
       - name: "Run the PR labeler"
         if: "github.event.pull_request || inputs.type == 'pr'"
         env:
           event_json: "${{ toJSON(github.event) }}"
           GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}
-        run:
-          ./venv/bin/python hacking/pr_labeler/label.py pr ${{ github.event.number || inputs.number }}
+          number: "${{ github.event.number || inputs.number }}"
+        run: |
+          ./venv/bin/python hacking/pr_labeler/label.py pr "${number}"

--- a/.github/workflows/reusable-pip-compile.yml
+++ b/.github/workflows/reusable-pip-compile.yml
@@ -82,43 +82,52 @@ jobs:
         run: |
           hacking/get_bot_user.sh "ansible-documentation-bot" "Ansible Documentation Bot"
       - name: "Use a branch named ${{ inputs.pr-branch }}"
+        env:
+          base_branch: "${{ inputs.base-branch }}"
+          pr_branch: "${{ inputs.pr-branch }}"
         id: branch
         run: |
           set -x
-          if git branch -r | grep "origin/${{ inputs.pr-branch }}"; then
+          if git branch -r | grep "origin/${pr_branch}"; then
             echo "branch-exists=true" >> "${GITHUB_OUTPUT}"
-            git switch "${{ inputs.pr-branch }}"
+            git switch "${pr_branch}"
             ${{ inputs.reset-branch && 'git reset --hard' || 'git rebase' }} \
-              "${{ inputs.base-branch }}"
+              "${base_branch}"
           else
             echo "branch-exists=false" >> "${GITHUB_OUTPUT}"
-            git switch -c "${{ inputs.pr-branch }}"
+            git switch -c "${pr_branch}"
           fi
       - name: "Run nox ${{ inputs.nox-args }}"
         env:
           # Ensure the latest pip version is used
           VIRTUALENV_DOWNLOAD: '1'
+          #
+          nox_args: "${{ inputs.nox-args }}"
         run: |
-          nox ${{ inputs.nox-args }}
+          nox ${nox_args}
       - name: Push new dependency versions and create a PR
         env:
           GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}
+          base_branch: "${{ inputs.base-branch }}"
+          pr_branch: "${{ inputs.pr-branch }}"
+          message: "${{ inputs.message }}"
+          changed_files: "${{ inputs.changed-files }}"
         run: |
           set -x
           git diff || :
-          git add ${{ inputs.changed-files }}
-          if git diff-index --quiet HEAD ${{ inputs.changed-files }}; then
+          git add ${changed_files}
+          if git diff-index --quiet HEAD ${changed_files}; then
             echo "Nothing to do!"
             exit
           fi
 
-          git commit -m "${{ inputs.message }}"
-          git push --force origin "${{ inputs.pr-branch }}"
+          git commit -m "${message}"
+          git push --force origin "${pr_branch}"
           if [ "${{ steps.branch.outputs.branch-exists }}" = "false" ]
           then
             gh pr create \
-              --base "${{ inputs.base-branch }}" \
-              --title "${{ inputs.message }}" \
+              --base "${base_branch}" \
+              --title "${message}" \
               --body "" \
               --label dependency_update
           fi


### PR DESCRIPTION
Github Actions makes it easy to inject arbitrary shell code into Github Actions scripts thanks to the way its templating language works. This change mediates that issue by passing action inputs to the `run:` scripts as env vars instead of using `${{ }}` expansions directly in the script bodies.

The pr_labeler job is the only one that both runs on pull requests and has access to secrets, but we don't interpolate anything other than `github.event.number`, so that wouldn't allow any malicious person to steal credentials.
reusable-pip-compile has access to secrets and accepts user input, but only from trusted sources (i.e., developers who already have write access to this repository) and can manually trigger workflows. Still, it's a good to tighten this up.