### PR TITLE
intro_installation: pass --include-injected in pipx upgrade example

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -98,7 +98,7 @@ To upgrade an existing Ansible installation to the latest released version:
 
 .. code-block:: console
 
-    $ pipx upgrade ansible
+    $ pipx upgrade --include-injected ansible
 
 .. _pipx_inject:
 


### PR DESCRIPTION
`--include-injected` ensures that the ansible-core package and other
packages that users may have injected into the ansible pipx venv are
updated alongside the ansible package.
