### PR TITLE
communication.rst: Make WG a top-level section

### DIFF
--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -105,10 +105,28 @@ The clickable links will take you directly to the relevant Matrix room in your b
 - `For public community meetings <https://matrix.to/#/#meeting:ansible.im>`_ - ``Matrix: #meeting:ansible.im | IRC: #ansible-meeting``
    - We will generally announce these on one or more of the above mailing lists. See the `meeting schedule and agenda page <https://github.com/ansible/community/blob/main/meetings/README.md>`_
 
+Working group-specific channels
+-------------------------------
+
+Many of the working groups have dedicated chat channels. See the :ref:`working_group_list` for more information.
+
+Regional and Language-specific channels
+---------------------------------------
+
+- Comunidad Ansible en español - Matrix: `#espanol:ansible.im <https://matrix.to:/#/#espanol:ansible.im>`_ | IRC: ``#ansible-es``
+- Communauté française d'Ansible - Matrix: `#francais:ansible.im <https://matrix.to:/#/#francais:ansible.im>`_ | IRC: ``#ansible-fr``
+- Communauté suisse d'Ansible - Matrix: `#suisse:ansible.im <https://matrix.to:/#/#suisse:ansible.im>`_ | IRC: ``#ansible-zh``
+- European Ansible Community - Matrix: `#europe:ansible.im <https://matrix.to:/#/#europe:ansible.im>`_ | IRC: ``#ansible-eu``
+
+Meetings on chat
+----------------
+
+The Ansible community holds regular meetings on various topics on Matrix/IRC, and anyone who is interested is invited to participate. For more information about Ansible meetings, consult the `meeting schedule and agenda page <https://github.com/ansible/community/blob/main/meetings/README.md>`_.
+
 .. _working_group_list:
 
 Working groups
---------------
+==============
 
 Our community working groups are represented in forms of `Forum groups <https://forum.ansible.com/g>`_ (new style) or `wiki pages <https://github.com/ansible/community/wiki#working-groups>`_ (deprecated).
 
@@ -142,19 +160,6 @@ Many of them meet in chat. If you want to get involved in a working group, join 
 - `Ansible developer tools Group <https://github.com/ansible/community/wiki/Ansible-developer-tools>`_ - Matrix: `#devtools:ansible.com <https://matrix.to/#/#devtools:ansible.com>`_ | IRC: ``#ansible-devtools``
 
 Want to `form a new Working Group <https://github.com/ansible/community/blob/main/WORKING-GROUPS.md>`_?
-
-Regional and Language-specific channels
----------------------------------------
-
-- Comunidad Ansible en español - Matrix: `#espanol:ansible.im <https://matrix.to:/#/#espanol:ansible.im>`_ | IRC: ``#ansible-es``
-- Communauté française d'Ansible - Matrix: `#francais:ansible.im <https://matrix.to:/#/#francais:ansible.im>`_ | IRC: ``#ansible-fr``
-- Communauté suisse d'Ansible - Matrix: `#suisse:ansible.im <https://matrix.to:/#/#suisse:ansible.im>`_ | IRC: ``#ansible-zh``
-- European Ansible Community - Matrix: `#europe:ansible.im <https://matrix.to:/#/#europe:ansible.im>`_ | IRC: ``#ansible-eu``
-
-Meetings on chat
-----------------
-
-The Ansible community holds regular meetings on various topics on Matrix/IRC, and anyone who is interested is invited to participate. For more information about Ansible meetings, consult the `meeting schedule and agenda page <https://github.com/ansible/community/blob/main/meetings/README.md>`_.
 
 Ansible Community Topics
 ========================


### PR DESCRIPTION
### Context
We have the [communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).

There's the `Working groups` section in there but it's a subsection of the `Real-time chat` section.

We also have a forum now where we encourage people to create their teams/working groups, etc. i.e. in a form of forum group **instead of old style WG wiki pages**.

So there are a few issues now in the guide:
- As the `Working groups` section is a subsection of `Real-time chat`, it feels like having a Matrix/IRC room is a primary thing for a WG to exist which **is not true / or at least should not be** in general.
- Also some of the groups have **only a forum** group w/o a real-time chat room (examples, the EE forum group), so now it's possible but illogical to put them in the list as it's under `Real-time chat`.

###  Solution

I think such a structure is something historical where IRC was an only way to communicate besides GitHub issues/discussions.
Now there's the forum which is, provided that the community is happy, supposed to become a main communication platform alongside   the real-time chat platforms for teams/WGs.

In my opinion, we should re-structure the communication guide to adhere to the new reality:)

This PR makes the `Working groups` a top-level section of the guide.