### PR TITLE
set release version to 2.16

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -43,7 +43,7 @@ assert applied_tags_count == 1, (
 )
 
 VERSION = (
-    'devel' if tags.has('core_lang') or tags.has('core') or tags.has('ansible') or tags.has('all') else
+    '2.16' if tags.has('core_lang') or tags.has('core') or tags.has('ansible') or tags.has('all') else
     '2.10' if tags.has('2.10')
     else '<UNKNOWN>'
 )


### PR DESCRIPTION
Applies only to `stable-2.16` branch.

Part of #427 