### PR TITLE
update galaxy urls for networking docs

### DIFF
--- a/docs/docsite/rst/network/user_guide/platform_ce.rst
+++ b/docs/docsite/rst/network/user_guide/platform_ce.rst
@@ -4,7 +4,7 @@
 CloudEngine OS Platform Options
 ***************************************
 
-CloudEngine CE OS is part of the `community.network <https://galaxy.ansible.com/community/network>`_ collection and supports multiple connections. This page offers details on how each connection works in Ansible and how to use it.
+CloudEngine CE OS is part of the `community.network <https://galaxy.ansible.com/ui/repo/published/community/network>`_ collection and supports multiple connections. This page offers details on how each connection works in Ansible and how to use it.
 
 .. contents::
   :local:

--- a/docs/docsite/rst/network/user_guide/platform_cnos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_cnos.rst
@@ -4,7 +4,7 @@
 CNOS Platform Options
 ***************************************
 
-CNOS is part of the `community.network <https://galaxy.ansible.com/community/network>`_ collection and supports Enable Mode (Privilege Escalation). This page offers details on how to use Enable Mode on CNOS in Ansible.
+CNOS is part of the `community.network <https://galaxy.ansible.com/ui/repo/published/community/network>`_ collection and supports Enable Mode (Privilege Escalation). This page offers details on how to use Enable Mode on CNOS in Ansible.
 
 .. contents::
   :local:

--- a/docs/docsite/rst/network/user_guide/platform_dellos10.rst
+++ b/docs/docsite/rst/network/user_guide/platform_dellos10.rst
@@ -4,7 +4,7 @@
 Dell OS10 Platform Options
 ***************************************
 
-The `dellemc.os10 <https://galaxy.ansible.com/dellemc_networking/os10>`_ collection supports Enable Mode (Privilege Escalation). This page offers details on how to use Enable Mode on OS10 in Ansible.
+The `dellemc.os10 <https://galaxy.ansible.com/ui/repo/published/dellemc_networking/os10>`_ collection supports Enable Mode (Privilege Escalation). This page offers details on how to use Enable Mode on OS10 in Ansible.
 
 .. contents::
   :local:

--- a/docs/docsite/rst/network/user_guide/platform_enos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_enos.rst
@@ -4,7 +4,7 @@
 ENOS Platform Options
 ***************************************
 
-ENOS is part of the `community.network <https://galaxy.ansible.com/community/network>`_ collection and supports Enable Mode (Privilege Escalation). This page offers details on how to use Enable Mode on ENOS in Ansible.
+ENOS is part of the `community.network <https://galaxy.ansible.com/ui/repo/published/community/network>`_ collection and supports Enable Mode (Privilege Escalation). This page offers details on how to use Enable Mode on ENOS in Ansible.
 
 .. contents::
   :local:

--- a/docs/docsite/rst/network/user_guide/platform_eos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_eos.rst
@@ -4,7 +4,7 @@
 EOS Platform Options
 ***************************************
 
-The `Arista EOS <https://galaxy.ansible.com/arista/eos>`_ collection supports multiple connections. This page offers details on how each connection works in Ansible and how to use it.
+The `Arista EOS <https://galaxy.ansible.com/ui/repo/published/arista/eos>`_ collection supports multiple connections. This page offers details on how each connection works in Ansible and how to use it.
 
 .. contents::
   :local:

--- a/docs/docsite/rst/network/user_guide/platform_eric_eccli.rst
+++ b/docs/docsite/rst/network/user_guide/platform_eric_eccli.rst
@@ -4,7 +4,7 @@
 ERIC_ECCLI Platform Options
 ***************************************
 
-Extreme ERIC_ECCLI is part of the `community.network <https://galaxy.ansible.com/community/network>`_ collection and only supports CLI connections today. This page offers details on how to use ``ansible.netcommon.network_cli`` on ERIC_ECCLI in Ansible.
+Extreme ERIC_ECCLI is part of the `community.network <https://galaxy.ansible.com/ui/repo/published/community/network>`_ collection and only supports CLI connections today. This page offers details on how to use ``ansible.netcommon.network_cli`` on ERIC_ECCLI in Ansible.
 
 .. contents::
   :local:

--- a/docs/docsite/rst/network/user_guide/platform_exos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_exos.rst
@@ -4,7 +4,7 @@
 EXOS Platform Options
 ***************************************
 
-Extreme EXOS is part of the `community.network <https://galaxy.ansible.com/community/network>`_ collection and supports multiple connections. This page offers details on how each connection works in Ansible and how to use it.
+Extreme EXOS is part of the `community.network <https://galaxy.ansible.com/ui/repo/published/community/network>`_ collection and supports multiple connections. This page offers details on how each connection works in Ansible and how to use it.
 
 .. contents::
   :local:

--- a/docs/docsite/rst/network/user_guide/platform_frr.rst
+++ b/docs/docsite/rst/network/user_guide/platform_frr.rst
@@ -4,7 +4,7 @@
 FRR Platform Options
 ***************************************
 
-The `FRR <https://galaxy.ansible.com/frr/frr>`_ collection supports the ``ansible.netcommon.network_cli`` connection. This section provides details on how to use this connection for Free Range Routing (FRR).
+The `FRR <https://galaxy.ansible.com/ui/repo/published/frr/frr>`_ collection supports the ``ansible.netcommon.network_cli`` connection. This section provides details on how to use this connection for Free Range Routing (FRR).
 
 .. contents::
   :local:

--- a/docs/docsite/rst/network/user_guide/platform_icx.rst
+++ b/docs/docsite/rst/network/user_guide/platform_icx.rst
@@ -4,7 +4,7 @@
 ICX Platform Options
 ***************************************
 
-ICX is part of the `community.network <https://galaxy.ansible.com/community/network>`_ collection supports Enable Mode (Privilege Escalation). This page offers details on how to use Enable Mode on ICX in Ansible.
+ICX is part of the `community.network <https://galaxy.ansible.com/ui/repo/published/community/network>`_ collection supports Enable Mode (Privilege Escalation). This page offers details on how to use Enable Mode on ICX in Ansible.
 
 .. contents::
   :local:

--- a/docs/docsite/rst/network/user_guide/platform_index.rst
+++ b/docs/docsite/rst/network/user_guide/platform_index.rst
@@ -91,34 +91,34 @@ Settings by Platform
     OS that supports Netconf `[†]`_  ``<network-os>``                               ✓                 ✓
     ===============================  ================================  ===========  =======  =======  ===========
 
-.. _Arista EOS: https://galaxy.ansible.com/arista/eos
-.. _Ciena SAOS6: https://galaxy.ansible.com/ciena/saos6
-.. _Cisco ASA: https://galaxy.ansible.com/cisco/asa
-.. _Cisco IOS: https://galaxy.ansible.com/cisco/ios
-.. _Cisco IOS XR: https://galaxy.ansible.com/cisco/iosxr
-.. _Cisco NX-OS: https://galaxy.ansible.com/cisco/nxos
-.. _Cloudengine OS: https://galaxy.ansible.com/community/network
+.. _Arista EOS: https://galaxy.ansible.com/ui/repo/published/arista/eos
+.. _Ciena SAOS6: https://galaxy.ansible.com/ui/repo/published/ciena/saos6
+.. _Cisco ASA: https://galaxy.ansible.com/ui/repo/published/cisco/asa
+.. _Cisco IOS: https://galaxy.ansible.com/ui/repo/published/cisco/ios
+.. _Cisco IOS XR: https://galaxy.ansible.com/ui/repo/published/cisco/iosxr
+.. _Cisco NX-OS: https://galaxy.ansible.com/ui/repo/published/cisco/nxos
+.. _Cloudengine OS: https://galaxy.ansible.com/ui/repo/published/community/network
 .. _Dell OS6: https://github.com/ansible-collections/dellemc.os6
 .. _Dell OS9: https://github.com/ansible-collections/dellemc.os9
-.. _Dell OS10: https://galaxy.ansible.com/dellemc/os10
-.. _Ericsson ECCLI: https://galaxy.ansible.com/community/network
-.. _Extreme EXOS: https://galaxy.ansible.com/community/network
-.. _Extreme IronWare: https://galaxy.ansible.com/community/network
-.. _Extreme NOS: https://galaxy.ansible.com/community/network
-.. _Extreme SLX-OS: https://galaxy.ansible.com/community/network
-.. _Extreme VOSS: https://galaxy.ansible.com/community/network
-.. _F5 BIG-IP: https://galaxy.ansible.com/f5networks/f5_modules
-.. _F5 BIG-IQ: https://galaxy.ansible.com/f5networks/f5_modules
-.. _Junos OS: https://galaxy.ansible.com/junipernetworks/junos
-.. _Lenovo CNOS: https://galaxy.ansible.com/community/network
-.. _Lenovo ENOS: https://galaxy.ansible.com/community/network
-.. _Meraki: https://galaxy.ansible.com/cisco/meraki
-.. _MikroTik RouterOS: https://galaxy.ansible.com/community/network
-.. _Nokia SR OS: https://galaxy.ansible.com/community/network
-.. _Pluribus Netvisor: https://galaxy.ansible.com/community/network
-.. _Ruckus ICX: https://galaxy.ansible.com/community/network
-.. _VyOS: https://galaxy.ansible.com/vyos/vyos
-.. _Westermo WeOS 4: https://galaxy.ansible.com/community/network
+.. _Dell OS10: https://galaxy.ansible.com/ui/repo/published/dellemc/os10
+.. _Ericsson ECCLI: https://galaxy.ansible.com/ui/repo/published/community/network
+.. _Extreme EXOS: https://galaxy.ansible.com/ui/repo/published/community/network
+.. _Extreme IronWare: https://galaxy.ansible.com/ui/repo/published/community/network
+.. _Extreme NOS: https://galaxy.ansible.com/ui/repo/published/community/network
+.. _Extreme SLX-OS: https://galaxy.ansible.com/ui/repo/published/community/network
+.. _Extreme VOSS: https://galaxy.ansible.com/ui/repo/published/community/network
+.. _F5 BIG-IP: https://galaxy.ansible.com/ui/repo/published/f5networks/f5_modules
+.. _F5 BIG-IQ: https://galaxy.ansible.com/ui/repo/published/f5networks/f5_modules
+.. _Junos OS: https://galaxy.ansible.com/ui/repo/published/junipernetworks/junos
+.. _Lenovo CNOS: https://galaxy.ansible.com/ui/repo/published/community/network
+.. _Lenovo ENOS: https://galaxy.ansible.com/ui/repo/published/community/network
+.. _Meraki: https://galaxy.ansible.com/ui/repo/published/cisco/meraki
+.. _MikroTik RouterOS: https://galaxy.ansible.com/ui/repo/published/community/network
+.. _Nokia SR OS: https://galaxy.ansible.com/ui/repo/published/community/network
+.. _Pluribus Netvisor: https://galaxy.ansible.com/ui/repo/published/community/network
+.. _Ruckus ICX: https://galaxy.ansible.com/ui/repo/published/community/network
+.. _VyOS: https://galaxy.ansible.com/ui/repo/published/vyos/vyos
+.. _Westermo WeOS 4: https://galaxy.ansible.com/ui/repo/published/community/network
 .. _`[†]`:
 
 **[†]** Maintained by Ansible Network Team

--- a/docs/docsite/rst/network/user_guide/platform_ios.rst
+++ b/docs/docsite/rst/network/user_guide/platform_ios.rst
@@ -4,7 +4,7 @@
 IOS Platform Options
 ***************************************
 
-The `Cisco IOS <https://galaxy.ansible.com/cisco/ios>`_ collection supports Enable Mode (Privilege Escalation). This page offers details on how to use Enable Mode on IOS in Ansible.
+The `Cisco IOS <https://galaxy.ansible.com/ui/repo/published/cisco/ios>`_ collection supports Enable Mode (Privilege Escalation). This page offers details on how to use Enable Mode on IOS in Ansible.
 
 .. contents::
   :local:

--- a/docs/docsite/rst/network/user_guide/platform_iosxr.rst
+++ b/docs/docsite/rst/network/user_guide/platform_iosxr.rst
@@ -4,7 +4,7 @@
 IOS-XR Platform Options
 ***************************************
 
-The `Cisco IOS-XR collection <https://galaxy.ansible.com/cisco/iosxr>`_ supports multiple connections. This page offers details on how each connection works in Ansible and how to use it.
+The `Cisco IOS-XR collection <https://galaxy.ansible.com/ui/repo/published/cisco/iosxr>`_ supports multiple connections. This page offers details on how each connection works in Ansible and how to use it.
 
 .. contents::
   :local:

--- a/docs/docsite/rst/network/user_guide/platform_ironware.rst
+++ b/docs/docsite/rst/network/user_guide/platform_ironware.rst
@@ -4,7 +4,7 @@
 IronWare Platform Options
 ***************************************
 
-IronWare is part of the `community.network <https://galaxy.ansible.com/community/network>`_ collection and supports Enable Mode (Privilege Escalation). This page offers details on how to use Enable Mode on IronWare in Ansible.
+IronWare is part of the `community.network <https://galaxy.ansible.com/ui/repo/published/community/network>`_ collection and supports Enable Mode (Privilege Escalation). This page offers details on how to use Enable Mode on IronWare in Ansible.
 
 .. contents::
   :local:

--- a/docs/docsite/rst/network/user_guide/platform_junos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_junos.rst
@@ -4,7 +4,7 @@
 Junos OS Platform Options
 ***************************************
 
-The `Juniper Junos OS <https://galaxy.ansible.com/junipernetworks/junos>`_ supports multiple connections. This page offers details on how each connection works in Ansible and how to use it.
+The `Juniper Junos OS <https://galaxy.ansible.com/ui/repo/published/junipernetworks/junos>`_ supports multiple connections. This page offers details on how each connection works in Ansible and how to use it.
 
 .. contents::
   :local:

--- a/docs/docsite/rst/network/user_guide/platform_meraki.rst
+++ b/docs/docsite/rst/network/user_guide/platform_meraki.rst
@@ -4,7 +4,7 @@
 Meraki Platform Options
 ***************************************
 
-The `cisco.meraki <https://galaxy.ansible.com/cisco/meraki>`_ collection only supports the ``local`` connection type at this time.
+The `cisco.meraki <https://galaxy.ansible.com/ui/repo/published/cisco/meraki>`_ collection only supports the ``local`` connection type at this time.
 
 .. contents::
   :local:

--- a/docs/docsite/rst/network/user_guide/platform_netvisor.rst
+++ b/docs/docsite/rst/network/user_guide/platform_netvisor.rst
@@ -4,7 +4,7 @@
 Pluribus NETVISOR Platform Options
 **********************************
 
-Pluribus NETVISOR Ansible is part of the `community.network <https://galaxy.ansible.com/community/network>`_ collection and only supports CLI connections today. ``httpapi`` modules may be added in future.
+Pluribus NETVISOR Ansible is part of the `community.network <https://galaxy.ansible.com/ui/repo/published/community/network>`_ collection and only supports CLI connections today. ``httpapi`` modules may be added in future.
 This page offers details on how to use ``ansible.netcommon.network_cli`` on NETVISOR in Ansible.
 
 .. contents::

--- a/docs/docsite/rst/network/user_guide/platform_nos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_nos.rst
@@ -4,7 +4,7 @@
 NOS Platform Options
 ***************************************
 
-Extreme NOS is part of the `community.network <https://galaxy.ansible.com/community/network>`_ collection and only supports CLI connections today. ``httpapi`` modules may be added in future.
+Extreme NOS is part of the `community.network <https://galaxy.ansible.com/ui/repo/published/community/network>`_ collection and only supports CLI connections today. ``httpapi`` modules may be added in future.
 This page offers details on how to use ``ansible.netcommon.network_cli`` on NOS in Ansible.
 
 .. contents::

--- a/docs/docsite/rst/network/user_guide/platform_nxos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_nxos.rst
@@ -4,7 +4,7 @@
 NXOS Platform Options
 ***************************************
 
-The `Cisco NXOS <https://galaxy.ansible.com/cisco/nxos>`_ supports multiple connections. This page offers details on how each connection works in Ansible and how to use it.
+The `Cisco NXOS <https://galaxy.ansible.com/ui/repo/published/cisco/nxos>`_ supports multiple connections. This page offers details on how each connection works in Ansible and how to use it.
 
 .. contents::
   :local:

--- a/docs/docsite/rst/network/user_guide/platform_routeros.rst
+++ b/docs/docsite/rst/network/user_guide/platform_routeros.rst
@@ -4,7 +4,7 @@
 RouterOS Platform Options
 ***************************************
 
-RouterOS is part of the `community.network <https://galaxy.ansible.com/community/network>`_ collection and only supports CLI connections today. ``httpapi`` modules may be added in future.
+RouterOS is part of the `community.network <https://galaxy.ansible.com/ui/repo/published/community/network>`_ collection and only supports CLI connections today. ``httpapi`` modules may be added in future.
 This page offers details on how to use ``ansible.netcommon.network_cli`` on RouterOS in Ansible.
 
 .. contents::

--- a/docs/docsite/rst/network/user_guide/platform_slxos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_slxos.rst
@@ -4,7 +4,7 @@
 SLX-OS Platform Options
 ***************************************
 
-Extreme SLX-OS is part of the `community.network <https://galaxy.ansible.com/community/network>`_ collection and only supports CLI connections today. ``httpapi`` modules may be added in future.
+Extreme SLX-OS is part of the `community.network <https://galaxy.ansible.com/ui/repo/published/community/network>`_ collection and only supports CLI connections today. ``httpapi`` modules may be added in future.
 This page offers details on how to use ``ansible.netcommon.network_cli`` on SLX-OS in Ansible.
 
 .. contents::

--- a/docs/docsite/rst/network/user_guide/platform_voss.rst
+++ b/docs/docsite/rst/network/user_guide/platform_voss.rst
@@ -4,7 +4,7 @@
 VOSS Platform Options
 ***************************************
 
-Extreme VOSS is part of the `community.network <https://galaxy.ansible.com/community/network>`_ collection and only supports CLI connections today. This page offers details on how to
+Extreme VOSS is part of the `community.network <https://galaxy.ansible.com/ui/repo/published/community/network>`_ collection and only supports CLI connections today. This page offers details on how to
 use ``ansible.netcommon.network_cli`` on VOSS in Ansible.
 
 .. contents::

--- a/docs/docsite/rst/network/user_guide/platform_vyos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_vyos.rst
@@ -4,7 +4,7 @@
 VyOS Platform Options
 ***************************************
 
-The `VyOS <https://galaxy.ansible.com/vyos/vyos>`_ collection supports the ``ansible.netcommon.network_cli`` connection type. This page offers details on connection options to manage VyOS using Ansible.
+The `VyOS <https://galaxy.ansible.com/ui/repo/published/vyos/vyos>`_ collection supports the ``ansible.netcommon.network_cli`` connection type. This page offers details on connection options to manage VyOS using Ansible.
 
 .. contents::
   :local:

--- a/docs/docsite/rst/network/user_guide/platform_weos4.rst
+++ b/docs/docsite/rst/network/user_guide/platform_weos4.rst
@@ -4,7 +4,7 @@
 WeOS 4 Platform Options
 ***************************************
 
-Westermo WeOS 4 is part of the `community.network <https://galaxy.ansible.com/community/network>`_ collection and only supports CLI connections.
+Westermo WeOS 4 is part of the `community.network <https://galaxy.ansible.com/ui/repo/published/community/network>`_ collection and only supports CLI connections.
 This page offers details on how to use ``ansible.netcommon.network_cli`` on WeOS 4 in Ansible.
 
 .. contents::

--- a/docs/docsite/rst/network/user_guide/validate.rst
+++ b/docs/docsite/rst/network/user_guide/validate.rst
@@ -13,7 +13,7 @@ The :ansplugin:`validate <ansible.utils.validate#module>` module validates data 
 Understanding the validate plugin
 ==================================
 
-The `ansible.utils <https://galaxy.ansible.com/ansible/utils>`_ collection includes the :ansplugin:`validate <ansible.utils.validate#module>` module.
+The `ansible.utils <https://galaxy.ansible.com/ui/repo/published/ansible/utils>`_ collection includes the :ansplugin:`validate <ansible.utils.validate#module>` module.
 
 To validate data:
 
@@ -21,7 +21,7 @@ To validate data:
 #. Define the criteria to test that data against.
 #. Select a validation engine and test the data to see if it is valid based on the selected criteria and validation engine.
 
-The structure of the data and the criteria depends on the validation engine you select. The examples here use the ``jsonschema`` validation engine provided in the `ansible.utils <https://galaxy.ansible.com/ansible/utils>`_ collection.Red Hat Ansible Automation Platform subscription supports limited use if jsonschema public APIs as documented.
+The structure of the data and the criteria depends on the validation engine you select. The examples here use the ``jsonschema`` validation engine provided in the `ansible.utils <https://galaxy.ansible.com/ui/repo/published/ansible/utils>`_ collection.Red Hat Ansible Automation Platform subscription supports limited use if jsonschema public APIs as documented.
 
 Structuring the data
 =====================


### PR DESCRIPTION
When galaxy changed to galaxyNG, all the collection-specific URLs changed as well. While Galaxy has redirects in place, this PR updates to the new URL format so we aren't depending on the redirects to keep our links working.