### PR TITLE
add ansible-galaxy to command cheatsheet

### DIFF
--- a/docs/docsite/rst/command_guide/cheatsheet.rst
+++ b/docs/docsite/rst/command_guide/cheatsheet.rst
@@ -41,7 +41,7 @@ Installing a collection:
 
    ansible-galaxy collection install mynamespace.mycollection
 
-Downloads ``mynamespace.mycollection`` from the configured Galaxy server (`<galaxy.ansible.com>`_ by default) and :
+Downloads ``mynamespace.mycollection`` from the configured Galaxy server (`<galaxy.ansible.com>`_ by default).
   
 
 Listing all installed collections:

--- a/docs/docsite/rst/command_guide/cheatsheet.rst
+++ b/docs/docsite/rst/command_guide/cheatsheet.rst
@@ -39,7 +39,7 @@ Installing a collection:
 
 .. code-block:: bash
 
-   ansible-galaxy collection install mynamespace.mycollection -p /path/to/collections --force-all-deps
+   ansible-galaxy collection install mynamespace.mycollection
 
 Downloads ``mynamespace.mycollection`` from the configured Galaxy server (`<galaxy.ansible.com>`_ by default) and :
   - ``-p`` - installs the collection to `/path/to/collections` (``~/.ansible/collections`` by default if this flag is not included).

--- a/docs/docsite/rst/command_guide/cheatsheet.rst
+++ b/docs/docsite/rst/command_guide/cheatsheet.rst
@@ -31,3 +31,26 @@ Loads ``my_playbook.yml`` from the current working directory and:
 
 See :ref:`ansible-playbook` for detailed documentation.
 
+
+ansible-galaxy
+==============
+
+Installing a collection:
+
+.. code-block:: bash
+
+   ansible-galaxy collection install mynamespace.mycollection -p /path/to/collections --force-all-deps
+
+Downloads ``mynamespace.mycollection`` from the configured Galaxy server (`<galaxy.ansible.com>`_ by default) and :
+  - ``-p`` - installs the collection to `/path/to/collections` (``~/.ansible/collections`` by default if this flag is not included).
+  - ``--force-with-deps`` - overwrites any existing collection and dependencies.
+  
+
+Listing all installed collections:
+
+.. code-block:: bash
+
+   ansible-galaxy collection list
+
+See :ref:`ansible-galaxy` for detailed documentation.
+

--- a/docs/docsite/rst/command_guide/cheatsheet.rst
+++ b/docs/docsite/rst/command_guide/cheatsheet.rst
@@ -42,8 +42,6 @@ Installing a collection:
    ansible-galaxy collection install mynamespace.mycollection
 
 Downloads ``mynamespace.mycollection`` from the configured Galaxy server (`<galaxy.ansible.com>`_ by default) and :
-  - ``-p`` - installs the collection to `/path/to/collections` (``~/.ansible/collections`` by default if this flag is not included).
-  - ``--force-with-deps`` - overwrites any existing collection and dependencies.
   
 
 Listing all installed collections:


### PR DESCRIPTION
Part of https://github.com/ansible/ansible-documentation/issues/48

Adds common CLI use for `ansible-galaxy` command.