### PR TITLE
sphinx: remove usage of deprecated notfound-page options

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -334,15 +334,10 @@ htmlhelp_basename = 'Poseidodoc'
 # with no 'notfound_template' and no 'notfound_context' set,
 # the extension builds 404.rst into a location-agnostic 404 page
 #
-# default is `en` - using this for the sub-site:
-notfound_default_language = "ansible"
-# default is `latest`:
 # setting explicitly - docsite serves up /ansible/latest/404.html
 # so keep this set to `latest` even on the `devel` branch
 # then no maintenance is needed when we branch a new stable_x.x
-notfound_default_version = "latest"
-# makes default setting explicit:
-notfound_no_urls_prefix = False
+notfound_urls_prefix = "/ansible/latest/"
 
 # Options for LaTeX output
 # ------------------------


### PR DESCRIPTION
sphinx-notfound-page deprecated and removed notfound_no_urls_prefix, notfound_default_language, and notfound_default_version in favor of notfound_urls_prefix.
We were still using these old options which caused our 404 pages to break.

---

Relates: https://github.com/ansible/ansible-documentation/issues/678