### PR TITLE
remove python version details

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -17,15 +17,16 @@ From the control node, Ansible can manage an entire fleet of machines and other 
 Control node requirements
 =========================
 
-For your *control* node (the machine that runs Ansible), you can use nearly any UNIX-like machine with Python 3.9 or newer installed. This includes Red Hat, Debian, Ubuntu, macOS, BSDs, and Windows under a `Windows Subsystem for Linux (WSL) distribution <https://docs.microsoft.com/en-us/windows/wsl/about>`_. Windows without WSL is not natively supported as a control node; see `Matt Davis' blog post <http://blog.rolpdog.com/2020/03/why-no-ansible-controller-for-windows.html>`_ for more information.
+For your *control* node (the machine that runs Ansible), you can use nearly any UNIX-like machine with Python installed. This includes Red Hat, Debian, Ubuntu, macOS, BSDs, and Windows under a `Windows Subsystem for Linux (WSL) distribution <https://docs.microsoft.com/en-us/windows/wsl/about>`_. Windows without WSL is not natively supported as a control node; see `Matt Davis' blog post <http://blog.rolpdog.com/2020/03/why-no-ansible-controller-for-windows.html>`_ for more information. See :ref:`ansible_core_support_matrix` for the required Python versions.
 
 .. _managed_node_requirements:
 
 Managed node requirements
 =========================
 
-The *managed* node (the machine that Ansible is managing) does not require Ansible to be installed, but requires Python 2.7, or Python 3.5 - 3.11 to run Ansible-generated Python code.
-The managed node also needs a user account that can connect through SSH to the node with an interactive POSIX shell.
+The *managed* node (the machine that Ansible is managing) does not require Ansible to be installed, but requires Python to run Ansible-generated Python code.
+The managed node also needs a user account that can connect through SSH to the node with an interactive POSIX shell. See :ref:`ansible_core_support_matrix` for the required Python  and PowerShell versions.
+
 
 .. note::
 


### PR DESCRIPTION
These were outdated. Instead, point to the canonical source for python versions elsewhere in the documentation.