### PR TITLE
Update the information on RouterOS network connections

### DIFF
--- a/docs/docsite/rst/network/user_guide/platform_routeros.rst
+++ b/docs/docsite/rst/network/user_guide/platform_routeros.rst
@@ -4,8 +4,14 @@
 RouterOS Platform Options
 ***************************************
 
-RouterOS is part of the `community.network <https://galaxy.ansible.com/ui/repo/published/community/network>`_ collection and only supports CLI connections today. ``httpapi`` modules may be added in future.
+RouterOS is part of the `community.network <https://galaxy.ansible.com/ui/repo/published/community/network>`_ collection and only supports CLI connections and direct API access.
 This page offers details on how to use ``ansible.netcommon.network_cli`` on RouterOS in Ansible.
+Further information can be found in :ref:`the community.routeros collection's SSH guide
+<ansible_collections.community.routeros.docsite.ssh-guide>`.
+
+Information on how to use the RouterOS API can be found in :ref:`the community.routeros collection's API guide
+<ansible_collections.community.routeros.docsite.api-guide>`.
+
 
 .. contents::
   :local:
@@ -37,7 +43,11 @@ Connections available
 .. |enable_mode| replace:: Enable Mode |br| (Privilege Escalation)
 
 
-RouterOS does not support ``ansible_connection: local``. You must use ``ansible_connection: ansible.netcommon.network_cli``.
+The RouterOS SSH modules do not support ``ansible_connection: local``. You must use ``ansible_connection: ansible.netcommon.network_cli``.
+
+The RouterOS API modules require ``ansible_connection: local``. See the :ref:`the community.routeros collection's API guide
+<ansible_collections.community.routeros.docsite.api-guide>` for more information.
+
 
 Using CLI in Ansible
 ====================
@@ -61,6 +71,7 @@ Example CLI ``group_vars/routeros.yml``
 - If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_ssh_common_args`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.
 - If you are getting timeout errors you may want to add ``+cet1024w`` suffix to your username which will disable console colors, enable "dumb" mode, tell RouterOS not to try detecting terminal capabilities and set terminal width to 1024 columns. See article `Console login process <https://wiki.mikrotik.com/wiki/Manual:Console_login_process>`_ in MikroTik wiki for more information.
+- More notes can be found in the :ref:`the community.routeros collection's SSH guide <ansible_collections.community.routeros.docsite.ssh-guide>`.
 
 Example CLI task
 ----------------


### PR DESCRIPTION
The community.routeros collection supports API modules for a long time by now. (They do not use the `httpapi` connection though.)

References the collection's SSH and API guides.