### PR TITLE
update logic to make it easier to patch for core vs ansible release

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -43,7 +43,10 @@ assert applied_tags_count == 1, (
 )
 
 VERSION = (
-    'devel' if tags.has('core_lang') or tags.has('core') or tags.has('ansible') or tags.has('all') else
+     # Controls branch version for core releases
+    'devel' if tags.has('core_lang') or tags.has('core') else
+    # Controls branch version for Ansible package releases
+    'devel' if tags.has('ansible') or tags.has('all') else
     '2.10' if tags.has('2.10')
     else '<UNKNOWN>'
 )


### PR DESCRIPTION
Every six months we have to patch a stable branch twice (once for core, once for Ansible) major releases. Updating the logic here so it's easier to patch the separate release versions in the stable branch at release time(s)