### PR TITLE
Update to sphinx-rtd-theme v2 to fix 404 pages

### DIFF
--- a/tests/constraints-base.in
+++ b/tests/constraints-base.in
@@ -1,3 +1,4 @@
 # Known limitations for indirect/transitive dependencies.
 
 rstcheck < 6  # rstcheck 6.x has problem with rstcheck.core triggered by include files w/ sphinx directives https://github.com/rstcheck/rstcheck-core/issues/3
+sphinx-rtd-theme>=2.0.0rc4  # Fix 404 pages with new sphinx -- https://github.com/ansible/ansible-documentation/issues/678

--- a/tests/requirements-relaxed.txt
+++ b/tests/requirements-relaxed.txt
@@ -136,8 +136,10 @@ sphinx-intl==2.1.0
     # via -r tests/requirements-relaxed.in
 sphinx-notfound-page==1.0.0
     # via -r tests/requirements-relaxed.in
-sphinx-rtd-theme==1.3.0
-    # via sphinx-ansible-theme
+sphinx-rtd-theme==2.0.0rc4
+    # via
+    #   -c tests/constraints-base.in
+    #   sphinx-ansible-theme
 sphinxcontrib-applehelp==1.0.7
     # via sphinx
 sphinxcontrib-devhelp==1.0.5

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -139,8 +139,10 @@ sphinx-intl==2.1.0
     # via -r tests/requirements-relaxed.in
 sphinx-notfound-page==1.0.0
     # via -r tests/requirements-relaxed.in
-sphinx-rtd-theme==1.3.0
-    # via sphinx-ansible-theme
+sphinx-rtd-theme==2.0.0rc4
+    # via
+    #   -c tests/constraints-base.in
+    #   sphinx-ansible-theme
 sphinxcontrib-applehelp==1.0.7
     # via sphinx
 sphinxcontrib-devhelp==1.0.5


### PR DESCRIPTION
Relates: https://github.com/ansible/ansible-documentation/issues/678

---

This along with https://github.com/ansible/ansible-documentation/pull/827 should fix https://github.com/ansible/ansible-documentation/issues/678.