### PR TITLE
[stable-2.16] Downgrade sphinx and fix 404 pages

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -333,15 +333,10 @@ htmlhelp_basename = 'Poseidodoc'
 # with no 'notfound_template' and no 'notfound_context' set,
 # the extension builds 404.rst into a location-agnostic 404 page
 #
-# default is `en` - using this for the sub-site:
-notfound_default_language = "ansible"
-# default is `latest`:
 # setting explicitly - docsite serves up /ansible/latest/404.html
 # so keep this set to `latest` even on the `devel` branch
 # then no maintenance is needed when we branch a new stable_x.x
-notfound_default_version = "latest"
-# makes default setting explicit:
-notfound_no_urls_prefix = False
+notfound_urls_prefix = "/ansible/latest/"
 
 # Options for LaTeX output
 # ------------------------

--- a/tests/constraints-base.in
+++ b/tests/constraints-base.in
@@ -1,3 +1,4 @@
 # Known limitations for indirect/transitive dependencies.
 
 rstcheck < 6  # rstcheck 6.x has problem with rstcheck.core triggered by include files w/ sphinx directives https://github.com/rstcheck/rstcheck-core/issues/3
+sphinx < 7.2  # sphinx >= 7.2 breaks for 404 pages. -- https://github.com/ansible/ansible-documentation/issues/678

--- a/tests/constraints.in
+++ b/tests/constraints.in
@@ -1,5 +1,5 @@
 # This constraints file contains pins for the stable, tested versions of sphinx
 # and antsibull-docs that production builds rely upon.
 
-sphinx == 7.2.5
+sphinx == 7.1.2
 antsibull-docs == 2.5.0  # currently approved version

--- a/tests/requirements-relaxed.txt
+++ b/tests/requirements-relaxed.txt
@@ -113,8 +113,9 @@ six==1.16.0
     # via twiggy
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==7.2.5
+sphinx==7.1.2
     # via
+    #   -c tests/constraints-base.in
     #   -r tests/requirements-relaxed.in
     #   antsibull-docs
     #   sphinx-ansible-theme

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -115,8 +115,9 @@ six==1.16.0
     # via twiggy
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==7.2.5
+sphinx==7.1.2
     # via
+    #   -c tests/constraints-base.in
     #   -c tests/constraints.in
     #   -r tests/requirements-relaxed.in
     #   antsibull-docs


### PR DESCRIPTION
Relates: https://github.com/ansible/ansible-documentation/issues/678