### PR TITLE
installation_distros.rst: fix RST hyperlink syntax

### DIFF
--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -69,7 +69,7 @@ Installing Ansible on OpenSUSE Tumbleweed/Leap
 
     $ sudo zypper install ansible
     
-See `OpenSUSE Support Portal <https://en.opensuse.org/Portal:Support>` for additional help with Ansible on OpenSUSE.
+See `OpenSUSE Support Portal <https://en.opensuse.org/Portal:Support>`_ for additional help with Ansible on OpenSUSE.
 
 .. _from_apt:
 


### PR DESCRIPTION
The link to OpenSUSE Support Portal was broken.
