### PR TITLE
collection_requirements: add meta/execution-environments.yml

### DIFF
--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -156,6 +156,7 @@ Your collection repository MUST have a ``README.md`` in the root of the collecti
 
 meta/runtime.yml
 ----------------
+
 Example: `meta/runtime.yml <https://github.com/ansible-collections/collection_template/blob/main/meta/runtime.yml>`_
 
 * The ``meta/runtime.yml`` MUST define the minimum version of Ansible which this collection works with.
@@ -164,6 +165,16 @@ Example: `meta/runtime.yml <https://github.com/ansible-collections/collection_te
   * It is usually better to avoid adding `<2.11` as a restriction, since this for example makes it impossible to use the collection with the current ansible-base devel branch (which has version 2.11.0.dev0)
 
 .. _coll_module-reqs:
+
+requirements.txt
+----------------
+
+If a collection has controler-side Python package requirements, to allow easy `execution environment <https://ansible.readthedocs.io/en/latest/getting_started_ee/index.html>`_ building, they MUST be listed in the ``requirements.txt`` file in the collection's root directory.
+
+bindep.txt
+----------
+
+If a collection has controller-side system package requirements, to allow easy `execution environment <https://ansible.readthedocs.io/en/latest/getting_started_ee/index.html>`_ building, they MUST be listed in the ``bindep.txt`` file in the collection's root directory.
 
 Modules & Plugins
 ------------------

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -166,15 +166,10 @@ Example: `meta/runtime.yml <https://github.com/ansible-collections/collection_te
 
 .. _coll_module-reqs:
 
-requirements.txt
-----------------
+meta/execution-environment.yml
+------------------------------
 
-If a collection has controler-side Python package requirements, to allow easy `execution environment <https://ansible.readthedocs.io/en/latest/getting_started_ee/index.html>`_ building, they MUST be listed in the ``requirements.txt`` file in the collection's root directory.
-
-bindep.txt
-----------
-
-If a collection has controller-side system package requirements, to allow easy `execution environment <https://ansible.readthedocs.io/en/latest/getting_started_ee/index.html>`_ building, they MUST be listed in the ``bindep.txt`` file in the collection's root directory.
+If a collection has controller-side Python package and/or system package requirements, to allow easy `execution environment <https://ansible.readthedocs.io/en/latest/getting_started_ee/index.html>`_ building, they SHOULD be listed in the ``meta/execution-environment.yml`` and `verified <https://ansible.readthedocs.io/projects/builder/en/latest/collection_metadata/#when-installing-collections-using-ansible-galaxy>`_.
 
 Modules & Plugins
 ------------------

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -169,7 +169,9 @@ Example: `meta/runtime.yml <https://github.com/ansible-collections/collection_te
 meta/execution-environment.yml
 ------------------------------
 
-If a collection has controller-side Python package and/or system package requirements, to allow easy `execution environment <https://ansible.readthedocs.io/en/latest/getting_started_ee/index.html>`_ building, they SHOULD be listed in the ``meta/execution-environment.yml`` and `verified <https://ansible.readthedocs.io/projects/builder/en/latest/collection_metadata/#when-installing-collections-using-ansible-galaxy>`_.
+If a collection has controller-side Python package and/or system package requirements, to allow easy `execution environment <https://ansible.readthedocs.io/en/latest/getting_started_ee/index.html>`_ building, they SHOULD be listed in corresponding files under the ``meta`` directory, specified in ``meta/execution-environment.yml``, and `verified <https://ansible.readthedocs.io/projects/builder/en/latest/collection_metadata/#when-installing-collections-using-ansible-galaxy>`_.
+
+See the `collection_template/meta <https://github.com/ansible-collections/collection_template/tree/main/meta>` directory content as an example.
 
 Modules & Plugins
 ------------------

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -171,7 +171,7 @@ meta/execution-environment.yml
 
 If a collection has controller-side Python package and/or system package requirements, to allow easy `execution environment <https://ansible.readthedocs.io/en/latest/getting_started_ee/index.html>`_ building, they SHOULD be listed in corresponding files under the ``meta`` directory, specified in ``meta/execution-environment.yml``, and `verified <https://ansible.readthedocs.io/projects/builder/en/latest/collection_metadata/#when-installing-collections-using-ansible-galaxy>`_.
 
-See the `collection_template/meta <https://github.com/ansible-collections/collection_template/tree/main/meta>` directory content as an example.
+See the `Collection-level dependencies guide <https://ansible.readthedocs.io/projects/builder/en/latest/collection_metadata/#collection-level-dependencies>`_ for more information and `collection_template/meta <https://github.com/ansible-collections/collection_template/tree/main/meta>` directory content as an example.
 
 Modules & Plugins
 ------------------


### PR DESCRIPTION
It's not hard to list controller-node requirements in two files but it'd make EE users' life much easier

- [ ] If approved by SC, after merging also update https://github.com/ansible-collections/overview/blob/main/collection_checklist.md

Discussion: https://forum.ansible.com/t/collection-inclusion-requirements-add-requirements-txt-and-bindep-txt/2611/