### PR TITLE
add support for Ansible 9 intersphinx links

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -395,19 +395,19 @@ intersphinx_mapping = {
     'python3': ('https://docs.python.org/3/', None, None),
     'jinja2': ('http://jinja.palletsprojects.com/', None, None),
     'ansible_2_9': ('https://docs.ansible.com/ansible/2.9/', None, None),
-    'ansible_8': ('https://docs.ansible.com/ansible/8/', None, None),
+    'ansible_9': ('https://docs.ansible.com/ansible/9/', None, None),
 } if tags.has('all') else {
     'python': ('https://docs.python.org/2/', None, None),
     'python3': ('https://docs.python.org/3/', None, None),
     'jinja2': ('http://jinja.palletsprojects.com/', None, None),
     'ansible_2_9': ('https://docs.ansible.com/ansible/2.9/', None, None),
-    'ansible_8': ('https://docs.ansible.com/ansible/8/', None, None),
+    'ansible_9': ('https://docs.ansible.com/ansible/8/', None, None),
 } if tags.has('core_lang') else {
     'python': ('https://docs.python.org/2/', (None, None)),
     'python3': ('https://docs.python.org/3/', (None, None)),
     'jinja2': ('http://jinja.palletsprojects.com/', (None, None)),
     'ansible_2_9': ('https://docs.ansible.com/ansible/2.9/', (None, None)),
-    'ansible_8': ('https://docs.ansible.com/ansible/8/', (None, None)),
+    'ansible_9': ('https://docs.ansible.com/ansible/8/', (None, None)),
 } if tags.has('core') else {
     'python': ('https://docs.python.org/2/', (None, '../python2.inv')),
     'python3': ('https://docs.python.org/3/', (None, '../python3.inv')),
@@ -423,7 +423,7 @@ intersphinx_mapping = {
     'python3': ('https://docs.python.org/3/', None, None),
     'jinja2': ('http://jinja.palletsprojects.com/', None, None),
     'ansible_2_9': ('https://docs.ansible.com/ansible/2.9/', None, None),
-    'ansible_8': ('https://docs.ansible.com/ansible/8/', None, None),
+    'ansible_9': ('https://docs.ansible.com/ansible/8/', None, None),
 } if tags.has('ansible') else {}
 
 # linckchecker settings

--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -401,13 +401,13 @@ intersphinx_mapping = {
     'python3': ('https://docs.python.org/3/', None, None),
     'jinja2': ('http://jinja.palletsprojects.com/', None, None),
     'ansible_2_9': ('https://docs.ansible.com/ansible/2.9/', None, None),
-    'ansible_9': ('https://docs.ansible.com/ansible/8/', None, None),
+    'ansible_9': ('https://docs.ansible.com/ansible/9/', None, None),
 } if tags.has('core_lang') else {
     'python': ('https://docs.python.org/2/', (None, None)),
     'python3': ('https://docs.python.org/3/', (None, None)),
     'jinja2': ('http://jinja.palletsprojects.com/', (None, None)),
     'ansible_2_9': ('https://docs.ansible.com/ansible/2.9/', (None, None)),
-    'ansible_9': ('https://docs.ansible.com/ansible/8/', (None, None)),
+    'ansible_9': ('https://docs.ansible.com/ansible/9/', (None, None)),
 } if tags.has('core') else {
     'python': ('https://docs.python.org/2/', (None, '../python2.inv')),
     'python3': ('https://docs.python.org/3/', (None, '../python3.inv')),
@@ -423,7 +423,7 @@ intersphinx_mapping = {
     'python3': ('https://docs.python.org/3/', None, None),
     'jinja2': ('http://jinja.palletsprojects.com/', None, None),
     'ansible_2_9': ('https://docs.ansible.com/ansible/2.9/', None, None),
-    'ansible_9': ('https://docs.ansible.com/ansible/8/', None, None),
+    'ansible_9': ('https://docs.ansible.com/ansible/9/', None, None),
 } if tags.has('ansible') else {}
 
 # linckchecker settings


### PR DESCRIPTION
Part of https://github.com/ansible/ansible-documentation/issues/428

Replaces ansible 8 with ansible 9 in the conf.py for intersphinx links.