### PR TITLE
nox pip-compile: allow passing --no-upgrade flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,7 @@ Use the following `nox` session to update the dependency lock files in `tests/`.
   nox -e pip-compile
   ```
 
-To ensure that the dependency lock files are in sync with the base requirements
-files but not upgrade transitive dependencies, use the `--no-upgrade` flag:
+To synchronize dependency lock files with base requirements files without changing transitive dependencies, use the `--no-upgrade` flag:
 
   ``` bash
   nox -e pip-compile -- --no-upgrade

--- a/README.md
+++ b/README.md
@@ -107,6 +107,13 @@ Use the following `nox` session to update the dependency lock files in `tests/`.
   nox -e pip-compile
   ```
 
+To ensure that the dependency lock files are in sync with the base requirements
+files but not upgrade transitive dependencies, use the `--no-upgrade` flag:
+
+  ``` bash
+  nox -e pip-compile -- --no-upgrade
+  ```
+
 > This session requires Python 3.10.
 
 If you do not have Python 3.10 installed, you can use root-less podman with a Python 3.10 image as follows:

--- a/noxfile.py
+++ b/noxfile.py
@@ -95,7 +95,7 @@ def pip_compile(session: nox.Session, req: str):
     # Use --upgrade by default unless a user passes -P.
     args = list(session.posargs)
     if not any(
-        arg.startswith("-P") or arg.startswith("--upgrade-package") for arg in args
+        arg.startswith(("-P", "--upgrade-package", "--no-upgrade")) for arg in args
     ):
         args.append("--upgrade")
 


### PR DESCRIPTION
This allows running `nox -e pip-compile -- --no-upgrade` to make sure
that the requirements.txt files are in sync with the .in files but not
updating any other transitive dependency.
