### PR TITLE
Update windows_winrm.rst

### DIFF
--- a/docs/docsite/rst/os_guide/windows_winrm.rst
+++ b/docs/docsite/rst/os_guide/windows_winrm.rst
@@ -359,8 +359,11 @@ Some system dependencies that must be installed prior to using Kerberos. The scr
     # Through DNF (RHEL/Centos/Fedora for the newer version)
     dnf -y install gcc python3-devel krb5-devel krb5-libs krb5-workstation
 
-    # Through Apt (Ubuntu)
+    # Through Apt (Ubuntu older than 20.04 LTS (focal)) 
     sudo apt-get install python-dev libkrb5-dev krb5-user
+
+    # Through Apt (Ubuntu newer than 20.04 LTS)
+    sudo apt-get install libkrb5-dev krb5-user
 
     # Through Portage (Gentoo)
     emerge -av app-crypt/mit-krb5

--- a/docs/docsite/rst/os_guide/windows_winrm.rst
+++ b/docs/docsite/rst/os_guide/windows_winrm.rst
@@ -363,7 +363,7 @@ Some system dependencies that must be installed prior to using Kerberos. The scr
     sudo apt-get install python-dev libkrb5-dev krb5-user
 
     # Through Apt (Ubuntu newer than 20.04 LTS)
-    sudo apt-get install libkrb5-dev krb5-user
+    sudo apt-get install python3-dev libkrb5-dev krb5-user
 
     # Through Portage (Gentoo)
     emerge -av app-crypt/mit-krb5


### PR DESCRIPTION
Starting with the Debian 11 (bullseye) and Ubuntu 20.04 LTS (focal) releases, all python packages use explicit python3 or python2 interpreter. 

Package python-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  python2-dev python2 python-dev-is-python3

E: Package 'python-dev' has no installation candidate


https://unix.stackexchange.com/questions/708493/python-dev-package-installation-error

https://packages.debian.org/bullseye/python-dev-is-python2
