### PR TITLE
documentation_contributions: show how to set up a venv and remove outdated notes

### DIFF
--- a/docs/docsite/rst/community/documentation_contributions.rst
+++ b/docs/docsite/rst/community/documentation_contributions.rst
@@ -92,7 +92,7 @@ To work with documentation on your local machine, you should use a version of Py
 For more information on minimum Python versions, see the :ref:`support matrix <support_life>`.
 
 
-#. Set up a virtual environment in which to install the dependencies
+#. Set up a virtual environment in which to install dependencies.
 
    .. code-block:: bash
 

--- a/docs/docsite/rst/community/documentation_contributions.rst
+++ b/docs/docsite/rst/community/documentation_contributions.rst
@@ -97,7 +97,7 @@ For more information on minimum Python versions, see the :ref:`support matrix <s
    .. code-block:: bash
 
       python3 -m venv ./venv
-      . ./venv/bin/activate
+      source ./venv/bin/activate
 
 #. Clone required parts of Ansible Core for the docs build.
 

--- a/docs/docsite/rst/community/documentation_contributions.rst
+++ b/docs/docsite/rst/community/documentation_contributions.rst
@@ -113,21 +113,6 @@ For more information on minimum Python versions, see the :ref:`support matrix <s
     pip install -r tests/requirements.in # Installs the unpinned dependency versions.
     pip install -r tests/requirements-relaxed.in # Installs the unpinned dependency versions including untested antsibull-docs.
 
-.. note::
-
-    You may need to install these general pre-requisites separately on some systems:
-    - ``gcc``
-    - ``libyaml``
-    - ``make``
-    - ``pyparsing``
-    - ``wheel``
-    - ``six``
-    On macOS with Xcode, you may need to install ``six`` and ``pyparsing`` with ``--ignore-installed`` to get versions that work with ``sphinx``.
-
-.. note::
-
-  	After checking out ``ansible/ansible-documentation``, make sure the ``docs/docsite/rst`` directory has strict enough permissions. It should only be writable by the owner's account. If your default ``umask`` is not 022, you can use ``chmod go-w docs/docsite/rst`` to set the permissions correctly in your new branch.  Optionally, you can set your ``umask`` to 022 to make all newly created files on your system (including those created by ``git clone``) have the correct permissions.
-
 .. _testing_documentation_locally:
 
 Testing the documentation locally

--- a/docs/docsite/rst/community/documentation_contributions.rst
+++ b/docs/docsite/rst/community/documentation_contributions.rst
@@ -91,13 +91,13 @@ To build documentation locally, ensure you have a working :ref:`development envi
 To work with documentation on your local machine, you should use a version of Python that meets the minimum requirement for ``ansible-core``.
 For more information on minimum Python versions, see the :ref:`support matrix <support_life>`.
 
-Drop the ``--user`` option in the following commands if you use a virtual environment (venv/virtenv).
 
-#. Upgrade pip before installing dependencies (recommended).
+#. Set up a virtual environment in which to install the dependencies
 
    .. code-block:: bash
 
-      pip install --user --upgrade pip
+      python3 -m venv ./venv
+      . ./venv/bin/activate
 
 #. Clone required parts of Ansible Core for the docs build.
 
@@ -109,9 +109,9 @@ Drop the ``--user`` option in the following commands if you use a virtual enviro
 
    .. code-block:: bash
 
-    pip install --user -r tests/requirements.in -c tests/requirements.txt # Installs tested dependency versions.
-    pip install --user -r tests/requirements.in # Installs the unpinned dependency versions.
-    pip install --user -r tests/requirements-relaxed.in # Installs the unpinned dependency versions including untested antsibull-docs.
+    pip install -r tests/requirements.in -c tests/requirements.txt # Installs tested dependency versions.
+    pip install -r tests/requirements.in # Installs the unpinned dependency versions.
+    pip install -r tests/requirements-relaxed.in # Installs the unpinned dependency versions including untested antsibull-docs.
 
 .. note::
 


### PR DESCRIPTION
This includes some updates to the documentation_contributions doc that were split out from https://github.com/ansible/ansible-documentation/pull/707. See this PR's commit messages for more details.