### PR TITLE
remove outdated ansible/community links

### DIFF
--- a/docs/docsite/rst/community/collection_contributors/collection_release_with_branches.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_release_with_branches.rst
@@ -150,7 +150,7 @@ Publishing the collection
 
 4. Add a GitHub release for the new tag. The title should be the version and content, such as -  ``See https://github.com/ansible-collections/community.xxx/blob/stable-X/CHANGELOG.rst for all changes``.
 
-5. Announce the release through the `Bullhorn Newsletter <https://github.com/ansible/community/wiki/News#the-bullhorn>`_.
+5. Announce the release through the `Bullhorn Newsletter <https://forum.ansible.com/c/news/bullhorn/17>`_.
 
 6. Announce the release in the pinned release issue/community pinboard of the collection and in the ``#ansible-community`` `Matrix/Libera.Chat IRC channel <https://docs.ansible.com/ansible/devel/community/communication.html#real-time-chat>`_.
 
@@ -205,7 +205,7 @@ Publishing the collection
 
 3. Add a GitHub release for the new tag. The title should be the version and content, such as -  ``See https://github.com/ansible-collections/community.xxx/blob/stable-X/CHANGELOG.rst for all changes``.
 
-4. Announce the release through the `Bullhorn Newsletter <https://github.com/ansible/community/wiki/News#the-bullhorn>`_.
+4. Announce the release through the `Bullhorn Newsletter <https://forum.ansible.com/c/news/bullhorn/17>`_.
 
 5. Announce the release in the pinned release issue/community pinboard of the collection and in the ``#ansible-community`` `Matrix/IRC channel <https://docs.ansible.com/ansible/devel/community/communication.html#real-time-chat>`_. Additionally, you can announce it using GitHub's Releases system.
 
@@ -289,7 +289,7 @@ Releasing when more minor versions are expected
     This is deliberate, since the next minor release ``X.(Y+1).0`` already contains the changes for ``X.Y.Z`` as well since these were cherry-picked from ``stable-X``.
 
 
-4. Announce the release through the `Bullhorn Newsletter <https://github.com/ansible/community/wiki/News#the-bullhorn>`_.
+4. Announce the release through the `Bullhorn Newsletter <https://forum.ansible.com/c/news/bullhorn/17>`_.
 
 5. Announce the release in the pinned release issue/community pinboard of the collection and in the ``#ansible-community`` `Matrix/IRC channel <https://docs.ansible.com/ansible/devel/community/communication.html#real-time-chat>`.
 
@@ -336,6 +336,6 @@ Releasing when no more minor versions are expected
 
 3. Add a GitHub release for the new tag. Title should be the version and content, such as: ``See https://github.com/ansible-collections/community.xxx/blob/stable-X/CHANGELOG.rst for all changes``.
 
-4. Announce the release through the `Bullhorn Newsletter <https://github.com/ansible/community/wiki/News#the-bullhorn>`_.
+4. Announce the release through the `Bullhorn Newsletter <https://forum.ansible.com/c/news/bullhorn/17>`_.
 
 5. Announce the release in the pinned issue/community pinboard of the collection and in the ``#ansible-community`` `Matrix/IRC channel <https://docs.ansible.com/ansible/devel/community/communication.html#real-time-chat>`_.

--- a/docs/docsite/rst/community/collection_contributors/collection_release_without_branches.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_release_without_branches.rst
@@ -110,6 +110,6 @@ Publish the collection
 
 4. Add a GitHub release for the new tag. Title should be the version and content ``See https://github.com/ansible-collections/community.xxx/blob/main/CHANGELOG.rst for all changes``.
 
-5. Announce the release through the `Bullhorn Newsletter issue <https://github.com/ansible/community/wiki/News#the-bullhorn>`_.
+5. Announce the release through the `Bullhorn Newsletter issue <https://forum.ansible.com/c/news/bullhorn/17>`_.
 
 6. Announce the release in the pinned release issue/community pinboard of the collection mentioned in step 3 and in the ``community`` :ref:`Matrix/IRC channel <communication_irc>`.

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -31,7 +31,7 @@ Feedback and communications
 As with any project it is very important that we get feedback from users, contributors, and maintainers. You can get feedback and help as follows:
 
 * Discussing in the `#community:ansible.com Matrix room <https://matrix.to/#/#community:ansible.com>`_, which is bridged with the ``#ansible-community`` channel on Libera.Chat IRC. See the :ref:`Ansible Communication Guide <communication_irc>` for details.
-* Discussing in the `Community Working Group meeting <https://github.com/ansible/community/blob/main/meetings/README.md#wednesdays>`_.
+* Discussing in the `Community Working Group meeting <https://github.com/ansible-community/meetings/blob/main/README.md#wednesdays>`_.
 * Creating `GitHub Issues <https://github.com/ansible-collections/overview/issues>`_ in the ``ansible-collections`` repository.
 
 Keeping informed
@@ -40,7 +40,7 @@ Keeping informed
 You should subscribe to:
 
 * The `news-for-maintainers repository <https://github.com/ansible-collections/news-for-maintainers>`_ to track changes that collection maintainers should be aware of. Subscribe only to issues if you want less traffic.
-* The `Bullhorn <https://github.com/ansible/community/wiki/News#the-bullhorn>`_ Ansible contributor newsletter.
+* The `Bullhorn <https://forum.ansible.com/c/news/bullhorn/17>`_ Ansible contributor newsletter.
 
 .. _coll_infrastructure_reqs:
 

--- a/docs/docsite/rst/community/collection_development_process.rst
+++ b/docs/docsite/rst/community/collection_development_process.rst
@@ -19,7 +19,7 @@ If you want to follow the conversation about what features will be added to the 
 
 * the :ref:`roadmaps`
 * the :ref:`Ansible Release Schedule <release_and_maintenance>`
-* the `Ansible Community Working Group <https://github.com/ansible/community/wiki/Community>`_ .
+* the `Ansible Community Working Group <https://forum.ansible.com/tags/c/project/7/community-wg>`_ .
 
 Micro development: the lifecycle of a PR
 ========================================

--- a/docs/docsite/rst/community/contributing_maintained_collections.rst
+++ b/docs/docsite/rst/community/contributing_maintained_collections.rst
@@ -66,7 +66,7 @@ The following table shows:
     <tr>
       <td><a href="https://galaxy.ansible.com/amazon/aws">amazon.aws</a></td>
       <td><a href="https://galaxy.ansible.com/community/aws">community.aws</a></td>
-      <td><a href="https://github.com/ansible/community/tree/main/group-aws">AWS</a></td>
+      <td><a href="https://forum.ansible.com/g/AWS">AWS</a></td>
       <td>✓**</td>
       <td>**</td>
       <td>✓</td>
@@ -77,7 +77,7 @@ The following table shows:
     <tr>
       <td><a href="https://galaxy.ansible.com/ansible/netcommon">ansible.netcommon***</a></td>
       <td><a href="https://galaxy.ansible.com/community/network">community.network</a></td>
-      <td><a href="https://github.com/ansible/community/wiki/Network">Network</a></td>
+      <td><a href="https://forum.ansible.com/g/network-wg">Network</a></td>
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>
@@ -99,7 +99,7 @@ The following table shows:
     <tr>
       <td><a href="https://galaxy.ansible.com/ansible/windows">ansible.windows</a></td>
       <td><a href="https://galaxy.ansible.com/community/windows">community.windows</a></td>
-      <td><a href="https://github.com/ansible/community/wiki/Windows">Windows</a></td>
+      <td><a href="https://matrix.to:/#/#windows:ansible.com">Windows</a></td>
       <td>✓</td>
       <td>✓****</td>
       <td>✓</td>
@@ -110,7 +110,7 @@ The following table shows:
     <tr>
       <td><a href="https://galaxy.ansible.com/arista/eos">arista.eos</a></td>
       <td><a href="https://galaxy.ansible.com/community/network">community.network</a></td>
-      <td><a href="https://github.com/ansible/community/wiki/Network">Network</a></td>
+      <td><a href="https://forum.ansible.com/g/network-wg">Network</a></td>
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>
@@ -121,7 +121,7 @@ The following table shows:
     <tr>
       <td><a href="https://galaxy.ansible.com/cisco/asa">cisco.asa</a></td>
       <td><a href="https://github.com/ansible-collections/community.asa">community.asa</a></td>
-      <td><a href="https://github.com/ansible/community/wiki/Security-Automation">Security</a></td>
+      <td><a href="https://matrix.to/#/#security-automation:ansible.com">Security</a></td>
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>
@@ -132,7 +132,7 @@ The following table shows:
     <tr>
       <td><a href="https://galaxy.ansible.com/cisco/ios">cisco.ios</a></td>
       <td><a href="https://galaxy.ansible.com/community/network">community.network</a></td>
-      <td><a href="https://github.com/ansible/community/wiki/Network">Network</a></td>
+      <td><a href="https://forum.ansible.com/g/network-wg">Network</a></td>
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>
@@ -143,7 +143,7 @@ The following table shows:
     <tr>
       <td><a href="https://galaxy.ansible.com/cisco/iosxr">cisco.iosxr</a></td>
       <td><a href="https://galaxy.ansible.com/community/network">community.network</a></td>
-      <td><a href="https://github.com/ansible/community/wiki/Network">Network</a></td>
+      <td><a href="https://forum.ansible.com/g/network-wg">Network</a></td>
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>
@@ -154,7 +154,7 @@ The following table shows:
     <tr>
       <td><a href="https://galaxy.ansible.com/cisco/nxos">cisco.nxos</a></td>
       <td><a href="https://galaxy.ansible.com/community/network">community.network</a></td>
-      <td><a href="https://github.com/ansible/community/wiki/Network">Network</a></td>
+      <td><a href="https://forum.ansible.com/g/network-wg">Network</a></td>
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>
@@ -165,7 +165,7 @@ The following table shows:
     <tr>
       <td><a href="https://galaxy.ansible.com/ibm/qradar">ibm.qradar</a></td>
       <td><a href="https://github.com/ansible-collections/community.qradar">community.qradar</a></td>
-      <td><a href="https://github.com/ansible/community/wiki/Security-Automation">Security</a></td>
+      <td><a href="https://matrix.to/#/#security-automation:ansible.com">Security</a></td>
       <td>✓</td>
       <td></td>
       <td>✓</td>
@@ -176,7 +176,7 @@ The following table shows:
     <tr>
       <td><a href="https://galaxy.ansible.com/junipernetworks/junos">junipernetworks.junos</a></td>
       <td><a href="https://galaxy.ansible.com/community/network">community.network</a></td>
-      <td><a href="https://github.com/ansible/community/wiki/Network">Network</a></td>
+      <td><a href="https://forum.ansible.com/g/network-wg">Network</a></td>
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>
@@ -187,7 +187,7 @@ The following table shows:
     <tr>
       <td><a href="https://galaxy.ansible.com/kubernetes/core">kubernetes.core</a></td>
       <td><a href="https://galaxy.ansible.com/kubernetes/core">kubernetes.core</a></td>
-      <td><a href="https://github.com/ansible/community/wiki/Kubernetes">Kubernetes</a></td>
+      <td><a href="https://matrix.to:/#/#kubernetes:ansible.com">Kubernetes</a></td>
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>
@@ -198,7 +198,7 @@ The following table shows:
     <tr>
       <td><a href="https://cloud.redhat.com/ansible/automation-hub/redhat/openshift">redhat.openshift</a></td>
       <td><a href="https://galaxy.ansible.com/community/okd">community.okd</a></td>
-      <td><a href="https://github.com/ansible/community/wiki/Kubernetes">Kubernetes</a></td>
+      <td><a href="https://matrix.to:/#/#kubernetes:ansible.com">Kubernetes</a></td>
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>
@@ -208,7 +208,7 @@ The following table shows:
     <tr>
       <td><a href="https://galaxy.ansible.com/openvswitch/openvswitch">openvswitch.openvswitch</a></td>
       <td><a href="https://galaxy.ansible.com/community/network">community.network</a></td>
-      <td><a href="https://github.com/ansible/community/wiki/Network">Network</a></td>
+      <td><a href="https://forum.ansible.com/g/network-wg">Network</a></td>
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>
@@ -219,7 +219,7 @@ The following table shows:
     <tr>
       <td><a href="https://github.com/ansible-collections/splunk.es">splunk.es</a></td>
       <td><a href="https://github.com/ansible-collections/community.es">community.es</a></td>
-      <td><a href="https://github.com/ansible/community/wiki/Security-Automation">Security</a></td>
+      <td><a href="https://matrix.to/#/#security-automation:ansible.com">Security</a></td>
       <td>✓</td>
       <td></td>
       <td>✓</td>
@@ -230,7 +230,7 @@ The following table shows:
     <tr>
       <td><a href="https://galaxy.ansible.com/vyos/vyos">vyos.vyos</a></td>
       <td><a href="https://galaxy.ansible.com/community/network">community.network</a></td>
-      <td><a href="https://github.com/ansible/community/wiki/Network">Network</a></td>
+      <td><a href="https://forum.ansible.com/g/network-wg">Network</a></td>
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>
@@ -241,7 +241,7 @@ The following table shows:
     <tr>
       <td><a href="https://galaxy.ansible.com/vmware/vmware_rest">vmware.vmware_rest</a></td>
       <td><a href="https://galaxy.ansible.com/vmware/vmware_rest">vmware.vmware_rest</a></td>
-      <td><a href="https://github.com/ansible/community/wiki/VMware">VMware</a></td>
+      <td><a href="https://matrix.to:/#/#vmware:ansible.com">VMware</a></td>
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>

--- a/docs/docsite/rst/community/contributor_path.rst
+++ b/docs/docsite/rst/community/contributor_path.rst
@@ -111,4 +111,4 @@ To reach the status, as the current Committee members did before getting it, alo
 
 * Subscribe to, comment on, and vote on the `Community Topics <https://github.com/ansible-community/community-topics/issues>`_.
 * Propose your topics.
-* If time permits, join the `Community meetings <https://github.com/ansible/community/blob/main/meetings/README.md#schedule>`_. Note this is **NOT** a requirement.
+* If time permits, join the `Community meetings <https://github.com/ansible-community/meetings/blob/main/README.md#schedule>`_. Note this is **NOT** a requirement.

--- a/docs/docsite/rst/community/documentation_contributions.rst
+++ b/docs/docsite/rst/community/documentation_contributions.rst
@@ -231,7 +231,7 @@ It is recommended to run tests on a clean copy of the repository, which is the p
 Joining the documentation working group
 =======================================
 
-The Documentation Working Group (DaWGs) meets weekly on Tuesdays in the Docs chat (using `Matrix <https://matrix.to/#/#docs:ansible.im>`_ or using IRC at `irc.libera.chat <https://libera.chat/>`_). For more information, including links to our agenda and a calendar invite, please visit the `working group page in the community repo <https://github.com/ansible/community/wiki/Docs>`_.
+The Documentation Working Group (DaWGs) meets weekly on Tuesdays in the Docs chat (using `Matrix <https://matrix.to/#/#docs:ansible.im>`_ or using IRC at `irc.libera.chat <https://libera.chat/>`_). For more information, including links to our agenda and a calendar invite, visit our `forum group <https://forum.ansible.com/g/Docs>`_.
 
 .. seealso::
    :ref:`More about testing module documentation <testing_module_documentation>`

--- a/docs/docsite/rst/community/maintainers_guidelines.rst
+++ b/docs/docsite/rst/community/maintainers_guidelines.rst
@@ -34,7 +34,7 @@ How to become a maintainer
 
 A person interested in becoming a maintainer and satisfying the :ref:`requirements<maintainer_requirements>` may either self-nominate or be nominated by another maintainer.
 
-To nominate a candidate, create a GitHub issue in the relevant collection repository. If there is no response, the repository is not actively maintained, or the current maintainers do not have permissions to add the candidate, Create a topic in the `Ansible community forum <https://forum.ansible.com/`_.
+To nominate a candidate, create a GitHub issue in the relevant collection repository. If there is no response, the repository is not actively maintained, or the current maintainers do not have permissions to add the candidate, Create a topic in the `Ansible community forum <https://forum.ansible.com/>`_.
 
 Communicating as a collection maintainer
 -----------------------------------------

--- a/docs/docsite/rst/community/maintainers_guidelines.rst
+++ b/docs/docsite/rst/community/maintainers_guidelines.rst
@@ -23,7 +23,7 @@ In general, collection maintainers:
 - :ref:`Release collections <Releasing>`.
 - Ensure that collections adhere to the :ref:`collections_requirements`.
 - Track changes announced in `News for collection contributors and maintainers <https://github.com/ansible-collections/news-for-maintainers>`_ and update a collection in accordance with these changes.
-- Subscribe and submit news to the  `Bullhorn newsletter <https://github.com/ansible/community/wiki/News#the-bullhorn>`_.
+- Subscribe and submit news to the  `Bullhorn newsletter <https://forum.ansible.com/c/news/bullhorn/17>`_.
 - :ref:`Build a healthy community <expanding_community>` to increase the number of active contributors and maintainers around collections.
 - Revise these guidelines to improve the maintainer experience for yourself and others.
 
@@ -34,12 +34,12 @@ How to become a maintainer
 
 A person interested in becoming a maintainer and satisfying the :ref:`requirements<maintainer_requirements>` may either self-nominate or be nominated by another maintainer.
 
-To nominate a candidate, create a GitHub issue in the relevant collection repository. If there is no response, the repository is not actively maintained, or the current maintainers do not have permissions to add the candidate, please create the issue in the `ansible/community <https://github.com/ansible/community>`_ repository.
+To nominate a candidate, create a GitHub issue in the relevant collection repository. If there is no response, the repository is not actively maintained, or the current maintainers do not have permissions to add the candidate, Create a topic in the `Ansible community forum <https://forum.ansible.com/`_.
 
 Communicating as a collection maintainer
 -----------------------------------------
 
- Maintainers are highly encouraged to subscribe to the `"Changes impacting collection contributors and maintainers" GitHub repo <https://github.com/ansible-collections/news-for-maintainers>`_ and the `Bullhorn newsletter <https://github.com/ansible/community/wiki/News#the-bullhorn>`_. If you have something important to announce through the newsletter (for example, recent releases), see the `Bullhorn's wiki page <https://github.com/ansible/community/wiki/News#the-bullhorn>`_ to learn how.
+ Maintainers are highly encouraged to subscribe to the `"Changes impacting collection contributors and maintainers" GitHub repo <https://github.com/ansible-collections/news-for-maintainers>`_ and the `Bullhorn newsletter <https://forum.ansible.com/c/news/bullhorn/17>`_. If you have something important to announce through the newsletter (for example, recent releases), see the Bullhorn to learn how.
 
 
 Collection contributors and maintainers can also communicate through:
@@ -61,7 +61,7 @@ Project maintainers can use the following techniques to establish communication 
 
 * Find an existing `forum group <https://forum.ansible.com/g>`_ or :ref:`working group<working_group_list>` that is similar to your project and join the conversation.
 * `Request <https://github.com/ansible/community/blob/main/WORKING-GROUPS.md>`_ a new working group for your project.
-* `Create <https://hackmd.io/@ansible-community/community-matrix-faq#How-do-I-create-a-public-community-room>`_ a public chat for your working group or `ask <https://github.com/ansible/community/issues/new>`_ the community team.
+* `Create <https://hackmd.io/@ansible-community/community-matrix-faq#How-do-I-create-a-public-community-room>`_ a public chat for your working group or `ask in the forum for help <https://forum.ansible.com/c/project/7>`_.
 * Provide working group details and links to chat rooms in the contributor section of your project ``README.md``.
 * Encourage contributors to join the forum group and chat.
 
@@ -79,12 +79,12 @@ Share your opinion and vote on the topics to help the community make the best de
 Contributor Summits
 -------------------
 
-The quarterly Ansible Contributor Summit is a global event that provides our contributors a great opportunity to meet each other, communicate, share ideas, and see that there are other real people behind the messages on Matrix or Libera Chat IRC, or GitHub. This gives a sense of community. Watch the `Bullhorn newsletter <https://github.com/ansible/community/wiki/News#the-bullhorn>`_ for information when the next contributor summit, invite contributors you know, and take part in the event together.
+The quarterly Ansible Contributor Summit is a global event that provides our contributors a great opportunity to meet each other, communicate, share ideas, and see that there are other real people behind the messages on Matrix or Libera Chat IRC, or GitHub. This gives a sense of community. Watch the `Bullhorn newsletter <https://forum.ansible.com/c/news/bullhorn/17>`_ for information when the next contributor summit, invite contributors you know, and take part in the event together.
 
 Weekly community Matrix/IRC meetings
 ------------------------------------
 
-The Community and the Steering Committee come together at weekly meetings in the ``#ansible-community`` `Libera.Chat IRC <https://docs.ansible.com/ansible/devel/community/communication.html#ansible-community-on-irc>`_ channel or in the bridged `#community:ansible.com <https://matrix.to/#/#community:ansible.com>`_ room on `Matrix <https://docs.ansible.com/ansible/devel/community/communication.html#ansible-community-on-matrix>`_ to discuss important project questions. Join us! Here is our `schedule <https://github.com/ansible/community/blob/main/meetings/README.md#schedule>`_.
+The Community and the Steering Committee come together at weekly meetings in the ``#ansible-community`` `Libera.Chat IRC <https://docs.ansible.com/ansible/devel/community/communication.html#ansible-community-on-irc>`_ channel or in the bridged `#community:ansible.com <https://matrix.to/#/#community:ansible.com>`_ room on `Matrix <https://docs.ansible.com/ansible/devel/community/communication.html#ansible-community-on-matrix>`_ to discuss important project questions. Join us! Here is our `schedule <https://github.com/ansible-community/meetings/blob/main/README.md#schedule>`_.
 
 Expanding the collection community
 ===================================
@@ -125,7 +125,7 @@ Conduct pull request days regularly. You could plan PR days, for example, on the
 
 Promote active contributors satisfying :ref:`requirements<maintainer_requirements>` to maintainers. Revise contributors' activity regularly.
 
-If your collection found new maintainers, announce that fact in the `Bullhorn newsletter <https://github.com/ansible/community/wiki/News#the-bullhorn>`_ and during the next Contributor Summit congratulating and thanking them for the work done. You can mention all the people promoted since the previous summit. Remember to invite the other maintainers to the Summit in advance.
+If your collection found new maintainers, announce that fact in the `Bullhorn newsletter <https://forum.ansible.com/c/news/bullhorn/17>`_ and during the next Contributor Summit congratulating and thanking them for the work done. You can mention all the people promoted since the previous summit. Remember to invite the other maintainers to the Summit in advance.
 
 Some other general guidelines to encourage contributors:
 

--- a/docs/docsite/rst/community/maintainers_workflow.rst
+++ b/docs/docsite/rst/community/maintainers_workflow.rst
@@ -89,7 +89,7 @@ If you feel you don't have time to maintain your collection anymore, you should:
 - If the collection is under the ``ansible-collections`` organization, also inform relevant :ref:`communication_irc`, the ``community`` chat channels on IRC or matrix, or by email ``ansible-community@redhat.com``.
 - Look at active contributors in the collection to find new maintainers among them. Discuss the potential candidates with other maintainers or with the community team.
 - If you failed to find a replacement, create a pinned issue in the collection, announcing that the collection needs new maintainers.
-- Make the same announcement through the `Bullhorn newsletter <https://github.com/ansible/community/wiki/News#the-bullhorn>`_.
+- Make the same announcement through the `Bullhorn newsletter <https://forum.ansible.com/c/news/bullhorn/17>`_.
 - Please be around to discuss potential candidates found by other maintainers or by the community team.
 
 Remember, this is a community, so you can come back at any time in the future.

--- a/docs/docsite/rst/community/maintainers_workflow.rst
+++ b/docs/docsite/rst/community/maintainers_workflow.rst
@@ -89,7 +89,7 @@ If you feel you don't have time to maintain your collection anymore, you should:
 - If the collection is under the ``ansible-collections`` organization, also inform relevant :ref:`communication_irc`, the ``community`` chat channels on IRC or matrix, or by email ``ansible-community@redhat.com``.
 - Look at active contributors in the collection to find new maintainers among them. Discuss the potential candidates with other maintainers or with the community team.
 - If you failed to find a replacement, create a pinned issue in the collection, announcing that the collection needs new maintainers.
-- Make the same announcement through the `Bullhorn newsletter <https://forum.ansible.com/c/news/bullhorn/17>`_.
+- Make the same announcement through the `Bullhorn newsletter <https://forum.ansible.com/t/about-the-newsletter-category/166>`_.
 - Please be around to discuss potential candidates found by other maintainers or by the community team.
 
 Remember, this is a community, so you can come back at any time in the future.

--- a/docs/docsite/rst/community/steering/community_steering_committee.rst
+++ b/docs/docsite/rst/community/steering/community_steering_committee.rst
@@ -159,7 +159,7 @@ When reviewing community collection `inclusion requests <https://github.com/ansi
   #. Declares the decision in the topic and in the inclusion request.
   #. Moves the request to the ``Resolved reviews`` category.
   #. Adds the collection to the ``ansible.in`` file in a corresponding directory of the `ansible-build-data repository <https://github.com/ansible-community/ansible-build-data>`_.
-  #. Announces the inclusion through the `Bullhorn newsletter <https://github.com/ansible/community/wiki/News#the-bullhorn>`_.
+  #. Announces the inclusion through the `Bullhorn newsletter <https://forum.ansible.com/c/news/bullhorn/17>`_.
   #. Closes the topic.
 
 Community Working Group meetings

--- a/docs/docsite/rst/community/steering/steering_committee_membership.rst
+++ b/docs/docsite/rst/community/steering/steering_committee_membership.rst
@@ -50,7 +50,7 @@ The process to join the Steering Committee consists of the following steps:
 #. Any community member may nominate someone or themselves for Committee membership by contacting one of the :ref:`current Committee members <steering_members>`) or by sending an email to ``ansible-community@redhat.com``.
 #. A Committee member who receives the nomination must inform the Committee about it by forwarding the full message.
 #. The vote is conducted by email. Nominees must receive a majority of votes from the present Committee members to be added to the Committee.
-#. Provided that the vote result is positive, it is announced in the `Bullhorn <https://github.com/ansible/community/wiki/News#the-bullhorn>`_ newsletter and the new member is added to the :ref:`Committee member list <steering_members>`.
+#. Provided that the vote result is positive, it is announced in the `Bullhorn <https://forum.ansible.com/c/news/bullhorn/17>`_ newsletter and the new member is added to the :ref:`Committee member list <steering_members>`.
 
 Leaving the Steering Committee
 -------------------------------

--- a/docs/docsite/rst/dev_guide/developing_modules_in_groups.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_in_groups.rst
@@ -21,7 +21,7 @@ This list of prerequisites is designed to help ensure that you develop high-qual
 * We encourage supporting :ref:`Python 2.6+ and Python 3.5+ <developing_python_3>`.
 * Look at Ansible Galaxy and review the naming conventions in your functional area (such as cloud, networking, databases).
 * With great power comes great responsibility: Ansible collection maintainers have a duty to help keep content up to date and release collections they are responsible for regularly. As with all successful community projects, collection maintainers should keep a watchful eye for reported issues and contributions.
-* We strongly recommend unit and/or integration tests. Unit tests are especially valuable when external resources (such as cloud or network devices) are required. For more information see :ref:`developing_testing` and the `Testing Working Group <https://github.com/ansible/community/blob/main/meetings/README.md>`_.
+* We strongly recommend unit and/or integration tests. Unit tests are especially valuable when external resources (such as cloud or network devices) are required. For more information see :ref:`developing_testing`.
 
 
 Naming conventions
@@ -56,7 +56,7 @@ In the :ref:`ansible_community_guide` you can find how to:
 
 * Subscribe to the Mailing Lists - We suggest "Ansible Development List" and "Ansible Announce list"
 * ``#ansible-devel`` - We have found that communicating on the ``#ansible-devel`` chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_) works best for developers so we can have an interactive dialog.
-* Working group and other chat channel meetings - Join the various weekly meetings `meeting schedule and agenda page <https://github.com/ansible/community/blob/main/meetings/README.md>`_
+* Working group and other chat channel meetings - Join the various weekly meetings `meeting schedule page <https://github.com/ansible-community/meetings/blob/main/README.md>`_
 
 Required files
 ==============

--- a/docs/docsite/rst/dev_guide/testing.rst
+++ b/docs/docsite/rst/dev_guide/testing.rst
@@ -242,4 +242,4 @@ Want to know more about testing?
 ================================
 
 If you'd like to know more about the plans for improving testing Ansible then why not join the
-`Testing Working Group <https://github.com/ansible/community/blob/main/meetings/README.md>`_.
+`Ansible community forum <https://forum.ansible.com/>`_.

--- a/docs/docsite/rst/dev_guide/testing_httptester.rst
+++ b/docs/docsite/rst/dev_guide/testing_httptester.rst
@@ -25,4 +25,5 @@ Source files can be found in the `http-test-container <https://github.com/ansibl
 Extending httptester
 ====================
 
-If you have sometime to improve ``httptester`` please add a comment on the `Testing Working Group Agenda <https://github.com/ansible/community/blob/main/meetings/README.md>`_ to avoid duplicated effort.
+If you have sometime to improve ``httptester``, open an issue in the 
+`http-test-container <https://github.com/ansible/http-test-container>`_ repository.

--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -244,4 +244,5 @@ For guidance on writing network test see :ref:`testing_resource_modules`.
 Where to find out more
 ======================
 
-If you'd like to know more about the plans for improving testing Ansible, join the `Testing Working Group <https://github.com/ansible/community/blob/main/meetings/README.md>`_.
+If you'd like to know more about the plans for improving testing Ansible, join the 
+`Ansible community forum <https://forum.ansible.com/>`_

--- a/docs/docsite/rst/roadmap/COLLECTIONS_9.rst
+++ b/docs/docsite/rst/roadmap/COLLECTIONS_9.rst
@@ -40,7 +40,7 @@ Release schedule
 
 .. [2] After this date only changes blocking a release are accepted. Accepted changes require creating a new release candidate and may slip the final release date.
 
-.. [3] Collections will be updated to a new version only if a blocker is approved. Collection owners should discuss any blockers with a ``community_wg`` forum topic(before this freeze) to decide whether to bump the version of the collection for a fix. See the `Creating a Community working group topic <https://github.com/ansible-community/community-topics/blob/main/community_topics_workflow.md#creating-a-topic>`_ for details.
+.. [3] Collections will be updated to a new version only if a blocker is approved. Collection owners should discuss any blockers with a ``community-wg`` tagged forum topic (before this freeze) to decide whether to bump the version of the collection for a fix. See the `Creating a Community working group topic <https://github.com/ansible-community/community-topics/blob/main/community_topics_workflow.md#creating-a-topic>`_ for details.
 
 .. note::
 

--- a/docs/docsite/rst/roadmap/COLLECTIONS_9.rst
+++ b/docs/docsite/rst/roadmap/COLLECTIONS_9.rst
@@ -40,7 +40,7 @@ Release schedule
 
 .. [2] After this date only changes blocking a release are accepted. Accepted changes require creating a new release candidate and may slip the final release date.
 
-.. [3] Collections will be updated to a new version only if a blocker is approved. Collection owners should discuss any blockers at a community IRC meeting (before this freeze) to decide whether to bump the version of the collection for a fix. See the `Community IRC meeting agenda <https://github.com/ansible/community/issues/539>`_.
+.. [3] Collections will be updated to a new version only if a blocker is approved. Collection owners should discuss any blockers at a Community working group meeting (before this freeze) to decide whether to bump the version of the collection for a fix. See the `Community IRC meeting agenda <https://github.com/ansible/community/issues/645>`_.
 
 .. note::
 

--- a/docs/docsite/rst/roadmap/COLLECTIONS_9.rst
+++ b/docs/docsite/rst/roadmap/COLLECTIONS_9.rst
@@ -40,7 +40,7 @@ Release schedule
 
 .. [2] After this date only changes blocking a release are accepted. Accepted changes require creating a new release candidate and may slip the final release date.
 
-.. [3] Collections will be updated to a new version only if a blocker is approved. Collection owners should discuss any blockers at a Community working group meeting (before this freeze) to decide whether to bump the version of the collection for a fix. See the `Community IRC meeting agenda <https://github.com/ansible/community/issues/645>`_.
+.. [3] Collections will be updated to a new version only if a blocker is approved. Collection owners should discuss any blockers with a ``community_wg`` forum topic(before this freeze) to decide whether to bump the version of the collection for a fix. See the `Creating a Community working group topic <https://github.com/ansible-community/community-topics/blob/main/community_topics_workflow.md#creating-a-topic>`_ for details.
 
 .. note::
 

--- a/docs/docsite/rst/roadmap/ansible_core_roadmap_index.rst
+++ b/docs/docsite/rst/roadmap/ansible_core_roadmap_index.rst
@@ -14,7 +14,6 @@ Each roadmap is published both as an idea of what is upcoming in ``ansible-core`
 
 You can submit feedback on the current roadmap in multiple ways:
 
-- Edit the agenda of an `Core Team Meeting <https://github.com/ansible/community/blob/main/meetings/README.md>`_ (preferred)
 - Post on the ``#ansible-devel`` chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_)
 - Email the ansible-devel list
 


### PR DESCRIPTION
As part of the effort to archive the ansible/community repo, updating urls where we can.

Another PR updates a few more, and some are pending the Community WG moving to the forum so will have to be updated later.