### PR TITLE
[stable-2.14] nox pip-compile: allow passing --no-upgrade flag (#883)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ Use the following `nox` session to update the dependency lock files in `tests/`.
   nox -e pip-compile
   ```
 
+To synchronize dependency lock files with base requirements files without changing transitive dependencies, use the `--no-upgrade` flag:
+
+  ``` bash
+  nox -e pip-compile -- --no-upgrade
+  ```
+
 > This session requires Python 3.10.
 
 If you do not have Python 3.10 installed, you can use root-less podman with a Python 3.10 image as follows:

--- a/noxfile.py
+++ b/noxfile.py
@@ -96,7 +96,7 @@ def pip_compile(session: nox.Session, req: str):
     # Use --upgrade by default unless a user passes -P.
     args = list(session.posargs)
     if not any(
-        arg.startswith("-P") or arg.startswith("--upgrade-package") for arg in args
+        arg.startswith(("-P", "--upgrade-package", "--no-upgrade")) for arg in args
     ):
         args.append("--upgrade")
 


### PR DESCRIPTION
* nox pip-compile: allow passing --no-upgrade flag

This allows running `nox -e pip-compile -- --no-upgrade` to make sure that the requirements.txt files are in sync with the .in files but not updating any other transitive dependency.

* README: make "## Updating dependencies" more concise

Co-authored-by: Don Naro <dnaro@redhat.com>

---------

Co-authored-by: Don Naro <dnaro@redhat.com>
(cherry picked from commit e952dd436561bd801562e8f70e5db44caaa53097)