### PR TITLE
Adds note for more details about variable precedence

### DIFF
--- a/docs/docsite/rst/inventory_guide/intro_inventory.rst
+++ b/docs/docsite/rst/inventory_guide/intro_inventory.rst
@@ -521,9 +521,9 @@ By default, variables are merged/flattened to the specific host before a play is
 - child group
 - host
 
-.. note:: See :ref:`ansible_variable_precedence` for information about merging variables across different sources (for example, `group_vars` in parent groups override inventory variables in child groups).
-
 By default, Ansible merges groups at the same parent/child level in ASCII order, and variables from the last group loaded overwrite variables from the previous groups. For example, an ``a_group`` will be merged with ``b_group`` and ``b_group`` vars that match will overwrite the ones in ``a_group``.
+
+.. note:: Ansible merges variables from different sources and applies precedence to some variables over others according to a set of rules. For example, variables defined in inventory sources that are included later in the list take precedence over variables defined in sources that appeared earlier. See :ref:`ansible_variable_precedence` for more information.
 
 You can change this behavior by setting the group variable ``ansible_group_priority`` to change the merge order for groups of the same level (after the parent/child order is resolved). The larger the number, the later it will be merged, giving it higher priority. This variable defaults to ``1`` if not set. For example:
 

--- a/docs/docsite/rst/inventory_guide/intro_inventory.rst
+++ b/docs/docsite/rst/inventory_guide/intro_inventory.rst
@@ -523,7 +523,7 @@ By default, variables are merged/flattened to the specific host before a play is
 
 By default, Ansible merges groups at the same parent/child level in ASCII order, and variables from the last group loaded overwrite variables from the previous groups. For example, an ``a_group`` will be merged with ``b_group`` and ``b_group`` vars that match will overwrite the ones in ``a_group``.
 
-.. note:: Ansible merges variables from different sources and applies precedence to some variables over others according to a set of rules. For example, variables defined in inventory sources that are included later in the list take precedence over variables defined in sources that appeared earlier. See :ref:`ansible_variable_precedence` for more information.
+.. note:: Ansible merges variables from different sources and applies precedence to some variables over others according to a set of rules. For example, variables that occur higher in an inventory can override variables that occur lower in the inventory. See :ref:`ansible_variable_precedence` for more information.
 
 You can change this behavior by setting the group variable ``ansible_group_priority`` to change the merge order for groups of the same level (after the parent/child order is resolved). The larger the number, the later it will be merged, giving it higher priority. This variable defaults to ``1`` if not set. For example:
 

--- a/docs/docsite/rst/inventory_guide/intro_inventory.rst
+++ b/docs/docsite/rst/inventory_guide/intro_inventory.rst
@@ -521,6 +521,8 @@ By default, variables are merged/flattened to the specific host before a play is
 - child group
 - host
 
+.. note:: See :ref:`ansible_variable_precedence` for information about merging variables across different sources (for example, `group_vars` in parent groups override inventory variables in child groups).
+
 By default, Ansible merges groups at the same parent/child level in ASCII order, and variables from the last group loaded overwrite variables from the previous groups. For example, an ``a_group`` will be merged with ``b_group`` and ``b_group`` vars that match will overwrite the ones in ``a_group``.
 
 You can change this behavior by setting the group variable ``ansible_group_priority`` to change the merge order for groups of the same level (after the parent/child order is resolved). The larger the number, the later it will be merged, giving it higher priority. This variable defaults to ``1`` if not set. For example:


### PR DESCRIPTION
Fixes #700
parent group_vars prioritized over child group vars from inventory #700 (https://github.com/ansible/ansible-documentation/issues/700)