### PR TITLE
documentation_contribution.rst: add ansible-documentation open PRs link

### DIFF
--- a/docs/docsite/rst/community/documentation_contributions.rst
+++ b/docs/docsite/rst/community/documentation_contributions.rst
@@ -48,6 +48,7 @@ Reviewing open PRs
 
 Review open documentation pull requests for:
 
+- Ansible `docsite <https://github.com/ansible/ansible-documentation/pulls>`_
 - Ansible `projects <https://github.com/search?q=user%3Aansible+user%3Aansible-community+label%3Adocs+state%3Aopen+type%3Apr>`_
 - Ansible `collections <https://github.com/search?q=user%3Aansible-collections+label%3Adocs+state%3Aopen+type%3Apr>`_
 

--- a/docs/docsite/rst/community/documentation_contributions.rst
+++ b/docs/docsite/rst/community/documentation_contributions.rst
@@ -48,7 +48,7 @@ Reviewing open PRs
 
 Review open documentation pull requests for:
 
-- Ansible `docsite <https://github.com/ansible/ansible-documentation/pulls>`_
+- Ansible `documentation <https://github.com/ansible/ansible-documentation/pulls>`_
 - Ansible `projects <https://github.com/search?q=user%3Aansible+user%3Aansible-community+label%3Adocs+state%3Aopen+type%3Apr>`_
 - Ansible `collections <https://github.com/search?q=user%3Aansible-collections+label%3Adocs+state%3Aopen+type%3Apr>`_
 


### PR DESCRIPTION
Fixes https://github.com/ansible/ansible-documentation/issues/853

Adds another item to the list of PR links, as was agreed in [this comment](https://github.com/ansible/ansible-documentation/issues/853#issuecomment-1832742938)