### PR TITLE
Improve module developing documenation for deprecation and linking

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -261,7 +261,7 @@ You can link from your module documentation to other module docs, other resource
 * ``U()`` for URLs. For example: ``See U(https://www.ansible.com/products/automation-platform) for an overview.``
 * ``R()`` for cross-references with a heading (added in Ansible 2.10). For example: ``See R(Cisco IOS Platform Guide,ios_platform_options)``.  Use the RST anchor for the cross-reference. See :ref:`adding_anchors_rst` for details.
 * ``M()`` for module names. For example: ``See also M(ansible.builtin.yum) or M(community.general.apt_rpm)``. A FQCN **must** be used, short names will create broken links; use ``ansible.builtin`` for modules in ansible-core.
-* ``P()`` for plugin names. For example: ``See also P(ansible.builtin.file#lookup) or P(community.general.json_query#filter)``. This is supported since ansible-core 2.15. FQCNs must be used; use ``ansible.builtin`` for plugins in ansible-core.
+* ``P()`` for plugin names. For example: ``See also P(ansible.builtin.file#lookup) or P(community.general.json_query#filter)``. This can also be used to reference roles: ``P(community.sops.install#role)``. This is supported since ansible-core 2.15. FQCNs must be used; use ``ansible.builtin`` for plugins in ansible-core.
 
 .. note::
 

--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -261,7 +261,7 @@ You can link from your module documentation to other module docs, other resource
 * ``U()`` for URLs. For example: ``See U(https://www.ansible.com/products/automation-platform) for an overview.``
 * ``R()`` for cross-references with a heading (added in Ansible 2.10). For example: ``See R(Cisco IOS Platform Guide,ios_platform_options)``.  Use the RST anchor for the cross-reference. See :ref:`adding_anchors_rst` for details.
 * ``M()`` for module names. For example: ``See also M(ansible.builtin.yum) or M(community.general.apt_rpm)``. A FQCN **must** be used, short names will create broken links; use ``ansible.builtin`` for modules in ansible-core.
-* ``P()`` for plugin names. For example: ``See also P(ansible.builtin.file#lookup) or P(community.general.json_query#filter)``. This can also be used to reference roles: ``P(community.sops.install#role)``. This is supported since ansible-core 2.15. FQCNs must be used; use ``ansible.builtin`` for plugins in ansible-core.
+* ``P()`` for plugin names. For example: ``See also P(ansible.builtin.file#lookup) or P(community.general.json_query#filter)``. This can also reference roles: ``P(community.sops.install#role)``. This is supported since ansible-core 2.15. FQCNs must be used; use ``ansible.builtin`` for plugins in ansible-core.
 
 .. note::
 

--- a/docs/docsite/rst/dev_guide/module_lifecycle.rst
+++ b/docs/docsite/rst/dev_guide/module_lifecycle.rst
@@ -53,7 +53,7 @@ To deprecate a module in a collection, you must:
                        removal_version: 2.0.0
                        warning_text: Use foo.bar.new_cloud instead.
 
-   For other plugin types, you have to replace ``modules:`` with ``<plugin_type>:``, for example ``lookup:`` for lookup plugins.
+   For other plugin types, you have to replace ``modules:`` with ``<plugin_type>:``, for example ``lookup:`` for lookup plugins. When deprecating action plugins, you need to add two entries, one for the action plugin, and one for the module file that contains the documentation.
 
    Instead of ``removal_version``, you can also use ``removal_date`` with an ISO 8601 formatted date after which the module will be removed in a new major version of the collection.
 

--- a/docs/docsite/rst/dev_guide/module_lifecycle.rst
+++ b/docs/docsite/rst/dev_guide/module_lifecycle.rst
@@ -62,8 +62,8 @@ To deprecate a module in a collection, you must:
 
   :removed_in: A ``string``, such as ``"2.10"``; the version of Ansible where the module will be replaced with a docs-only module stub. Usually current release +4. Mutually exclusive with :removed_by_date:.
   :remove_by_date: (Added in ansible-base 2.10). An ISO 8601 formatted date when the module will be removed. Usually 2 years from the date the module is deprecated. Mutually exclusive with :removed_in:.
-  :why: Optional string that used to detail why this has been removed.
-  :alternative: Inform users they should do instead, for example, ``Use M(whatmoduletouseinstead) instead.``.
+  :why: String that used to detail why this has been removed.
+  :alternative: Inform users they should do instead, for example, ``Use M(whatmoduletouseinstead) instead.``. See :ref:`module_documents_linking` for ways to reference other entities than modules.
 
 Changing a module or plugin name in the Ansible main repository
 ===============================================================

--- a/docs/docsite/rst/dev_guide/module_lifecycle.rst
+++ b/docs/docsite/rst/dev_guide/module_lifecycle.rst
@@ -53,7 +53,7 @@ To deprecate a module in a collection, you must:
                        removal_version: 2.0.0
                        warning_text: Use foo.bar.new_cloud instead.
 
-   For other plugin types, you have to replace ``modules:`` with ``<plugin_type>:``, for example ``lookup:`` for lookup plugins. When deprecating action plugins, you need to add two entries, one for the action plugin, and one for the module file that contains the documentation.
+   For other plugin types, you have to replace ``modules:`` with ``<plugin_type>:``, for example ``lookup:`` for lookup plugins. When deprecating action plugins, you need to add two entries: one for the action plugin and one for the module file that contains the documentation.
 
    Instead of ``removal_version``, you can also use ``removal_date`` with an ISO 8601 formatted date after which the module will be removed in a new major version of the collection.
 
@@ -63,7 +63,7 @@ To deprecate a module in a collection, you must:
   :removed_in: A ``string``, such as ``"2.10"``; the version of Ansible where the module will be replaced with a docs-only module stub. Usually current release +4. Mutually exclusive with :removed_by_date:.
   :remove_by_date: (Added in ansible-base 2.10). An ISO 8601 formatted date when the module will be removed. Usually 2 years from the date the module is deprecated. Mutually exclusive with :removed_in:.
   :why: String that used to detail why this has been removed.
-  :alternative: Inform users they should do instead, for example, ``Use M(whatmoduletouseinstead) instead.``. See :ref:`module_documents_linking` for ways to reference other entities than modules.
+  :alternative: Inform users they should do instead, for example, ``Use M(whatmoduletouseinstead) instead.``. See :ref:`module_documents_linking` for ways to reference entities other than modules.
 
 Changing a module or plugin name in the Ansible main repository
 ===============================================================


### PR DESCRIPTION
Ref: https://forum.ansible.com/t/cannot-deprecate-a-collection-plugin/2751

That forum thread exposed multiple shortcomings of the documentation:
- Deprecating action plugins requires two entries in meta/runtime.yml.
- The `why` attribute is not optional (the sanity tests require them, and ansible-doc will crash if it isn't there).
- The documentation for `alternative` mentions `M(...)`, which only works for modules; linking to the docs that show how to link to all kind of entities should make it easier to figure out how to reference something else than a module.
- You can use `P(...)` to link to roles - that is not obvious since roles are not plugins, so it should be explicitly mentioned.
