### PR TITLE
Add documentation for the custom Jinja2 global function `undef`

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks.rst
@@ -26,6 +26,7 @@ These illustrate best practices as well as how to put many of the various concep
    playbooks_lookups
    playbooks_python_version
    playbooks_templating_now
+   playbooks_templating_undef
    playbooks_loops
    playbooks_delegation
    playbooks_conditionals

--- a/docs/docsite/rst/playbook_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_filters.rst
@@ -76,7 +76,7 @@ If you configure Ansible to ignore undefined variables, you may want to define s
 
 The variable value will be used as is, but the template evaluation will raise an error if it is undefined.
 
-A convenient way of requiring a variable to be overridden is to give it an undefined value using the ``undef`` keyword. This can be useful in a role's defaults.
+A convenient way of requiring a variable to be overridden is to give it an undefined value using the :ref:`undef() <templating_undef>` keyword. This can be useful in a role's defaults.
 
 .. code-block:: yaml+jinja
 

--- a/docs/docsite/rst/playbook_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_filters.rst
@@ -76,7 +76,7 @@ If you configure Ansible to ignore undefined variables, you may want to define s
 
 The variable value will be used as is, but the template evaluation will raise an error if it is undefined.
 
-A convenient way of requiring a variable to be overridden is to give it an undefined value using the :ref:`undef() <templating_undef>` keyword. This can be useful in a role's defaults.
+A convenient way of requiring a variable to be overridden is to give it an undefined value using the :ref:`undef() <templating_undef>` function. This can be useful in a role's defaults.
 
 .. code-block:: yaml+jinja
 

--- a/docs/docsite/rst/playbook_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_filters.rst
@@ -76,7 +76,7 @@ If you configure Ansible to ignore undefined variables, you may want to define s
 
 The variable value will be used as is, but the template evaluation will raise an error if it is undefined.
 
-A convenient way of requiring a variable to be overridden is to give it an undefined value using the :ref:`undef() <templating_undef>` function. This can be useful in a role's defaults.
+A convenient way of requiring a variable to be overridden is to give it an undefined value using the :ref:`undef() <templating_undef>` function.
 
 .. code-block:: yaml+jinja
 

--- a/docs/docsite/rst/playbook_guide/playbooks_templating_now.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_templating_now.rst
@@ -7,7 +7,7 @@ The now function: get the current time
 
 The ``now()`` Jinja2 function retrieves a Python datetime object or a string representation for the current time.
 
-The ``now()`` function supports 2 arguments:
+The ``now()`` function supports two arguments:
 
 utc
   Specify ``True`` to get the current time in UTC. Defaults to ``False``.

--- a/docs/docsite/rst/playbook_guide/playbooks_templating_undef.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_templating_undef.rst
@@ -1,0 +1,31 @@
+.. _templating_undef:
+
+The undef function: add hint for undefined variables
+====================================================
+
+.. versionadded:: 2.12
+
+The Jinja2 ``undef()`` function returns a Python ``AnsibleUndefined`` object, derived from ``jinja2.StrictUndefined``. Use ``undef()`` to undefine variables of :ref:`lesser precedence <ansible_variable_precedence>`.
+
+For example, ``roles:`` defaults/vars are scoped to the play and a role could avoid inheriting another role's default by using ``undef()``.
+
+.. code-block:: yaml
+
+    roles:
+      - role_a
+      - role_b
+
+.. code-block:: yaml
+
+    # roles/role_a/defaults/main.yml
+    role_default: role_a
+
+    # roles/role_b/defaults/main.yml
+    role_default: "{{ undef(hint='If this is required and missing, this error will be displayed. This must be defined with higher precedence than role defaults.') }}"
+
+.. seealso:: :ref:`DEFAULT_PRIVATE_ROLE_VARS` is a general way to do this for M(ansible.builtin.include_role)/M(ansible.builtin.import_role).
+
+The ``undef`` function accepts 1 optional argument:
+
+hint
+    Give a custom hint about the undefined variable if :ref:`DEFAULT_UNDEFINED_VAR_BEHAVIOR` is configured to give an error.

--- a/docs/docsite/rst/playbook_guide/playbooks_templating_undef.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_templating_undef.rst
@@ -23,9 +23,9 @@ For example, ``roles:`` defaults/vars are scoped to the play and a role could av
     # roles/role_b/defaults/main.yml
     role_default: "{{ undef(hint='If this is required and missing, this error will be displayed. This must be defined with higher precedence than role defaults.') }}"
 
-.. seealso:: :ref:`DEFAULT_PRIVATE_ROLE_VARS` is a general way to do this for M(ansible.builtin.include_role)/M(ansible.builtin.import_role).
+.. seealso:: :ref:`DEFAULT_PRIVATE_ROLE_VARS` is a general way to do this for :ansplugin:`ansible.builtin.include_role#module`/:ansplugin:`ansible.builtin.import_role#module`.
 
-The ``undef`` function accepts 1 optional argument:
+The ``undef`` function accepts one optional argument:
 
 hint
     Give a custom hint about the undefined variable if :ref:`DEFAULT_UNDEFINED_VAR_BEHAVIOR` is configured to give an error.

--- a/docs/docsite/rst/playbook_guide/playbooks_templating_undef.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_templating_undef.rst
@@ -5,25 +5,25 @@ The undef function: add hint for undefined variables
 
 .. versionadded:: 2.12
 
-The Jinja2 ``undef()`` function returns a Python ``AnsibleUndefined`` object, derived from ``jinja2.StrictUndefined``. Use ``undef()`` to undefine variables of :ref:`lesser precedence <ansible_variable_precedence>`.
-
-For example, ``roles:`` defaults/vars are scoped to the play and a role could avoid inheriting another role's default by using ``undef()``.
+The Jinja2 ``undef()`` function returns a Python ``AnsibleUndefined`` object, derived from ``jinja2.StrictUndefined``. Use ``undef()`` to undefine variables of :ref:`lesser precedence <ansible_variable_precedence>`. For example, a host variable can be overridden for a block of tasks:
 
 .. code-block:: yaml
 
-    roles:
-      - role_a
-      - role_b
+    ---
+    - hosts: localhost
+      gather_facts: no
+      module_defaults:
+        group/ns.col.auth: "{{ vaulted_credentials | default({}) }}"
+      tasks:
+        - ns.col.module1:
+        - ns.col.module2:
 
-.. code-block:: yaml
+        - name: override host variable
+          vars:
+            vaulted_credentials: "{{ undef() }}"
+          block:
+            - ns.col.module1:
 
-    # roles/role_a/defaults/main.yml
-    role_default: role_a
-
-    # roles/role_b/defaults/main.yml
-    role_default: "{{ undef(hint='If this is required and missing, this error will be displayed. This must be defined with higher precedence than role defaults.') }}"
-
-.. seealso:: :ref:`DEFAULT_PRIVATE_ROLE_VARS` is a general way to do this for :ansplugin:`ansible.builtin.include_role#module`/:ansplugin:`ansible.builtin.import_role#module`.
 
 The ``undef`` function accepts one optional argument:
 


### PR DESCRIPTION
`undef` was added in https://github.com/ansible/ansible/pull/75435. It's briefly mentioned in the filters page, but is not a filter itself.