### PR TITLE
bump minimum antsibull-docs version to 2.6.0

### DIFF
--- a/tests/constraints.in
+++ b/tests/constraints.in
@@ -2,4 +2,4 @@
 # and antsibull-docs that production builds rely upon.
 
 sphinx == 7.2.5
-antsibull-docs == 2.5.0  # currently approved version
+antsibull-docs == 2.6.0  # currently approved version

--- a/tests/requirements-relaxed.in
+++ b/tests/requirements-relaxed.in
@@ -12,5 +12,5 @@ sphinx-intl # translation utility used by docs/docsite/Makefile
 sphinx-notfound-page
 sphinx-ansible-theme
 rstcheck
-antsibull-docs >= 2.6.0, < 3  # 2.6.0 has a fix for EXAMPLES parsing that previously caused docs builds to fail
+antsibull-docs ~= 2.6 # 2.6.0 has a fix for EXAMPLES parsing that previously caused docs builds to fail
 sphinx-copybutton

--- a/tests/requirements-relaxed.in
+++ b/tests/requirements-relaxed.in
@@ -12,5 +12,5 @@ sphinx-intl # translation utility used by docs/docsite/Makefile
 sphinx-notfound-page
 sphinx-ansible-theme
 rstcheck
-antsibull-docs ~= 2.0
+antsibull-docs >= 2.6.0, < 3  # 2.6.0 has a fix for EXAMPLES parsing that previously caused docs builds to fail
 sphinx-copybutton

--- a/tests/requirements-relaxed.txt
+++ b/tests/requirements-relaxed.txt
@@ -20,7 +20,7 @@ ansible-pygments==0.1.1
     #   sphinx-ansible-theme
 antsibull-core==2.1.0
     # via antsibull-docs
-antsibull-docs==2.5.0
+antsibull-docs==2.6.0
     # via -r tests/requirements-relaxed.in
 antsibull-docs-parser==1.0.0
     # via antsibull-docs

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -20,7 +20,7 @@ ansible-pygments==0.1.1
     #   sphinx-ansible-theme
 antsibull-core==2.1.0
     # via antsibull-docs
-antsibull-docs==2.5.0
+antsibull-docs==2.6.0
     # via
     #   -c tests/constraints.in
     #   -r tests/requirements-relaxed.in


### PR DESCRIPTION
This fixes the build failures causes by
https://github.com/ansible/ansible/pull/82361.
