### PR TITLE
EOL Ansible 8 docs

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -221,7 +221,7 @@ html_theme_options = {
 html_context = {
     'display_github': 'True',
     'show_sphinx': False,
-    'is_eol': False,
+    'is_eol': True,
     'github_user': 'ansible',
     'github_repo': 'ansible-documentation',
     'github_version': 'devel',


### PR DESCRIPTION
Fixes https://github.com/ansible/ansible-documentation/issues/428

Ansible 8 is EOL with the release of 8.7.0. This PR removes Ansible 8 from the version switcher and puts up the EOL banner at the top of the page.