### PR TITLE
docs: Document removal of ConfigureRemotingForAnsible.ps1 #794

### DIFF
--- a/docs/docsite/rst/os_guide/windows_setup.rst
+++ b/docs/docsite/rst/os_guide/windows_setup.rst
@@ -93,7 +93,7 @@ WinRM Setup
 You need to configure the WinRM service so that Ansible can connect to it. There are two main components of the WinRM service that govern how Ansible can interface with the Windows host: the ``listener`` and the ``service`` configuration settings.
 
 .. Note:: 
-    The script for setting up this service has been moved to a new `location <https://github.com/oraNod/ansible-documentation/blob/a1133258b90fbbd5e120bb187bcbe9b907e9f3f8/examples/scripts/ConfigureRemotingForAnsible.ps1>`_.
+    The script for setting up this service is `available to download on GitHub <https://raw.githubusercontent.com/ansible/ansible-documentation/ae8772176a5c645655c91328e93196bcf741732d/examples/scripts/ConfigureRemotingForAnsible.ps1>`_.
     Reason been that using it can cause several issues for the user. Chances are it will be completely taken down in the future.
 
 

--- a/docs/docsite/rst/os_guide/windows_setup.rst
+++ b/docs/docsite/rst/os_guide/windows_setup.rst
@@ -94,7 +94,7 @@ You need to configure the WinRM service so that Ansible can connect to it. There
 
 .. Note:: 
     The script for setting up this service is `available to download on GitHub <https://raw.githubusercontent.com/ansible/ansible-documentation/ae8772176a5c645655c91328e93196bcf741732d/examples/scripts/ConfigureRemotingForAnsible.ps1>`_.
-    Reason been that using it can cause several issues for the user. Chances are it will be completely taken down in the future.
+    Reason being that using it can cause several issues for the user. Chances are it will be completely taken down in the future.
 
 
 

--- a/docs/docsite/rst/os_guide/windows_setup.rst
+++ b/docs/docsite/rst/os_guide/windows_setup.rst
@@ -92,6 +92,12 @@ WinRM Setup
 ```````````
 You need to configure the WinRM service so that Ansible can connect to it. There are two main components of the WinRM service that govern how Ansible can interface with the Windows host: the ``listener`` and the ``service`` configuration settings.
 
+.. Note:: 
+    The script for setting up this service has been moved to a new `location <https://github.com/oraNod/ansible-documentation/blob/a1133258b90fbbd5e120bb187bcbe9b907e9f3f8/examples/scripts/ConfigureRemotingForAnsible.ps1>`_.
+    Reason been that using it can cause several issues for the user. Chances are it will be completely taken down in the future.
+
+
+
 .. _winrm_listener:
 
 WinRM Listener

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,14 @@
+# Update on maintenance of scripts `ConfigureRemotingForAnsible.ps1`
+
+## Important Notice
+This is to notify users that the aforementioned script is currently unmaintained and may be removed in the future. Please read this notice carefully before using the script.
+
+### Why Unmaintained ?
+The script is designed to check the current WinRM (PS Remoting) configuration and make the necessary changes to allow Ansible to connect, authenticate and execute PowerShell commands. As of now, Ansible can connect to Windows host that has already run `Enable-PSRemoting` in PowerShell already. 
+
+There's really no need to use this script at all as the defaults in Windows are just fine. Also, using the scripts may result to potential security issues.
+
+
+### Use at Your Own Risk
+- The script is provided as-is, without ongoing support or updates.
+- Use them at your own risk, and carefully consider the potential consequences. 

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,8 @@ This is to notify users that the aforementioned script is currently unmaintained
 ### Why Unmaintained ?
 The script is designed to check the current WinRM (PS Remoting) configuration and make the necessary changes to allow Ansible to connect, authenticate and execute PowerShell commands. As of now, Ansible can connect to Windows host that has already run `Enable-PSRemoting` in PowerShell already. 
 
-There's really no need to use this script at all as the defaults in Windows are just fine. Also, using the scripts may result to potential security issues.
+There's really no need to use this script at all as the defaults in Windows are just fine. Also, using the scripts may result in potential security issues.
+
 
 
 ### Use at Your Own Risk

--- a/examples/scripts/README.md
+++ b/examples/scripts/README.md
@@ -19,7 +19,8 @@ We strongly advised against using `ConfigureRemotingForAnsible.ps1` due to sever
 
 A lot of these settings are done (Basic auth and HTTPS with self signed certificate) because it was created in a time where the WinRM support on Python was very basic and barebones. There was no *NTLM* or *Kerberos* support, no message encryption over HTTP. This is no longer the case and the Python WinRM library that is used supports the full gauntlet of authentication protocols WinRM supports as well as message encryption when it's run over HTTP. In fact, Ansible has been able to connect to a Windows host that has already run `Enable-PSRemoting` in PowerShell already. There's really no need to use this script at all as the defaults in Windows are just fine.
 
-The reason why we still have this script is simple, people still use it and have their scripts set to download it directly from [here](https://github.com/ansible/ansible/blob/devel/examples/scripts/ConfigureRemotingForAnsible.ps1). If we were to remove it, or even just some of the default behaviour to be a bit more secure we will be breaking plenty of scripts that still rely on its current behaviour.
+The reason why we still have this script is simple, people still use it and have their scripts set to download it directly from GitHub. If we were to remove it, or even just some of the default behaviour to be a bit more secure we will be breaking plenty of scripts that still rely on its current behaviour.
+
 
 **TLDR:** We are trying to discourage users from using the script as much as we can. It was created for a time where Ansible couldn't work with the default WinRM settings. If you do wish to use it then take a copy of the script and only run the parts you need, i.e. self signed certificates and so on.
 

--- a/examples/scripts/README.md
+++ b/examples/scripts/README.md
@@ -1,0 +1,25 @@
+# Cautionary Note on ConfigureRemotingForAnsible.ps1
+`ConfigureRemotingForAnsible.ps1` is a script designed to check the current WinRM (PS Remoting) configuration and makes the necessary changes to allow Ansible to connect, authenticate and execute PowerShell commands. However, recent user experiences have raised concerns about its reliability and potential for causing issues.
+
+
+**Warning:**
+We strongly advised against using `ConfigureRemotingForAnsible.ps1` due to several potential issues which are:
+
+* It enables Basic authentication:
+
+    * Windows has this disabled by default because it is not secure when running over HTTP.
+    * Over HTTP this is an issue because the messages are not encrypted, even the credentials are just base64 encoded
+    * Anyone sniffing the network will be able to get your credentials as well as any data that Ansible sends to the remote host and what it receives back.
+    * Requires HTTPS to be set up to be secure, even then it's problematic because it only supports local account and not domain accounts.
+* It creates a self signed certificate
+    * Fine for basic testing but in a domain environment you should be using your own CA issued certificates for the host.
+    * Also it creates both a HTTP and HTTPS listener, where only the latter is enabled by default. Not really an issue but some places like to reduce the amount of inbound entrypoints as much as they can.
+* It allows WinRM traffic in all network profiles
+    * Usually you want to restrict traffic to just the network/profile you will be managing it from.
+
+A lot of these settings are done (Basic auth and HTTPS with self signed certificate) because it was created in a time where the WinRM support on Python was very basic and barebones. There was no *NTLM* or *Kerberos* support, no message encryption over HTTP. This is no longer the case and the Python WinRM library that is used supports the full gauntlet of authentication protocols WinRM supports as well as message encryption when it's run over HTTP. In fact, Ansible has been able to connect to a Windows host that has already run `Enable-PSRemoting` in PowerShell already. There's really no need to use this script at all as the defaults in Windows are just fine.
+
+The reason why we still have this script is simple, people still use it and have their scripts set to download it directly from [here](https://github.com/ansible/ansible/blob/devel/examples/scripts/ConfigureRemotingForAnsible.ps1). If we were to remove it, or even just some of the default behaviour to be a bit more secure we will be breaking plenty of scripts that still rely on its current behaviour.
+
+**TLDR:** We are trying to discourage users from using the script as much as we can. It was created for a time where Ansible couldn't work with the default WinRM settings. If you do wish to use it then take a copy of the script and only run the parts you need, i.e. self signed certificates and so on.
+


### PR DESCRIPTION
Made the following changes for the issue Document removal of ConfigureRemotingForAnsible.ps1 
Fixes #794:
1. Added a note to https://docs.ansible.com/ansible/devel/os_guide/windows_setup.html#winrm-setup to say the script is available at new location
2. Added a README.md file to examples/ to say that the script is currently unmaintaned and may be removed at some point.
3. Added a README.md file to examples/scripts to add the details from https://github.com/ansible/ansible/issues/72449#issuecomment-722917124 so people know why we don't recommend using this particular script.