### PR TITLE
Document collection naming

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_collections_creating.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_creating.rst
@@ -34,7 +34,7 @@ There are a few special namespaces:
 
 :ansible:
 
-  The `ansible` namespace <https://galaxy.ansible.com/ui/namespaces/ansible/>`__ is owned by Red Hat and reserved for official Ansible collections. Two special members are the synthetic ``ansible.builtin`` and ``ansible.legacy`` collections. These cannot be found on Ansible Galaxy, but are built-in into ansible-core.
+  The `ansible namespace <https://galaxy.ansible.com/ui/namespaces/ansible/>`__ is owned by Red Hat and reserved for official Ansible collections. Two special members are the synthetic ``ansible.builtin`` and ``ansible.legacy`` collections. These cannot be found on Ansible Galaxy, but are built-in into ansible-core.
 
 :community:
 

--- a/docs/docsite/rst/dev_guide/developing_collections_creating.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_creating.rst
@@ -17,6 +17,33 @@ A user can then install your collection on their systems.
    :local:
    :depth: 2
 
+Naming your collection
+======================
+
+Collection names consist of a namespace and a name, separated by a period (``.``). Both namespace and name should be valid Python identifiers. This means that they should consist of ASCII letters, digits, and underscores.
+
+.. note::
+
+    Usually namespaces and names use lower-case letters, digits, and underscores, but no upper-case letters.
+
+You should make sure that the namespace you use is not registered by someone else by checking on `Ansible Galaxy's namespace list <https://galaxy.ansible.com/ui/namespaces/>`__. If you chose a namespace or even a full collection name that collides with another collection on Galaxy, it can happen that if you or someone else runs ``ansible-galaxy collection install`` with your collection name, you end up with another collection. Even if the namespace currently does not exist, it could be created later by someone else.
+
+If you want to request a new namespace on Ansible Galaxy, `create an issue on github.com/ansible/galaxy <https://github.com/ansible/galaxy/issues/new?assignees=thedoubl3j%2C+alisonlhart%2C+chynasan%2C+traytorous&labels=area%2Fnamespace&projects=&template=New_namespace.md&title=namespace%3A+FIXME>`__.
+
+There are a few special namespaces:
+
+:ansible:
+
+  The `ansible` namespace <https://galaxy.ansible.com/ui/namespaces/ansible/>`__ is owned by Red Hat and reserved for official Ansible collections. Two special members are the synthetic ``ansible.builtin`` and ``ansible.legacy`` collections. These cannot be found on Ansible Galaxy, but are built-in into ansible-core.
+
+:community:
+
+  The `community namespace <https://galaxy.ansible.com/ui/namespaces/community/>`__ is owned by the Ansible community. Collections from this namespace generally live in the `GitHub ansible-collection organization <https://github.com/ansible-collections/>`__. If you want to create a collection in this namespace, it is best to `create an issue in github.com/ansible-collections/overview <https://github.com/ansible-collections/overview/issues/new?assignees=&labels=repo&projects=&template=request-a-new-repo.md&title=repo%3A+%24NAME>`__.
+
+:local:
+
+  The `local namespace <https://galaxy.ansible.com/ui/namespaces/local/>`__ does not contain any collection on Ansible Galaxy, and the intention is that this will never change. You can use the ``local`` namespace for collections that are locally on your machine or locally in your git repositories, without having to fear collisions with actually existing collections on Ansible Galaxy.
+
 .. _creating_collections_skeleton:
 
 Creating a collection skeleton


### PR DESCRIPTION
It came up in https://forum.ansible.com/t/the-namespace-for-the-collection-used-only-within-the-organization/2896/2 that there is a reserved namespace `local` that is reserved for local collections, but which isn't documented anywhere. This PR changes that, and provides some more information on namespaces.

@GregSutcliffe I included two links to issues in GitHub repos that might be better suited for the forum, but since the issue templates still exist I'm not sure what is best to link.