### PR TITLE
Collection requirements: undocumented-parameter must only be used for deprecated parameters or internal parameters

### DIFF
--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -408,6 +408,7 @@ CI Testing
 
   * The following validations MUST not be ignored except in specific circumstances:
       * ``validate-modules:undocumented-parameter``: this MUST only be ignored in one of these two cases:
+
         1. A dangerous module parameter has been deprecated or removed, and code is present to inform the user that they should not use this specific parameter anymore or that it stopped working intentionally.
         2. Module parameters are only used to pass in data from an accompanying action plugin.
 

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -405,7 +405,11 @@ CI Testing
       * ``validate-modules:nonexistent-parameter-documented``
       * ``validate-modules:parameter-list-no-elements``
       * ``validate-modules:parameter-type-not-in-doc``
-      * ``validate-modules:undocumented-parameter``
+
+  * The following validations MUST not be ignored except in specific circumstances:
+      * ``validate-modules:undocumented-parameter``: this MUST only be ignored in one of these two cases:
+        1. A dangerous module parameter has been deprecated or removed, and code is present to inform the user that they should not use this specific parameter anymore or that it stopped working intentionally.
+        2. Module parameters are only used to pass in data from an accompanying action plugin.
 
   * All entries in ignores.txt MUST have a justification in a comment in the ignore.txt file for each entry.  For example ``plugins/modules/docker_container.py use-argspec-type-path # uses colon-separated paths, can't use type=path``.
   * Reviewers can block acceptance of a new collection if they don't agree with the ignores.txt entries.


### PR DESCRIPTION
Proposal: update the collection requirements so that `undocumented-parameter` in tests/sanity/ignore-*.txt is allowed in specific circumstances:
1) deprecated parameters;
2) internal parameters used to transport data from an action plugin to a module.

Right now `undocumented-parameter` is listed as explicitly forbidden. Some collections in Ansible violate this rule, especially for 2 above. But let me give some more details:

Rationale for exception 1: This has been used in the past when removing dangerous parameters to make sure that users get a useful error message. One such case was https://github.com/ansible-collections/community.general/commit/11ef03e9dd1dc05fd80bbe74eafd89b3645965cf.

Rationale for exception 2: If code has to be spread over both an action plugin and a module, some data often needs to be passed from the action plugin to the module. The only way to do this is to add a module parameter. The validate-modules sanity tests requires this parameter to be documented, which is wrong since the user cannot use that parameter - it is provided directly by the action plugin. Since there is no mechanism to disable the error for a specific module parameter, it needs to be disabled completely. Example: https://github.com/ansible-collections/community.docker/blob/main/plugins/action/docker_container_copy_into.py#L28 → https://github.com/ansible-collections/community.docker/blob/main/plugins/modules/docker_container_copy_into.py#L776.

I'll create a discussion in the forum where we can also vote on this.