### PR TITLE
pr_labeler: refactor new_contributor_welcome code

### DIFF
--- a/hacking/pr_labeler/label.py
+++ b/hacking/pr_labeler/label.py
@@ -236,7 +236,14 @@ def is_new_contributor_manual(ctx: IssueOrPrCtx) -> bool:
     Determine whether a user has previously opened an issue or PR in this repo
     without needing special API access.
     """
-    query_data = dict(repo=ctx.global_args.full_repo, author=ctx.issue.user.login)
+    query_data = {
+        "repo": "ansible/ansible-documentation",
+        "author": ctx.issue.user.login,
+        # Avoid potential race condition where a new contributor opens multiple
+        # PRs or issues at once.
+        # Better to welcome twice than not at all.
+        "is": "closed",
+    }
     issues = ctx.client.search_issues("", **query_data)
     for issue in issues:
         if issue.number != ctx.issue.number:


### PR DESCRIPTION
As of https://github.com/ansible/ansible-documentation/issues/69, the
pr_labeler responds with a welcome message when an issue or PR is opened
by a new contributor. It turns out this never actually worked properly.

The previous method that relied on Github's `author_association` flag
did not work with the app token that the pr_labeler uses. This refactors
the code to figure out whether a user is a new contributor by
searching the list of issues and PRs.

Fixes: https://github.com/ansible/ansible-documentation/issues/204