### PR TITLE
docs: Fixed Developer Certificate Of Origin link

### DIFF
--- a/docs/docsite/rst/community/developer_certificate_of_origin.rst
+++ b/docs/docsite/rst/community/developer_certificate_of_origin.rst
@@ -7,5 +7,5 @@ Developer Certificate Of Origin
 By contributing to this project you agree to the Developer Certificate of
 Origin (DCO). This document was created by the Linux Kernel community and is a
 simple statement that you, as a contributor, have the legal right to make the
-contribution. See the `DCO file <https://github.com/ansible-documentation/blob/devel/DCO>`_
+contribution. See the `DCO file <https://github.com/ansible/ansible-documentation/blob/devel/DCO>`_
 file for details.


### PR DESCRIPTION
Made following changes:
1. Updated the DCO link provided at https://docs.ansible.com/ansible/latest/community/developer_certificate_of_origin.html .