### PR TITLE
Extend Ansible 9 lifecycle to November 2024

### DIFF
--- a/docs/docsite/rst/roadmap/COLLECTIONS_9.rst
+++ b/docs/docsite/rst/roadmap/COLLECTIONS_9.rst
@@ -74,7 +74,7 @@ Ansible 9.x minor releases may contain new features (including new collections) 
 
 .. note::
 
-    Minor and patch releases will stop in November 2024, at the end of the Ansible Core 2.16 critical bugfix support lifecycle. This is roughly half a year longer as regular Ansible releases. See the :ref:`Release and Maintenance Page <release_and_maintenance>` for more information.
+    Minor and patch releases will stop in November 2024, at the end of the Ansible Core 2.16 critical bugfix support lifecycle. This is roughly half a year longer than regular Ansible releases. See the :ref:`Release and Maintenance Page <release_and_maintenance>` for more information.
 
 
 For more information, reach out on a mailing list or a chat channel - see :ref:`communication` for more details.

--- a/docs/docsite/rst/roadmap/COLLECTIONS_9.rst
+++ b/docs/docsite/rst/roadmap/COLLECTIONS_9.rst
@@ -74,7 +74,7 @@ Ansible 9.x minor releases may contain new features (including new collections) 
 
 .. note::
 
-    Minor and patch releases will stop when Ansible-10 is released. See the :ref:`Release and Maintenance Page <release_and_maintenance>` for more information.
+    Minor and patch releases will stop in November 2024, at the end of the Ansible Core 2.16 critical bugfix support lifecycle. See the :ref:`Release and Maintenance Page <release_and_maintenance>` for more information.
 
 
 For more information, reach out on a mailing list or a chat channel - see :ref:`communication` for more details.

--- a/docs/docsite/rst/roadmap/COLLECTIONS_9.rst
+++ b/docs/docsite/rst/roadmap/COLLECTIONS_9.rst
@@ -74,7 +74,7 @@ Ansible 9.x minor releases may contain new features (including new collections) 
 
 .. note::
 
-    Minor and patch releases will stop in November 2024, at the end of the Ansible Core 2.16 critical bugfix support lifecycle. See the :ref:`Release and Maintenance Page <release_and_maintenance>` for more information.
+    Minor and patch releases will stop in November 2024, at the end of the Ansible Core 2.16 critical bugfix support lifecycle. This is roughly half a year longer as regular Ansible releases. See the :ref:`Release and Maintenance Page <release_and_maintenance>` for more information.
 
 
 For more information, reach out on a mailing list or a chat channel - see :ref:`communication` for more details.

--- a/docs/docsite/rst/roadmap/COLLECTIONS_9.rst
+++ b/docs/docsite/rst/roadmap/COLLECTIONS_9.rst
@@ -76,5 +76,10 @@ Ansible 9.x minor releases may contain new features (including new collections) 
 
     Minor and patch releases will stop in November 2024, at the end of the Ansible Core 2.16 critical bugfix support lifecycle. This is roughly half a year longer than regular Ansible releases. See the :ref:`Release and Maintenance Page <release_and_maintenance>` for more information.
 
+.. note::
+
+   We will not provide bugfixes or security fixes for collections that do not
+   provide updates for their major release cycle included in Ansible 9.
+
 
 For more information, reach out on a mailing list or a chat channel - see :ref:`communication` for more details.


### PR DESCRIPTION
Relates: https://forum.ansible.com/t/maintain-ansible-9-for-longer-than-6-months/2574