### PR TITLE
Update Arch Linux bugtracker link

### DIFF
--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -163,7 +163,7 @@ standalone packages that users can install alongside ``ansible-core``.
 See the `Arch Linux Packages index <https://archlinux.org/packages/?sort=&q=ansible>`_
 for a full list of Ansible packages in Arch Linux.
 
-Please `file a bug <https://bugs.archlinux.org/>`__ to reach the package maintainers.
+Please `open an issue <https://gitlab.archlinux.org/archlinux/packaging/packages>`_ in the related package GitLab repository to reach the package maintainers.
 
 .. _from_windows:
 


### PR DESCRIPTION
Hi,

Arch Linux bugtracker has recently [moved away from Flyspray to GitLab](https://archlinux.org/news/bugtracker-migration-to-gitlab-completed/).

This commit aims to update the Arch's bugtracker link accordingly in the installation guide.