### PR TITLE
Move community_topics_workflow to docs.ansible.com

### DIFF
--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -22,6 +22,8 @@ The `Ansible Forum <https://forum.ansible.com>`_ is a single starting point and 
 Take a look at the `forum groups <https://forum.ansible.com/g>`_ and join ones that match your interests.
 In most cases, joining a forum group automatically subscribes you to related posts.
 
+.. _bullhorn:
+
 The Bullhorn
 ------------
 

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -29,7 +29,7 @@ Any person can :ref:`create a community topic<creating_community_topic>`.
 Preparation stage
 -----------------
 
-* A Committee person checks the topic's content and asks the author/other persons to provide additional information if needed.
+* A Committee person checks the topic's content and asks the author/other persons to provide additional information as needed.
 
 Discussion stage
 ----------------

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -63,7 +63,7 @@ The vote always consists of two polls: one for the Steering Committee, one for e
   * Do NOT set the close date because this cannot be changed later.
   * Results should be ``Always Visible`` unless there is a good reason for the SC votes not to be public.
   * Submit the poll (the BBcode will appear in the post):
-  * Repeat the above for the second poll:
+  * Repeat the above steps for the second poll:
 
     * Title should be "Community vote".
     * No group limitation.

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -48,7 +48,7 @@ The Committee person:
 * Starts the vote on the beginning date and establishes an end date, which is $CURRENT_DATE plus:
 
   * 7 days: simple cases
-  * 14 days: should not be more than that
+  * 14 days: maximum vote length
   * 21 days: only used in cases like common holiday seasons when the majority of the Committee out of participation
 * Labels the topic with the ``active-vote`` tag.
 * Adds ``[Vote ends on $YYYY-MM-DD]`` to the beginning of the topic's description.

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -12,9 +12,9 @@ Community topics workflow
 Overview
 --------
 
-This document describes the Ansible Community Topics workflow (hereinafter Workflow) to provide guidance on successful resolving topics in the asynchronous way.
+This document describes the Ansible community topics workflow to provide guidance on successful resolving topics in the asynchronous way.
 
-The Workflow is a set of actions that need to be done successively within the corresponding time frames.
+The workflow is a set of actions that need to be done successively within the corresponding time frames.
 
 .. note::
 
@@ -107,7 +107,7 @@ After the actions are done, the assignee:
 Package-release related actions required
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If the topic implies actions related to the future Ansible Community package releases (for example, a collection exclusion), the Committee person/assignee:
+If the topic implies actions related to the future Ansible community package releases (for example, a collection exclusion), the Committee person/assignee:
 
 * Adds the ``scheduled-for-future-release`` tag to the topic.
 * Checks if there is a corresponding milestone in the `ansible-build-data <https://github.com/ansible-community/ansible-build-data/milestones>`_ repository.

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -71,7 +71,7 @@ The vote always consists of two polls: one for the Steering Committee, one for e
 Voting result stage
 -------------------
 
-The next day after the last day of the vote, the Committee person:
+On the vote end date, the Committee person:
 
 * Closes the polls if the :ref:`quorum<community_topics_workflow>` is reached, otherwise prolongs the polls.
 * Removes the ``active-vote`` tag.

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -28,7 +28,7 @@ Any person can `create a topic <https://forum.ansible.com/new-topic?title=topic%
 Preparation stage
 -----------------
 
-* A Committee person checks the topic's content, asks the author/other persons to provide additional information if needed.
+* A Committee person checks the topic's content and asks the author/other persons to provide additional information if needed.
 
 Discussion stage
 ----------------

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -49,7 +49,7 @@ The Committee person:
 
   * 7 days: simple cases
   * 14 days: maximum vote length
-  * 21 days: only used in cases like common holiday seasons when the majority of the Committee out of participation
+  * 21 days: only used in exceptional cases such as holiday seasons when the majority of the Committee are not able to participate in the vote
 * Labels the topic with the ``active-vote`` tag.
 * Adds ``[Vote ends on $YYYY-MM-DD]`` to the beginning of the topic's description.
 

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -16,85 +16,108 @@ This document describes the Ansible Community Topics workflow (hereinafter Workf
 
 The Workflow is a set of actions that need to be done successively within the corresponding time frames.
 
-Creating a topic
-----------------
-
-Any person can `create a topic <https://forum.ansible.com/new-topic?title=topic%20title&body=topic%20body&category=project&tags=community-wg>`_ tagged with ``community-wg`` under the ``Project Discussions`` category in the `Ansible Forum <https://forum.ansible.com/>`_.
-A :ref:`steering committee <steering_responsibilities>` member can tag the forum post with ``community-wg-nextmtg`` to put it on the meeting agenda.
-
-Workflow
---------
-
 .. note::
 
   This is a rough scenario and it can vary depending on a topic's complexity and other nuances, for example, when there is a mass agreement up-front.
 
+Creating a topic
+----------------
+
+Any person can `create a topic <https://forum.ansible.com/new-topic?title=topic%20title&body=topic%20body&category=project&tags=community-wg>`_ tagged with ``community-wg`` under the ``Project Discussions`` category in the `Ansible Forum <https://forum.ansible.com/>`_.
+
 Preparation stage
-~~~~~~~~~~~~~~~~~
+-----------------
 
 * A Committee person checks the topic's content, asks the author/other persons to provide additional information if needed.
 
 Discussion stage
-~~~~~~~~~~~~~~~~
+----------------
 
-* If the topic is ready to be discussed, the Committee person:
+* The discussion by default happens asynchronously in the topic.
 
-  * Adds the ``community-wg-nextmtg`` tag if it needs to be discussed in the meeting.
-  * Opens the discussion by adding a comment asking the Community and the Committee to take part in it.
-* No synchronous discussion is needed (there are no blockers, complications, confusion, or impasses).
+  * A :ref:`steering committee <steering_responsibilities>` member can tag the forum post with ``community-wg-nextmtg`` to put it on the synchronous meeting agenda.
 
 Voting stage
-~~~~~~~~~~~~
+------------
 
-* Depending on the topic's complexity, 1-2 weeks after the discussion was opened, the Committee person formulates vote options based on the prior discussion and gives participants reasonable amount of time to propose changes to the options (no longer than a week). The person summarizes the options in a comment and also establishes a date when the vote begins if there are no objections about the options/vote date.
-* In the vote date, the vote starts with the comment of a Committee person which opens the vote and establishes a date when the vote ends ($CURRENT_DATE + no longer than 21 days; usually it should not exceed 14 days, 21 days should only be used if it is known that a lot of interested persons will likely not have time to vote in a 15 days period).
-* The Committee person labels the topic with the ``active-vote`` tag.
-* The Committee person adds ``[Vote ends on $YYYY-MM-DD]`` to the beginning of the topic's description.
-* A vote is actually two polls, one for the Steering Committee, one for everyone else. To create a vote in a topic:
+The Committee person:
+
+* Depending on the topic's complexity, 1-2 weeks after the discussion was opened, formulates vote options based on the prior discussion and gives participants reasonable amount of time to propose changes to the options (no longer than a week).
+* Summarizes the options in a comment and also establishes a date when the vote begins and ends if there are no objections about the options.
+* In the vote date, starts the vote and establishes its end date, which is $CURRENT_DATE plus:
+
+  * 7 days: simple cases
+  * 14 days: should not be more than that
+  * 21 days: only used in cases like common holiday seasons when the majority of the Committee out of participation
+* Labels the topic with the ``active-vote`` tag.
+* Adds ``[Vote ends on $YYYY-MM-DD]`` to the beginning of the topic's description.
+
+The vote always consists of two polls: one for the Steering Committee, one for everyone else. To create a vote in a topic:
 
   * Create a new post in the topic.
-  * Click the ``gear`` button in the composer and select Build Poll.
-  * Click the ``gear`` in the Poll Builder for advanced mode.
-  * Set up the options (generally this will be Single Choice but other poll types can be used).
-  * Title it "Steering Committee vote" and "Limit voting" to the ``Steering Committee``.
-  * Do not set the close date because this cannot be changed later.
+  * Click the ``gear`` button in the composer and select ``Build Poll``.
+  * Click the ``gear`` in the ``Poll Builder`` for advanced mode.
+  * Set up the options (generally this will be ``Single Choice`` but other poll types can be used).
+  * Title it "Steering Committee vote" and ``Limit voting`` to the ``@SteeringCommittee``.
+  * Do NOT set the close date because this cannot be changed later.
   * Results should be ``Always Visible`` unless there is some good reason for the SC votes not to be public.
-  * Submit the poll (the BBcode will appear in the post) and then repeat the above for the second poll.
-  * Title should be "Community vote".
-  * No group limitation.
+  * Submit the poll (the BBcode will appear in the post):
+  * Repeat the above for the second poll:
+
+    * Title should be "Community vote".
+    * No group limitation.
 
 Voting result stage
-~~~~~~~~~~~~~~~~~~~
+-------------------
 
-* The next day after the last day of the vote, the Committee person:
+The next day after the last day of the vote, the Committee person:
 
-  * Closes the polls.
-  * Removes the ``active-vote`` tag.
-  * Add a comment that the vote ended.
-  * Changes the beginning of the topic's description to ``[Vote ended]``.
-  * Creates a summary comment declaring the vote result.
-* The vote's result and the final decision are announced via the :ref:`Bullhorn <bullhorn>`.
+* Closes the polls if the :ref:`quorum<community_topics_workflow>` is reached, otherwise prolongs the polls.
+* Removes the ``active-vote`` tag.
+* Add a comment that the vote ended.
+* Changes the beginning of the topic's description to ``[Vote ended]``.
+* Creates a summary comment declaring the vote result.
+* Announces the vote result and the final decision in the :ref:`Bullhorn <bullhorn>`.
 
 Implementation stage
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 
-* If the topic implies some actions (if it does not, just mark this as complete), the Committee person:
+No further action required
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  * Assigns the topic to a person responsible for performing the actions.
-  * Add the ``being-implemented`` tag to the topic.
-* After the topic is implemented, the assignee:
+The Committee person:
 
-  * Comments on the topic that the work is done.
-  * Removes the ``being-implemented`` tag.
-  * Add the ``implemented`` tag.
-* If the topic implies actions related to the future Ansible Community package releases (for example, a collection exclusion), the Committee person:
+* Merges an associated pull request if exists.
+* Adds the ``resolved`` tag.
 
-  * Adds the ``scheduled-for-future-release`` tag to the topic.
-  * Checks if there's a corresponding milestone in the `ansible-build-data <https://github.com/ansible-community/ansible-build-data/milestones>`_ repository. If there's no milestone, the person creates it.
-  * Creates an issue in ansible-build-data that references the topic in community-topics, and adds it to the milestone.
+Further actions required
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Committee person:
+
+* Assigns a person responsible for performing the actions by mentioning them in a comment.
+* Adds the ``being-implemented`` tag to the topic.
+
+After the actions are done, the assignee:
+
+* Comments on the topic that the work is done.
+* Removes the ``being-implemented`` tag.
+* Adds the ``implemented`` and ``resolved`` tags.
+
+Package-release related actions required
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the topic implies actions related to the future Ansible Community package releases (for example, a collection exclusion), the Committee person/assignee:
+
+* Adds the ``scheduled-for-future-release`` tag to the topic.
+* Checks if there is a corresponding milestone in the `ansible-build-data <https://github.com/ansible-community/ansible-build-data/milestones>`_ repository.
+
+  * If there is no milestone, the person creates it.
+* Creates an issue in ansible-build-data that references the topic and adds it to the milestone.
+* After it is implemented, adds the ``implemented`` and ``resolved`` tags.
 
 Tools
-~~~~~
+-----
 
 There are a few `scripts <https://github.com/ansible-community/community-topics/tree/main/scripts>`_ that can be used to create Ansible community announcements on Bullhorn and similar.
 

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -23,7 +23,7 @@ The workflow is a set of actions that need to be done successively within the co
 Creating a topic
 ----------------
 
-Any person can `create a topic <https://forum.ansible.com/new-topic?title=topic%20title&body=topic%20body&category=project&tags=community-wg>`_ tagged with ``community-wg`` under the ``Project Discussions`` category in the `Ansible Forum <https://forum.ansible.com/>`_.
+Any person can :ref:`create a community topic<creating_community_topic>`.
 
 Preparation stage
 -----------------

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -61,7 +61,7 @@ The vote always consists of two polls: one for the Steering Committee, one for e
   * Set up the options (generally this will be ``Single Choice`` but other poll types can be used).
   * Title it "Steering Committee vote" and ``Limit voting`` to the ``@SteeringCommittee``.
   * Do NOT set the close date because this cannot be changed later.
-  * Results should be ``Always Visible`` unless there is some good reason for the SC votes not to be public.
+  * Results should be ``Always Visible`` unless there is a good reason for the SC votes not to be public.
   * Submit the poll (the BBcode will appear in the post):
   * Repeat the above for the second poll:
 

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -75,7 +75,7 @@ The next day after the last day of the vote, the Committee person:
 
 * Closes the polls if the :ref:`quorum<community_topics_workflow>` is reached, otherwise prolongs the polls.
 * Removes the ``active-vote`` tag.
-* Add a comment that the vote ended.
+* Adds a comment that the vote has ended.
 * Changes the beginning of the topic's description to ``[Vote ended]``.
 * Creates a summary comment declaring the vote result.
 * Announces the vote result and the final decision in the :ref:`Bullhorn <bullhorn>`.

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -44,7 +44,7 @@ Voting stage
 The Committee person:
 
 * Formulates vote options based on the prior discussion and gives participants up to one week to propose changes to the options. This step takes place one to two weeks after the discussion was opened, depending on the complexity of the topic.
-* Summarizes the options in a comment and also establishes a date when the vote begins and ends if there are no objections about the options.
+* Summarizes the options in a comment and establishes a dates for the vote to begin if there are no objections to the options.
 * In the vote date, starts the vote and establishes its end date, which is $CURRENT_DATE plus:
 
   * 7 days: simple cases

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -114,7 +114,7 @@ If the topic implies actions related to the future Ansible community package rel
 * Checks if there is a corresponding milestone in the `ansible-build-data <https://github.com/ansible-community/ansible-build-data/milestones>`_ repository.
 
   * If there is no milestone, the person creates it.
-* Creates an issue in ansible-build-data that references the topic and adds it to the milestone.
+* Creates an issue in ``ansible-build-data`` that references the topic and adds it to the milestone.
 * After it is implemented, adds the ``implemented`` and ``resolved`` tags.
 
 Tools

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -4,121 +4,101 @@
    For other changes, create a `community topic <https://forum.ansible.com/new-topic?category=project&tags=community-wg>`_ to discuss them.
    (Creating a draft PR for this file and mentioning it in the community topic is also OK.)
 
-Ansible community topics workflow
-=================================
+.. _community_topics_workflow:
+
+Community topics workflow
+=========================
 
 Overview
 --------
 
-This document describes the Ansible community topics workflow (herein after ``Workflow``) to provide guidance on successful resolving topics in an asynchronous way.
+This document describes the Ansible Community Topics workflow (hereinafter Workflow) to provide guidance on successful resolving topics in the asynchronous way.
 
 The Workflow is a set of actions that need to be done successively within the corresponding time frames.
-
-.. note::
-
-   If you have any ideas on how the Workflow can be improved, please create an issue in this repository or pull request against this document.
 
 Creating a topic
 ----------------
 
-Any person can `create a topic <https://forum.ansible.com/new-topic?title=topic%20title&body=topic%20body&category=project&tags=community-wg>`_ tagged with ``community-wg`` under the ``Project Discussions`` category in the `Ansible Forum <https://forum.ansible.com/>`_. A :ref:`Steering Committee member<steering_members>` can tag the forum post with `community-wg-nextmtg` to put it on the meeting agenda.
+Any person can `create a topic <https://forum.ansible.com/new-topic?title=topic%20title&body=topic%20body&category=project&tags=community-wg>`_ tagged with ``community-wg`` under the ``Project Discussions`` category in the `Ansible Forum <https://forum.ansible.com/>`_.
+A :ref:`steering committee <steering_responsibilities>` member can tag the forum post with ``community-wg-nextmtg`` to put it on the meeting agenda.
 
 Workflow
 --------
 
 .. note::
 
-  This is a rough scenario and it can vary depending on a topic's complexity and other nuances, for example, when there is a mass agreement upfront.
+  This is a rough scenario and it can vary depending on a topic's complexity and other nuances, for example, when there is a mass agreement up-front.
 
 Preparation stage
-^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~
 
-A Committee person checks the topic content and asks the author, or other persons, to provide additional information if needed.
+* A Committee person checks the topic's content, asks the author/other persons to provide additional information if needed.
 
 Discussion stage
-^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~
 
 * If the topic is ready to be discussed, the Committee person:
 
   * Adds the ``community-wg-nextmtg`` tag if it needs to be discussed in the meeting.
-
   * Opens the discussion by adding a comment asking the Community and the Committee to take part in it.
-
 * No synchronous discussion is needed (there are no blockers, complications, confusion, or impasses).
 
 Voting stage
-^^^^^^^^^^^^
+~~~~~~~~~~~~
 
-* Depending on the topic complexity, 1-2 weeks after the discussion was opened, the Committee person formulates vote options based on the prior discussion and gives participants a reasonable amount of time to propose changes to the options (no longer than a week). The person summarizes the options in a comment and also establishes a date when the vote begins if there are no objections about the options or vote date.
-* In the vote date, the vote starts with a comment from a Committee person who opens the vote and establishes a date when the vote ends ($CURRENT_DATE + no longer than 21 days; Usually it should not exceed 14 days. 21 days should only be used if it is known that a lot of interested persons will likely not have time to vote in a 14 day period).
+* Depending on the topic's complexity, 1-2 weeks after the discussion was opened, the Committee person formulates vote options based on the prior discussion and gives participants reasonable amount of time to propose changes to the options (no longer than a week). The person summarizes the options in a comment and also establishes a date when the vote begins if there are no objections about the options/vote date.
+* In the vote date, the vote starts with the comment of a Committee person which opens the vote and establishes a date when the vote ends ($CURRENT_DATE + no longer than 21 days; usually it should not exceed 14 days, 21 days should only be used if it is known that a lot of interested persons will likely not have time to vote in a 15 days period).
 * The Committee person labels the topic with the ``active-vote`` tag.
-* The Committee person adds ``[Vote ends on $YYYY-MM-DD]`` to the beginning of the topic description.
+* The Committee person adds ``[Vote ends on $YYYY-MM-DD]`` to the beginning of the topic's description.
 * A vote is actually two polls, one for the Steering Committee, one for everyone else. To create a vote in a topic:
 
   * Create a new post in the topic.
-
-  * Click the ``gear`` button in the composer and select ``Build Poll``.
-
+  * Click the ``gear`` button in the composer and select Build Poll.
   * Click the ``gear`` in the Poll Builder for advanced mode.
-
   * Set up the options (generally this will be Single Choice but other poll types can be used).
-
   * Title it "Steering Committee vote" and "Limit voting" to the ``Steering Committee``.
-
-  * Do not set the close date because it cannot be changed later.
-
-  * Results should be "Always Visible" unless there is some good reason for the SC votes not to be public.
-
+  * Do not set the close date because this cannot be changed later.
+  * Results should be ``Always Visible`` unless there is some good reason for the SC votes not to be public.
   * Submit the poll (the BBcode will appear in the post) and then repeat the above for the second poll.
-
-    * The title should be "Community vote".
-
-    * No group limitation.
+  * Title should be "Community vote".
+  * No group limitation.
 
 Voting result stage
-^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~
 
-* The day after the last day of the vote, the Committee person:
+* The next day after the last day of the vote, the Committee person:
 
   * Closes the polls.
-
   * Removes the ``active-vote`` tag.
-
   * Add a comment that the vote ended.
-
   * Changes the beginning of the topic's description to ``[Vote ended]``.
-
   * Creates a summary comment declaring the vote result.
-
-* The vote result and final decision are announced via the `Bullhorn newsletter <https://forum.ansible.com/c/news/bullhorn/17>`_.
-
+* The vote's result and the final decision are announced via the :ref:`Bullhorn <bullhorn>`.
 
 Implementation stage
-^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~
 
 * If the topic implies some actions (if it does not, just mark this as complete), the Committee person:
 
-  * Assigns the topic to the person who is responsible for performing the actions.
-
+  * Assigns the topic to a person responsible for performing the actions.
   * Add the ``being-implemented`` tag to the topic.
-
-  * After the topic is implemented, the assignee:
+* After the topic is implemented, the assignee:
 
   * Comments on the topic that the work is done.
-
   * Removes the ``being-implemented`` tag.
-
   * Add the ``implemented`` tag.
-
 * If the topic implies actions related to the future Ansible Community package releases (for example, a collection exclusion), the Committee person:
 
   * Adds the ``scheduled-for-future-release`` tag to the topic.
-
-  * Checks if there is a corresponding milestone in the `ansible-build-data <https://github.com/ansible-community/ansible-build-data/milestones>`_ repository. If there is no milestone, the person creates it.
-
-  * Creates an issue in ansible-build-data that references the :ref:`community topic<creating_community_topic>`, and adds it to the milestone.
+  * Checks if there's a corresponding milestone in the `ansible-build-data <https://github.com/ansible-community/ansible-build-data/milestones>`_ repository. If there's no milestone, the person creates it.
+  * Creates an issue in ansible-build-data that references the topic in community-topics, and adds it to the milestone.
 
 Tools
------
+~~~~~
 
-We have some `scripts <https://github.com/ansible-community/community-topics/tree/main/scripts>`_ that can be used to create Ansible community announcements in the Bullhorn and similar places.
+There are a few `scripts <https://github.com/ansible-community/community-topics/tree/main/scripts>`_ that can be used to create Ansible community announcements on Bullhorn and similar.
+
+.. seealso::
+
+  :ref:`steering committee <steering_responsibilities>`
+     Ansible Community Steering Committee

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -18,7 +18,8 @@ The workflow is a set of actions that need to be completed in order within the c
 
 .. note::
 
-  This is a rough scenario and it can vary depending on a topic's complexity and other nuances, for example, when there is a mass agreement up-front.
+  The following section outlines a generic scenario for a workflow.
+  Workflows can vary depending on a topic's complexity and other nuances; for example, when there is a mass agreement from the beginning.
 
 Creating a topic
 ----------------

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -45,7 +45,7 @@ The Committee person:
 
 * Formulates vote options based on the prior discussion and gives participants up to one week to propose changes to the options. This step takes place one to two weeks after the discussion was opened, depending on the complexity of the topic.
 * Summarizes the options in a comment and establishes a dates for the vote to begin if there are no objections to the options.
-* In the vote date, starts the vote and establishes its end date, which is $CURRENT_DATE plus:
+* Starts the vote on the beginning date and establishes an end date, which is $CURRENT_DATE plus:
 
   * 7 days: simple cases
   * 14 days: should not be more than that

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -44,7 +44,7 @@ Voting stage
 The Committee person:
 
 * Formulates vote options based on the prior discussion and gives participants up to one week to propose changes to the options. This step takes place one to two weeks after the discussion was opened, depending on the complexity of the topic.
-* Summarizes the options in a comment and establishes a dates for the vote to begin if there are no objections to the options.
+* Summarizes the options in a comment and establishes a date for the vote to begin if there are no objections to the options.
 * Starts the vote on the beginning date and establishes an end date, which is $CURRENT_DATE plus:
 
   * 7 days: simple cases

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -120,7 +120,7 @@ If the topic implies actions related to the future Ansible community package rel
 Tools
 -----
 
-There are a few `scripts <https://github.com/ansible-community/community-topics/tree/main/scripts>`_ that can be used to create Ansible community announcements on Bullhorn and similar.
+There are a few `scripts <https://github.com/ansible-community/community-topics/tree/main/scripts>`_ that can be used to create Ansible community announcements on the Bullhorn and similar locations.
 
 .. seealso::
 

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -14,7 +14,7 @@ Overview
 
 This document describes the Ansible community topics workflow to provide guidance on successful resolving topics in the asynchronous way.
 
-The workflow is a set of actions that need to be done successively within the corresponding time frames.
+The workflow is a set of actions that need to be completed in order within the corresponding time frames.
 
 .. note::
 

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -43,7 +43,7 @@ Voting stage
 
 The Committee person:
 
-* Depending on the topic's complexity, 1-2 weeks after the discussion was opened, formulates vote options based on the prior discussion and gives participants reasonable amount of time to propose changes to the options (no longer than a week).
+* Formulates vote options based on the prior discussion and gives participants up to one week to propose changes to the options. This step takes place one to two weeks after the discussion was opened, depending on the complexity of the topic.
 * Summarizes the options in a comment and also establishes a date when the vote begins and ends if there are no objections about the options.
 * In the vote date, starts the vote and establishes its end date, which is $CURRENT_DATE plus:
 

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -33,7 +33,7 @@ Preparation stage
 Discussion stage
 ----------------
 
-* The discussion by default happens asynchronously in the topic.
+* By default, the discussion happens asynchronously in the topic.
 
   * A :ref:`steering committee <steering_responsibilities>` member can tag the forum post with ``community-wg-nextmtg`` to put it on the synchronous meeting agenda.
 


### PR DESCRIPTION
- Moves https://github.com/ansible-community/community-topics/blob/main/community_topics_workflow.md to docs.ansible.com
- I don't change refs in other committee docs in this PRs until other now-pending PRs get merged (will do in another PR after that)
- Stub https://github.com/ansible-community/community-topics/blob/main/community_topics_workflow.md after merging this
- It simplifies, restructures, and slightly changes things, I'm not sure if the vote is needed though. Maybe just a couple of approvals from SC here