### PR TITLE
Update task definition in playbook getting started doc

### DIFF
--- a/docs/docsite/rst/getting_started/get_started_playbook.rst
+++ b/docs/docsite/rst/getting_started/get_started_playbook.rst
@@ -13,7 +13,7 @@ Play
    An ordered list of tasks that maps to managed nodes in an inventory.
 
 Task
-   A list of one or more modules that defines the operations that Ansible performs.
+   A reference to a single module that defines the operations that Ansible performs.
 
 Module
    A unit of code or binary that Ansible runs on managed nodes.


### PR DESCRIPTION
I'm almost positive there's no way to provide multiple modules to a single task - if I'm wrong we should probably include examples to such a situation, maybe in an advanced section of the docs.