### PR TITLE
Fix internal links for ansible forum

### DIFF
--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -215,7 +215,7 @@ The Bullhorn
 ============
 
 **The Bullhorn** is our newsletter for the Ansible contributor community. You can get Bullhorn updates
-from the :ref:`forum` or `subscribe <https://eepurl.com/gZmiEP>`_ to receive it.
+from the :ref:`ansible_forum` or `subscribe <https://eepurl.com/gZmiEP>`_ to receive it.
 
 If you have any questions or content you would like to share, you are welcome to chat with us
 in the `Ansible Social room on Matrix<https://matrix.to/#/#social:ansible.com>, and mention
@@ -229,7 +229,7 @@ Asking questions over email
 
 .. note::
 
-  This form of communication is deprecated. Consider using the :ref:`forum` instead.
+  This form of communication is deprecated. Consider using the :ref:`ansible_forum` instead.
 
 Your first post to the mailing list will be moderated (to reduce spam), so please allow up to a day or so for your first post to appear.
 

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -362,7 +362,7 @@ See the `argcomplete documentation <https://kislyuk.github.io/argcomplete/>`_.
        Learning ansible's configuration management language
    :ref:`installation_faqs`
        Ansible Installation related to FAQs
-   :ref:`forum`
+   :ref:`ansible_forum`
        Join the Ansible community forum to get help and share insights
    :ref:`communication_irc`
        How to join Ansible chat channels


### PR DESCRIPTION
Fix internal links for ansible forum.

By #912 , anchor `_forum` was modified to `_ansible_forum`.
However, the internal links ware still `forum`.

I noticed the error in  my PR #1051 CI [fail](https://github.com/ansible/ansible-documentation/actions/runs/7625997151/job/20771459140?pr=1051#step:5:51).

```log
nox > python tests/checkers.py docs-build
Running 'docs-build' checker ...
docs/docsite/rst/installation_guide/intro_installation.rst:365:0: undefined-label: undefined label: 'forum'
docs/docsite/rst/community/communication.rst:217:0: undefined-label: undefined label: 'forum'
docs/docsite/rst/community/communication.rst:232:0: undefined-label: undefined label: 'forum'
nox > Command python tests/checkers.py docs-build failed with exit code 1
nox > Session checkers(docs-build) failed.
Error: Process completed with exit code 1.
```