### PR TITLE
nox: run clone-core session in a venv as well

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -110,7 +110,7 @@ def pip_compile(session: nox.Session, req: str):
     # fmt: on
 
 
-@nox.session(name="clone-core", venv_backend="none")
+@nox.session(name="clone-core")
 def clone_core(session: nox.Session):
     """
     Clone relevant portions of ansible-core from ansible/ansible into the current


### PR DESCRIPTION
Previously, the clone-core session ran in the global environment
(`venv_backend="none"`) and instead of provisioning a venv. I did this
to save time, as the clone-core session needs no other dependencies
besides a python interpreter. This turned out to be shortsighted. It's
better to just create an empty venv that we know we can call `python` in
as opposed to relying on whatever `python` may or may not be on `$PATH`.
Some systems may only have `python3` or have `python` pointing to the
wrong thing.

Fixes: https://github.com/ansible/ansible-documentation/issues/1054
