### PR TITLE
Add documentation for module option context

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
@@ -770,7 +770,7 @@ This section will discuss the behavioral attributes for arguments:
 
   .. versionadded:: 2.17
 
-  This key accepts an arbitrary dict of additional context utilized by the module for a specific option.
+  You can set the value of the ``context`` key to a dict of custom content. This allows you to provide additional context in the argument spec.
 
   Example:
 

--- a/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
@@ -766,6 +766,23 @@ This section will discuss the behavioral attributes for arguments:
 
   If ``options`` is specified, ``required_by`` refers to the sub-options described in ``options`` and behaves as in :ref:`argument_spec_dependencies`.
 
+:context:
+
+  .. versionadded:: 2.17
+
+  This key accepts an arbitrary dict of additional context utilized by the module for a specific option.
+
+  Example:
+
+  .. code-block:: python
+
+      option = {
+          'type': 'str',
+          'context': {
+              'disposition': '/properties/apiType',
+          },
+          'choices': ['http', 'soap'],
+      }
 
 .. _argument_spec_dependencies:
 

--- a/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
@@ -770,7 +770,7 @@ This section will discuss the behavioral attributes for arguments:
 
   .. versionadded:: 2.17
 
-  You can set the value of the ``context`` key to a dict of custom content. This allows you to provide additional context in the argument spec.
+  You can set the value of the ``context`` key to a dict of custom content. This allows you to provide additional context in the argument spec. The content provided is not validated or utilized by the core engine.
 
   Example:
 


### PR DESCRIPTION
This PR adds documentation for the new module option context added in https://github.com/ansible/ansible/pull/82183