### PR TITLE
ci pip-compile: add appropriate labels to dev and docs jobs

### DIFF
--- a/.github/workflows/pip-compile-dev.yml
+++ b/.github/workflows/pip-compile-dev.yml
@@ -15,6 +15,9 @@ name: "Refresh dev dependencies"
       reset-branch:
         type: boolean
         default: false
+      labels:
+        required: false
+        type: string
   push:
     branches:
       - devel
@@ -37,4 +40,5 @@ jobs:
         'pip-compile-3.10(static)'
         'pip-compile-3.10(spelling)'
       reset-branch: "${{ inputs.reset-branch || false }}"
+      labels: "${{ inputs.labels || 'backport-2.14,backport-2.15,backport-2.16,tooling' }}"
     secrets: inherit

--- a/.github/workflows/pip-compile-docs.yml
+++ b/.github/workflows/pip-compile-docs.yml
@@ -15,6 +15,9 @@ name: "Refresh docs build dependencies"
       reset-branch:
         type: boolean
         default: false
+      labels:
+        required: false
+        type: string
   push:
     branches:
       - devel
@@ -33,4 +36,5 @@ jobs:
       pr-branch: "${{ inputs.pr-branch || 'pip-compile/devel/docs' }}"
       nox-args: "-e 'pip-compile-3.10(requirements)' 'pip-compile-3.10(requirements-relaxed)'"
       reset-branch: "${{ inputs.reset-branch || false }}"
+      labels: "${{ inputs.labels || 'doc builds,no_backport' }}"
     secrets: inherit

--- a/.github/workflows/reusable-pip-compile.yml
+++ b/.github/workflows/reusable-pip-compile.yml
@@ -29,6 +29,9 @@ name: "Refresh pinned dependencies"
       reset-branch:
         type: boolean
         default: false
+      labels:
+        type: string
+        default: ""
 jobs:
   refresh:
     runs-on: ubuntu-latest
@@ -86,6 +89,7 @@ jobs:
           pr_branch: "${{ inputs.pr-branch }}"
           message: "${{ inputs.message }}"
           changed_files: "${{ inputs.changed-files }}"
+          labels: "${{ inputs.labels }}"
         run: |
           set -x
           git diff || :
@@ -99,9 +103,18 @@ jobs:
           git push --force origin "${pr_branch}"
           if [ "${{ steps.branch.outputs.branch-exists }}" = "false" ]
           then
-            gh pr create \
-              --base "${base_branch}" \
-              --title "${message}" \
-              --body "" \
+            command=(gh pr create
+              --base "${base_branch}"
+              --title "${message}"
+              --body ""
               --label dependency_update
+            )
+            # Add custom labels to the command.
+            old_ifs="$IFS"
+            IFS=","
+            for label in ${labels}; do
+              command+=("--label" "${label}")
+            done
+            IFS="${old_ifs}"
           fi
+          "${command[@]}"


### PR DESCRIPTION
This PR updates the workflow that automatically creates the dependency update PRs to add appropriate labels to the PRs so I don't have to do it manually.

Dev dependency PRs are usually backported to all stable branches and
should be marked with the `tooling` label. Labels added are:

- backport-2.14
- backport-2.15
- backport-2.16
- tooling

Doc build dependency PRs are never backported and should be marked with
the `doc builds` label. Labels added are:

- doc builds
- no_backport