### PR TITLE
[network] update note about `gather_network_resources`

### DIFF
--- a/docs/docsite/rst/network/getting_started/first_playbook.rst
+++ b/docs/docsite/rst/network/getting_started/first_playbook.rst
@@ -207,6 +207,6 @@ The playbook returns the following interface facts:
             }
 
 
-Note that this returns a subset of what is returned by just setting ``gather_subset: interfaces``.
+Note that `gather_network_resources` renders configuration data as facts for all supported resources (interfaces/bgp/ospf/etc.), whereas, `gather_subset` is primarily used to fetch operational data.
 
 You can store these facts and use them directly in another task, such as with the :ansplugin:`eos_interfaces <arista.eos.eos_interfaces#module>` resource module.

--- a/docs/docsite/rst/network/getting_started/first_playbook.rst
+++ b/docs/docsite/rst/network/getting_started/first_playbook.rst
@@ -207,6 +207,6 @@ The playbook returns the following interface facts:
             }
 
 
-Note that `gather_network_resources` renders configuration data as facts for all supported resources (interfaces/bgp/ospf/etc.), whereas, `gather_subset` is primarily used to fetch operational data.
+Note that ``gather_network_resources`` renders configuration data as facts for all supported resources (interfaces, bgp, ospf, and so on), whereas, ``gather_subset`` is primarily used to fetch operational data.
 
 You can store these facts and use them directly in another task, such as with the :ansplugin:`eos_interfaces <arista.eos.eos_interfaces#module>` resource module.


### PR DESCRIPTION
The doc currently says that `gather_network_resources` returns a subset of the data returned by `gather_subset`. This is not fully accurate. In general, `gather_subset: interfaces` deals with operational data from the interfaces, whereas, `gather_network_resources: interfaces` returns configurations facts _only_. There might be some overlap due to the nature of the data returned, but they are meant to return different information.