### PR TITLE
fix version switcher problem

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -46,7 +46,7 @@ VERSION = (
      # Controls branch version for core releases
     '2.16' if tags.has('core_lang') or tags.has('core') else
     # Controls branch version for Ansible package releases
-    'devel' if tags.has('ansible') or tags.has('all')
+    '9' if tags.has('ansible') or tags.has('all')
     else '<UNKNOWN>'
 )
 AUTHOR = 'Ansible, Inc'


### PR DESCRIPTION
Fixes regression introduced in https://github.com/ansible/ansible-documentation/pull/1069

TL;DR; the 'VERSION` in releases other than devel have to match the actual release (2.16 or 9 in this instance). So any backports to this area of the code have to be adjusted for this difference with devel.