### PR TITLE
Fix core deprecation cycle example to match reality

### DIFF
--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -408,7 +408,7 @@ Since Ansible is a package of individual collections, the deprecation cycle depe
 ansible-core deprecation cycle
 -------------------------------
 
-The deprecation cycle in ``ansible-core`` is normally across 4 feature releases (2.x. where the x marks a feature release). The feature is normally removed in the 4th release after we announce the deprecation. For example, something deprecated in 2.10 will be removed in 2.14. The tracking is tied to the number of releases, not the release numbering itself.
+The deprecation cycle in ``ansible-core`` is normally across 4 feature releases (2.x. where the x marks a feature release). The feature is normally removed in the 4th release after we announce the deprecation. For example, something deprecated in 2.10 will be removed in 2.13. The tracking is tied to the number of releases, not the release numbering itself. Although this is the standard, there are times where a deprecation cycle for a feature or behavior may have a longer or shorter deprecation cycle based on use or urgency of removal.
 
 .. seealso::
 


### PR DESCRIPTION
This PR updates the example in the core deprecation cycle to reflect reality.  The 4th release including the version the deprecation was introduced in, not 4 releases excluding the introduced version.

We realized that the documentation didn't match what we were doing in practice, and after polling the core team, nearly everyone believed that what I'm changing to in this PR was what we did, or those that didn't, believed that the documentation was wrong, but knew what the documentation stated.

Also clarification that while 4 releases is our standard, there are cases where we will do longer or shorter if there is a necessity.