### PR TITLE
Commented out ellipsis in YAML inventory samples

### DIFF
--- a/docs/docsite/rst/inventory_guide/intro_inventory.rst
+++ b/docs/docsite/rst/inventory_guide/intro_inventory.rst
@@ -20,6 +20,8 @@ Ansible :ref:`inventory_plugins` supports a range of formats and sources to make
 .. contents::
    :local:
 
+.. note:: The following YAML snippets include an ellipsis to indicate they are part of a larger YAML file. You can find out more about YAML syntax at `YAML Basics <https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html#yaml-basics">`_.
+
 .. _inventoryformat:
 
 Inventory basics: formats, hosts, and groups

--- a/docs/docsite/rst/inventory_guide/intro_inventory.rst
+++ b/docs/docsite/rst/inventory_guide/intro_inventory.rst
@@ -185,7 +185,7 @@ In YAML:
 
 .. code-block:: yaml
 
-      # ...
+    # ...
       webservers:
         hosts:
           www[01:50].example.com:
@@ -203,7 +203,7 @@ In YAML:
 
 .. code-block:: yaml
 
-      # ...
+    # ...
       webservers:
         hosts:
           www[01:50:2].example.com:
@@ -349,7 +349,7 @@ In YAML:
 
 .. code-block:: yaml
 
-      # ...
+    # ...
       hosts:
         jumper:
           ansible_port: 5555

--- a/docs/docsite/rst/inventory_guide/intro_inventory.rst
+++ b/docs/docsite/rst/inventory_guide/intro_inventory.rst
@@ -185,7 +185,7 @@ In YAML:
 
 .. code-block:: yaml
 
-    ...
+      # ...
       webservers:
         hosts:
           www[01:50].example.com:
@@ -203,7 +203,7 @@ In YAML:
 
 .. code-block:: yaml
 
-    ...
+      # ...
       webservers:
         hosts:
           www[01:50:2].example.com:
@@ -349,7 +349,7 @@ In YAML:
 
 .. code-block:: yaml
 
-    ...
+      # ...
       hosts:
         jumper:
           ansible_port: 5555


### PR DESCRIPTION
Commented out ellipsis in YAML inventory samples.

This is because someone misunderstood that `...` was necessary.
https://forum.ansible.com/t/how-to-add-hosts-with-yaml-files/3745/4

The method of commenting out was adapted from other pages such as the following.

- https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-access-shell-environment-variables
- https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_strategies.html#running-on-a-single-machine-with-run-once