### PR TITLE
Fix syntax error in error condition

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -38,8 +38,8 @@ applied_tags_count = sum(
     int(tags.has(known_tag_name)) for known_tag_name in KNOWN_TAGS
 )
 assert applied_tags_count == 1, (
-    'Exactly one of the following tags expected: {", ".join(tags)}'.
-    format(tags=KNOWN_TAGS)
+    'Exactly one of the following tags expected: {tags}'.
+    format(tags=", ".join(KNOWN_TAGS))
 )
 
 VERSION = (


### PR DESCRIPTION
Seen when running `make -f Makefile.sphinx CPUS=1 PYTHON=python3 man`.

This should result in an error message, but not a *syntax* error.

Python v3.9.18