### PR TITLE
Update Ansible 9 porting guide

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_9.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_9.rst
@@ -8,15 +8,12 @@ Ansible 9 Porting Guide
 =======================
 
 .. contents::
-  :local:
   :depth: 2
 
 
 Ansible 9 is based on Ansible-core 2.16.
 
-
-We suggest you read this page along with the `Ansible 9 Changelog <https://github.com/ansible-community/ansible-build-data/blob/main/9/CHANGELOG-v9.rst>`_ to understand what updates you may need to make.
-
+We suggest you read this page along with the `Ansible 9 Changelog <https://github.com/ansible-community/ansible-build-data/blob/main/9/CHANGELOG-v9.md>`_ to understand what updates you may need to make.
 
 Playbook
 ========
@@ -86,7 +83,6 @@ Porting custom scripts
 
 Networking
 ==========
-
 
 Porting Guide for v9.2.0
 ========================


### PR DESCRIPTION
Copied over from https://github.com/ansible-community/ansible-build-data/pull/364.

The main change is that it refers to the MarkDown changelog.