### PR TITLE
Document attributes

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -22,7 +22,7 @@ Every Ansible module written in Python must begin with seven standard sections i
   Some older Ansible modules have ``imports`` at the bottom of the file, ``Copyright`` notices with the full GPL prefix, and/or ``DOCUMENTATION`` fields in the wrong order. These are legacy files that need updating - do not copy them into new modules. Over time we are updating and correcting older modules. Please follow the guidelines on this page!
 
 .. note:: For non-Python modules you still create a ``.py`` file for documentation purposes. Starting at ansible-core 2.14 you can instead choose to create a ``.yml`` file that has the same data structure, but in pure YAML.
-          With YAML files, the examples below are easy to use by removing Python quoting and substituting ``=`` for ``:``, for example ``DOCUMENTATION = r''' ... '''` ` to ``DOCUMENTATION: ...`` and removing closing quotes. :ref:`adjacent_yaml_doc`
+          With YAML files, the examples below are easy to use by removing Python quoting and substituting ``=`` for ``:``, for example ``DOCUMENTATION = r''' ... '''`` to ``DOCUMENTATION: ...`` and removing closing quotes. :ref:`adjacent_yaml_doc`
 
 
 .. _shebang:
@@ -134,13 +134,13 @@ All fields in the ``DOCUMENTATION`` block are lower-case. All fields are require
 
 :options:
 
-  * Options are often called `parameters` or `arguments`. Because the documentation field is called `options`, we will use that term.
+  * Options are often called "parameters" or "arguments". Because the documentation field is called ``options``, we will use that term.
   * If the module has no options (for example, it is a ``_facts`` module), all you need is one line: ``options: {}``.
   * If your module has options (in other words, accepts arguments), each option should be documented thoroughly. For each module option, include:
 
   :option-name:
 
-    * Declarative operation (not CRUD), to focus on the final state, for example `online:`, rather than `is_online:`.
+    * Declarative operation (not CRUD), to focus on the final state, for example ``online:``, rather than ``is_online:``.
     * The name of the option should be consistent with the rest of the module, as well as other modules in the same category.
     * When in doubt, look for other modules to find option names that are used for the same purpose, we like to offer consistency to our users.
 
@@ -186,7 +186,7 @@ All fields in the ``DOCUMENTATION`` block are lower-case. All fields are require
 
   :version_added:
 
-    * Only needed if this option was extended after initial Ansible release, in other words, this is greater than the top level `version_added` field.
+    * Only needed if this option was extended after initial Ansible release, in other words, this is greater than the top level ``version_added`` field.
     * This is a string, and not a float, for example, ``version_added: '2.3'``.
     * In collections, this must be the collection version the option was added to, not the Ansible version. For example, ``version_added: 1.0.0``.
 
@@ -430,7 +430,7 @@ Otherwise, for each value returned, provide the following fields. All fields are
   :sample:
     One or more examples.
   :version_added:
-    Only needed if this return was extended after initial Ansible release, in other words, this is greater than the top level `version_added` field.
+    Only needed if this return was extended after initial Ansible release, in other words, this is greater than the top level ``version_added`` field.
     This is a string, and not a float, for example, ``version_added: '2.3'``.
   :contains:
     Optional. To describe nested return values, set ``type: dict``, or ``type: list``/``elements: dict``, or if you really have to, ``type: complex``, and repeat the elements above for each sub-field.

--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -143,6 +143,7 @@ All fields in the ``DOCUMENTATION`` block are lower-case. All fields are require
     * Declarative operation (not CRUD), to focus on the final state, for example ``online:``, rather than ``is_online:``.
     * The name of the option should be consistent with the rest of the module, as well as other modules in the same category.
     * When in doubt, look for other modules to find option names that are used for the same purpose, we like to offer consistency to our users.
+    * (There is no explicit field ``option-name``. This entry is about the *key* of the option in the ``options`` dictionary.)
 
   :description:
 

--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -245,11 +245,50 @@ All fields in the ``DOCUMENTATION`` block are lower-case. All fields are require
 
   * If you use ``ref:`` to link to an anchor that is not associated with a title, you must add a title to the ref for the link to work correctly.
 
+:attributes:
+
+  * A dictionary mapping attribute names to dictionaries describing that attribute.
+  * Usually attributes are provided by documentation fragments, for example ``ansible.builtin.action_common_attributes`` and its sub-fragments.
+    Modules and plugins use the appropriate docs fragments and fill in the ``support``, ``details``, and potential attribute-specific other fields.
+
+  :description:
+
+    * A string or a list of strings. Each string is one paragraph. The description is required.
+    * Explanation of what this attribute does. It should be written in full sentences.
+
+  :details:
+
+    * A string or a list of strings. Each string is one paragraph.
+    * Describes how support might not work as expected by the user.
+    * The details are optional in general, but must be provided if ``support`` is ``partial``.
+
+  :support:
+
+    * One of ``full``, ``none``, ``partial``, or ``N/A``. This is required.
+    * Indicates whether this attribute is supported by this module or plugin.
+
+  :membership:
+
+    * A string or a list of strings.
+    * Must only be used for the attribute ``action_group``, and must always be specified for that attribute.
+    * Lists the action groups this module or action is part of.
+
+  :platforms:
+
+    * A string or a list of strings.
+    * Must only be used for the attribute ``platform``, and must always be specified for that attribute.
+    * Lists the platforms the module or action supports.
+
+  :version_added:
+
+    * Only needed if this attribute's support was extended after the module/plugin was created, in other words, this is greater than the top level ``version_added`` field.
+    * This is a string, and not a float, for example, ``version_added: '2.3'``.
+    * In collections, this must be the collection version the attribute's support was added to, not the Ansible version. For example, ``version_added: 1.0.0``.
 
 :notes:
 
   * Details of any important information that doesn't fit in one of the above sections.
-  * For example, whether ``check_mode`` is or is not supported.
+  * Information on ``check_mode`` or ``diff`` should **not** be listed here, but instead be mentioned in the ``attributes``.
 
 .. _module_documents_linking:
 

--- a/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
@@ -195,7 +195,7 @@ You can pass other keywords, including variables and tags, when including roles:
           tags: typeA
       ...
 
-When you add a :ref:`tag <tags>` to an ``include_role`` task, Ansible applies the tag `only` to the include itself. This means you can pass ``--tags`` to run only selected tasks from the role, if those tasks themselves have the same tag as the include statement. See :ref:`selective_reuse` for details.
+When you add a :ref:`tag <tags>` to an ``include_role`` task, Ansible applies the tag **only** to the include itself. This means you can pass ``--tags`` to run only selected tasks from the role, if those tasks themselves have the same tag as the include statement. See :ref:`selective_reuse` for details.
 
 You can conditionally include a role:
 
@@ -246,7 +246,7 @@ You can pass other keywords, including variables and tags when importing roles:
             app_port: 5000
       ...
 
-When you add a tag to an ``import_role`` statement, Ansible applies the tag to `all` tasks within the role. See :ref:`tag_inheritance` for details.
+When you add a tag to an ``import_role`` statement, Ansible applies the tag to **all** tasks within the role. See :ref:`tag_inheritance` for details.
 
 .. _role_argument_spec:
 


### PR DESCRIPTION
Fixes https://github.com/ansible/ansible-documentation/issues/91

These haven't been documented so far, despite being available since ansible-core 2.12.

I also included them for role entrypoints, where they have been supported in all currently released stable versions. Support has been removed in the current ansible-core `devel` branch, but if that should stay this way it can still be removed again from `devel` after this has been backported to the stable branches.

I've also fixed some broken markup I noticed.

Ref: https://forum.ansible.com/t/antsibull-docs-is-description-for-check-mode-and-diff-mode-required/3923