### PR TITLE
Fix problems with example inventory in the intro_patterns doc

### DIFF
--- a/docs/docsite/rst/inventory_guide/intro_patterns.rst
+++ b/docs/docsite/rst/inventory_guide/intro_patterns.rst
@@ -111,10 +111,11 @@ Your pattern must match your inventory syntax. If you define a host as an :ref:`
 .. code-block:: yaml
 
     atlanta:
-      host1:
-        http_port: 80
-        maxRequestsPerChild: 808
-        host: 127.0.0.2
+      hosts:
+        host1:
+          http_port: 80
+          maxRequestsPerChild: 808
+          host: 127.0.0.2
 
 you must use the alias in your pattern. In the example above, you must use ``host1`` in your pattern. If you use the IP address, you will once again get the error:
 

--- a/docs/docsite/rst/inventory_guide/intro_patterns.rst
+++ b/docs/docsite/rst/inventory_guide/intro_patterns.rst
@@ -115,7 +115,7 @@ Your pattern must match your inventory syntax. If you define a host as an :ref:`
         host1:
           http_port: 80
           maxRequestsPerChild: 808
-          host: 127.0.0.2
+          ansible_host: 127.0.0.2
 
 you must use the alias in your pattern. In the example above, you must use ``host1`` in your pattern. If you use the IP address, you will once again get the error:
 


### PR DESCRIPTION
This PR addresses two problems with the introductory document "Patterns: targeting hosts and groups". First, a syntax error exists in an example inventory file.

I'm onboarding a team member into our ansible codebase, and this [section on the limitations of patterns](https://docs.ansible.com/ansible/latest/inventory_guide/intro_patterns.html#limitations-of-patterns) in the latest Ansible docs caused us both a bit of confusion. The document discusses an example inventory:
```yaml
atlanta:
  host1:
    http_port: 80
    maxRequestsPerChild: 808
    host: 127.0.0.2
```

Trying to use the inventory as written to deepen his understanding of the example, my colleague noticed that ansible complained about the host pattern in the inventory file:
```
$ ansible-playbook -i /tmp/test_inventory.yml /tmp/test_playbook.yml 
[WARNING]: Skipping unexpected key (host1) in group (atlanta), only "vars", "children" and "hosts" are valid
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
[WARNING]: Could not match supplied host pattern, ignoring: host1

PLAY [Test example inventory] *************************************************************
skipping: no hosts matched
```
The first commit in this PR fixes the inventory format, correctly placing `host1` under the `hosts` key in the `atlanta` dictionary. Even though this is an example, I think it's important that the syntax for example files be correct in the documentation.

The **second** problem - addressed in the second commit - is that the example is confusing and misleading. When running `ansible-playbook`, ansible doesn't use `hostvars['host1']['host']` to find the target host's address for SSH, it uses `hostvars['host1']['ansible_host']`. The correctness of the document doesn't depend on this necessarily, but the wording strongly suggests that:

- using the supplied inventory
- using the `host1` alias as the pattern to target a particular host
- `ansible-playbook` will communicate with said host using the address `127.0.0.2`

But this simply isn't the case. Using this amended inventory:
```yaml
atlanta:
  hosts:
    host1:
      http_port: 80
      maxRequestsPerChild: 808
      host: 127.0.0.2
```
...and this playbook:
```yaml
- name: Test example inventory
  hosts: host1
  remote_user: root

  tasks:
    - name: output host var
      ansible.builtin.debug:
        msg: "ansible_host: {{ ansible_host }}"
```
...causes `ansible-playbook` to attempt connecting using the address `host1` instead of `127.0.0.2`:
```
$ ansible-playbook -i /tmp/test_inventory.yml /tmp/test_playbook.yml 

PLAY [Test example inventory] ******************************************************

TASK [Gathering Facts] ************************************************************
fatal: [host1]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: ssh: Could not resolve hostname host1: Name or service not known", "unreachable": true}
```
Replacing `host` with `ansible_host` in the inventory file yields the correct behavior that the documentation hints at:
```
fatal: [host1]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: root@127.0.0.2: Permission denied (publickey,gssapi-keyex,gssapi-with-mic).", "unreachable": true}
```
Note the change in the error message, and the address used in the failed SSH attempt.

Thanks to @tangyisheng2 for bringing this to my attention.