### PR TITLE
Build package docs

### DIFF
--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -1,0 +1,99 @@
+name: Ansible package docs build
+on:
+  workflow_dispatch:
+    inputs:
+      github_fork:
+        description: 'GitHub Fork'
+        required: true
+        default: 'ansible'
+      github_branch:
+        description: 'GitHub Branch'
+        required: true
+        default: 'devel'
+      language:
+        type: choice
+        description: 'Language'
+        required: true
+        default: 'english'
+        options:
+        - 'english'
+        - 'japanese'
+      package_version:
+        type: choice
+        description: 'Ansible Version'
+        required: true
+        default: 'devel'
+        options:
+        - 'devel'
+        - '9'
+        - '8'
+        - '7'
+        - '6'
+        - '5'
+        - '4'
+        - '3'
+        - '2.10'
+      latest_symlink:
+        type: boolean
+        description: 'Add latest symlink'
+        required: true
+
+jobs:
+  build-package-docs:
+    runs-on: ubuntu-latest
+    env:
+      PACKAGE_VERSION: "${{ github.event.inputs.package_version }}"
+      LANGUAGE: ${{ github.event.inputs.language}}
+    steps:
+      - name: Checkout Ansible documentation
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.inputs.github_fork }}/ansible-documentation
+          ref: ${{ github.event.inputs.github_branch }}
+          path: build-directory
+
+      - name: Setup nox
+        uses: wntrblm/nox@2024.03.02
+
+      - name: Output Python info
+        run: python --version --version && which python
+
+      - name: Graft ansible-core
+        run: nox -s clone-core
+        working-directory: build-directory
+
+      - name: Install project requirements
+        run: python -m pip install -r tests/requirements.in -c tests/requirements.txt
+        working-directory: build-directory
+
+      - name: Set the COLLECTION_LIST variable
+        run: |
+          if [ ${PACKAGE_VERSION} == "devel" ]; then
+            echo COLLECTION_LIST="" >> $GITHUB_ENV
+          else
+            echo COLLECTION_LIST="${PACKAGE_VERSION}" >> $GITHUB_ENV
+          fi
+
+      - name: Set the VERSION variable
+        run: |
+          if [ ${LANGUAGE} == "english" ]; then
+            echo VERSION="${PACKAGE_VERSION}" >> $GITHUB_ENV
+          elif [ ${LANGUAGE} == "japanese" ]; then
+            echo VERSION="${PACKAGE_VERSION}_ja" >> $GITHUB_ENV
+          fi
+
+      - name: Build the docs
+        run: make webdocs ANSIBLE_VERSION="${COLLECTION_LIST}"
+        working-directory: build-directory/docs/docsite
+
+      - name: Create latest symlink
+        if: ${{ github.event.inputs.latest_symlink == 'true' }}
+        run: ln -s ${VERSION} _build/latest
+        working-directory: build-directory/docs/docsite
+
+      - name: Create a downloadable archive of the build output
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-docs-build
+          path: build-directory/docs/docsite/_build/html/**
+          retention-days: 7

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -92,7 +92,7 @@ jobs:
       working-directory: build-directory/docs/docsite
 
     - name: Create latest symlink
-      if: github.event.inputs.latest-symlink == 'true'
+      if: github.event.inputs.latest-symlink
       run: ln -s "${VERSION}" _build/html/latest
       working-directory: build-directory/docs/docsite
 

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -1,3 +1,5 @@
+---
+
 name: Ansible package docs build
 on:
   workflow_dispatch:
@@ -41,53 +43,53 @@ jobs:
       PACKAGE_VERSION: ${{ github.event.inputs.package_version }}
       LANGUAGE: ${{ github.event.inputs.language }}
     steps:
-      - name: Checkout Ansible documentation
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event.inputs.github_fork }}/ansible-documentation
-          ref: ${{ github.event.inputs.github_branch }}
-          path: build-directory
+    - name: Checkout Ansible documentation
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.event.inputs.github_fork }}/ansible-documentation
+        ref: ${{ github.event.inputs.github_branch }}
+        path: build-directory
 
-      - name: Setup nox
-        uses: wntrblm/nox@2024.03.02
+    - name: Setup nox
+      uses: wntrblm/nox@2024.03.02
 
-      - name: Output Python info
-        run: python --version --version && which python
+    - name: Output Python info
+      run: python --version --version && which python
 
-      - name: Graft ansible-core
-        run: nox -s clone-core
-        working-directory: build-directory
+    - name: Graft ansible-core
+      run: nox -s clone-core
+      working-directory: build-directory
 
-      - name: Install project requirements
-        run: python -m pip install -r tests/requirements.in -c tests/requirements.txt
-        working-directory: build-directory
+    - name: Install project requirements
+      run: python -m pip install -r tests/requirements.in -c tests/requirements.txt
+      working-directory: build-directory
 
-      - name: Set the COLLECTION_LIST variable
-        if: env.PACKAGE_VERSION != 'devel'
-        run: >-
-          echo COLLECTION_LIST='"${PACKAGE_VERSION}"'
-          >> "${GITHUB_ENV}"
+    - name: Set the COLLECTION_LIST variable
+      if: env.PACKAGE_VERSION != 'devel'
+      run: >-
+        echo COLLECTION_LIST='"${PACKAGE_VERSION}"'
+        >> "${GITHUB_ENV}"
 
-      - name: Set the VERSION variable
-        run: |
-          if [ ${LANGUAGE} == "english" ]; then
-            echo VERSION="${PACKAGE_VERSION}" >> $GITHUB_ENV
-          elif [ ${LANGUAGE} == "japanese" ]; then
-            echo VERSION="${PACKAGE_VERSION}_ja" >> $GITHUB_ENV
-          fi
+    - name: Set the VERSION variable
+      run: |
+        if [ ${LANGUAGE} == "english" ]; then
+          echo VERSION="${PACKAGE_VERSION}" >> $GITHUB_ENV
+        elif [ ${LANGUAGE} == "japanese" ]; then
+          echo VERSION="${PACKAGE_VERSION}_ja" >> $GITHUB_ENV
+        fi
 
-      - name: Build the docs
-        run: make webdocs ANSIBLE_VERSION=${COLLECTION_LIST}
-        working-directory: build-directory/docs/docsite
+    - name: Build the docs
+      run: make webdocs ANSIBLE_VERSION=${COLLECTION_LIST}
+      working-directory: build-directory/docs/docsite
 
-      - name: Create latest symlink
-        if: github.event.inputs.latest_symlink == 'true'
-        run: ln -s ${VERSION} _build/latest
-        working-directory: build-directory/docs/docsite
+    - name: Create latest symlink
+      if: github.event.inputs.latest_symlink == 'true'
+      run: ln -s ${VERSION} _build/latest
+      working-directory: build-directory/docs/docsite
 
-      - name: Create a downloadable archive of the build output
-        uses: actions/upload-artifact@v4
-        with:
-          name: package-docs-build
-          path: build-directory/docs/docsite/_build/html/**
-          retention-days: 7
+    - name: Create a downloadable archive of the build output
+      uses: actions/upload-artifact@v4
+      with:
+        name: package-docs-build
+        path: build-directory/docs/docsite/_build/html/**
+        retention-days: 7

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -83,7 +83,7 @@ jobs:
         working-directory: build-directory/docs/docsite
 
       - name: Create latest symlink
-        if: ${{ github.event.inputs.latest_symlink == 'true' }}
+        if: github.event.inputs.latest_symlink == 'true'
         run: ln -s ${VERSION} _build/latest
         working-directory: build-directory/docs/docsite
 

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -4,11 +4,11 @@ name: Ansible package docs build
 on:
   workflow_dispatch:
     inputs:
-      github_fork:
+      github-fork:
         description: GitHub Fork
         required: true
         default: ansible
-      github_branch:
+      github-branch:
         description: GitHub Branch
         required: true
         default: devel
@@ -20,7 +20,7 @@ on:
         options:
         - english
         - japanese
-      package_version:
+      package-version:
         type: choice
         description: Ansible Version
         required: true
@@ -31,7 +31,7 @@ on:
         - '9'
         - '8'
         - '7'
-      latest_symlink:
+      latest-symlink:
         type: boolean
         description: Add latest symlink
         required: true
@@ -40,14 +40,14 @@ jobs:
   build-package-docs:
     runs-on: ubuntu-latest
     env:
-      PACKAGE_VERSION: ${{ github.event.inputs.package_version }}
+      PACKAGE_VERSION: ${{ github.event.inputs.package-version }}
       LANGUAGE: ${{ github.event.inputs.language }}
     steps:
     - name: Checkout Ansible documentation
       uses: actions/checkout@v4
       with:
-        repository: ${{ github.event.inputs.github_fork }}/ansible-documentation
-        ref: ${{ github.event.inputs.github_branch }}
+        repository: ${{ github.event.inputs.github-fork }}/ansible-documentation
+        ref: ${{ github.event.inputs.github-branch }}
         path: build-directory
 
     - name: Setup nox
@@ -86,7 +86,7 @@ jobs:
       working-directory: build-directory/docs/docsite
 
     - name: Create latest symlink
-      if: github.event.inputs.latest_symlink == 'true'
+      if: github.event.inputs.latest-symlink == 'true'
       run: ln -s ${VERSION} _build/latest
       working-directory: build-directory/docs/docsite
 

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -87,18 +87,22 @@ jobs:
           echo VERSION="${PACKAGE_VERSION}_ja" >> $GITHUB_ENV
         fi
 
-    - name: Build the docs
+    - name: Build the Ansible community package docs
       run: make webdocs ANSIBLE_VERSION=${COLLECTION_LIST}
       working-directory: build-directory/docs/docsite
 
     - name: Create latest symlink
       if: github.event.inputs.latest-symlink == 'true'
-      run: ln -s ${VERSION} _build/latest
+      run: ln -s "${VERSION}" _build/html/latest
       working-directory: build-directory/docs/docsite
 
-    - name: Create a downloadable archive of the build output
+    - name: Create a tarball with the build contents
+      run: tar -zcvf build.tar.gz --directory=_build/html/ .
+      working-directory: build-directory/docs/docsite
+
+    - name: Create a downloadable archive that contains the tarball
       uses: actions/upload-artifact@v4
       with:
         name: package-docs-build
-        path: build-directory/docs/docsite/_build/html/**
+        path: build-directory/docs/docsite/build.tar.gz
         retention-days: 7

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -3,42 +3,42 @@ on:
   workflow_dispatch:
     inputs:
       github_fork:
-        description: 'GitHub Fork'
+        description: GitHub Fork
         required: true
-        default: 'ansible'
+        default: ansible
       github_branch:
-        description: 'GitHub Branch'
+        description: GitHub Branch
         required: true
-        default: 'devel'
+        default: devel
       language:
         type: choice
-        description: 'Language'
+        description: Language
         required: true
-        default: 'english'
+        default: english
         options:
-        - 'english'
-        - 'japanese'
+        - english
+        - japanese
       package_version:
         type: choice
-        description: 'Ansible Version'
+        description: Ansible Version
         required: true
-        default: 'devel'
+        default: devel
         options:
-        - 'devel'
+        - devel
         - '10'
         - '9'
         - '8'
         - '7'
       latest_symlink:
         type: boolean
-        description: 'Add latest symlink'
+        description: Add latest symlink
         required: true
 
 jobs:
   build-package-docs:
     runs-on: ubuntu-latest
     env:
-      PACKAGE_VERSION: "${{ github.event.inputs.package_version }}"
+      PACKAGE_VERSION: ${{ github.event.inputs.package_version }}
       LANGUAGE: ${{ github.event.inputs.language }}
     steps:
       - name: Checkout Ansible documentation
@@ -77,7 +77,7 @@ jobs:
           fi
 
       - name: Build the docs
-        run: make webdocs ANSIBLE_VERSION="${COLLECTION_LIST}"
+        run: make webdocs ANSIBLE_VERSION=${COLLECTION_LIST}
         working-directory: build-directory/docs/docsite
 
       - name: Create latest symlink

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -4,12 +4,16 @@ name: Ansible package docs build
 on:
   workflow_dispatch:
     inputs:
-      github-fork:
-        description: GitHub Fork
+      repository-owner:
+        description: GitHub account or org that owns the repository
         required: true
         default: ansible
-      github-branch:
-        description: GitHub Branch
+      repository-name:
+        description: Name of the GitHub repository
+        required: true
+        default: ansible-documentation
+      repository-branch:
+        description: Branch, tag, or commit SHA
         required: true
         default: devel
       language:
@@ -48,8 +52,8 @@ jobs:
     - name: Checkout Ansible documentation
       uses: actions/checkout@v4
       with:
-        repository: ${{ github.event.inputs.github-fork }}/ansible-documentation
-        ref: ${{ github.event.inputs.github-branch }}
+        repository: ${{ github.event.inputs.repository-owner }}/${{ github.event.inputs.repository-name }}
+        ref: ${{ github.event.inputs.repository-branch }}
         path: build-directory
 
     - name: Setup nox

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -97,7 +97,17 @@ jobs:
       working-directory: build-directory/docs/docsite
 
     - name: Create a tarball with the build contents
-      run: tar -zcvf build.tar.gz --directory=_build/html/ .
+      run: >-
+        tar czvf
+        --directory=_build/html/
+        ansible-package-docs-html-"${PACKAGE_VERSION}"-$(date '+%Y-%m-%d')-${{
+          github.run_id
+        }}-${{
+          github.run_number
+        }}-${{
+          github.run_attempt
+        }}.tar.gz
+        .
       working-directory: build-directory/docs/docsite
 
     - name: Create a downloadable archive that contains the tarball

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -82,7 +82,7 @@ jobs:
     - name: Set the VERSION variable
       run: |
         if [ ${LANGUAGE} == "english" ]; then
-          echo VERSION="${PACKAGE_VERSION}" >> $GITHUB_ENV
+          echo VERSION="${PACKAGE_VERSION}" >> "${GITHUB_ENV}"
         elif [ ${LANGUAGE} == "japanese" ]; then
           echo VERSION="${PACKAGE_VERSION}_ja" >> $GITHUB_ENV
         fi

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PACKAGE_VERSION: "${{ github.event.inputs.package_version }}"
-      LANGUAGE: ${{ github.event.inputs.language}}
+      LANGUAGE: ${{ github.event.inputs.language }}
     steps:
       - name: Checkout Ansible documentation
         uses: actions/checkout@v4

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -25,14 +25,10 @@ on:
         default: 'devel'
         options:
         - 'devel'
+        - '10'
         - '9'
         - '8'
         - '7'
-        - '6'
-        - '5'
-        - '4'
-        - '3'
-        - '2.10'
       latest_symlink:
         type: boolean
         description: 'Add latest symlink'

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -61,7 +61,10 @@ jobs:
       working-directory: build-directory
 
     - name: Install project requirements
-      run: python -m pip install -r tests/requirements.in -c tests/requirements.txt
+      run: |
+        python -m pip install \
+          -r tests/requirements.in \
+          -c tests/requirements.txt
       working-directory: build-directory
 
     - name: Set the COLLECTION_LIST variable

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -88,7 +88,7 @@ jobs:
         fi
 
     - name: Build the Ansible community package docs
-      run: make webdocs ANSIBLE_VERSION=${COLLECTION_LIST}
+      run: make webdocs ANSIBLE_VERSION="${COLLECTION_LIST}"
       working-directory: build-directory/docs/docsite
 
     - name: Create latest symlink

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -20,9 +20,9 @@ on:
         options:
         - english
         - japanese
-      package-version:
+      ansible-package-version:
         type: choice
-        description: Ansible Version
+        description: Version of the Ansible community package to build
         required: true
         default: devel
         options:
@@ -40,7 +40,7 @@ jobs:
   build-package-docs:
     runs-on: ubuntu-latest
     env:
-      PACKAGE_VERSION: ${{ github.event.inputs.package-version }}
+      PACKAGE_VERSION: ${{ github.event.inputs.ansible-package-version }}
       LANGUAGE: ${{ github.event.inputs.language }}
     steps:
     - name: Checkout Ansible documentation

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -63,12 +63,10 @@ jobs:
         working-directory: build-directory
 
       - name: Set the COLLECTION_LIST variable
-        run: |
-          if [ ${PACKAGE_VERSION} == "devel" ]; then
-            echo COLLECTION_LIST="" >> $GITHUB_ENV
-          else
-            echo COLLECTION_LIST="${PACKAGE_VERSION}" >> $GITHUB_ENV
-          fi
+        if: env.PACKAGE_VERSION != 'devel'
+        run: >-
+          echo COLLECTION_LIST='"${PACKAGE_VERSION}"'
+          >> "${GITHUB_ENV}"
 
       - name: Set the VERSION variable
         run: |

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -98,8 +98,7 @@ jobs:
 
     - name: Create a tarball with the build contents
       run: >-
-        tar czvf
-        --directory=_build/html/
+        tar -czvf
         ansible-package-docs-html-"${PACKAGE_VERSION}"-$(date '+%Y-%m-%d')-${{
           github.run_id
         }}-${{
@@ -107,7 +106,7 @@ jobs:
         }}-${{
           github.run_attempt
         }}.tar.gz
-        .
+        --directory=_build/html/ .
       working-directory: build-directory/docs/docsite
 
     - name: Create a downloadable archive that contains the tarball

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -84,7 +84,7 @@ jobs:
         if [ ${LANGUAGE} == "english" ]; then
           echo VERSION="${PACKAGE_VERSION}" >> "${GITHUB_ENV}"
         elif [ ${LANGUAGE} == "japanese" ]; then
-          echo VERSION="${PACKAGE_VERSION}_ja" >> $GITHUB_ENV
+          echo VERSION="${PACKAGE_VERSION}_ja" >> "${GITHUB_ENV}"
         fi
 
     - name: Build the Ansible community package docs

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -36,12 +36,14 @@ on:
         description: Add latest symlink
         required: true
 
+
+env:
+  PACKAGE_VERSION: ${{ github.event.inputs.ansible-package-version }}
+  LANGUAGE: ${{ github.event.inputs.language }}
+
 jobs:
   build-package-docs:
     runs-on: ubuntu-latest
-    env:
-      PACKAGE_VERSION: ${{ github.event.inputs.ansible-package-version }}
-      LANGUAGE: ${{ github.event.inputs.language }}
     steps:
     - name: Checkout Ansible documentation
       uses: actions/checkout@v4


### PR DESCRIPTION
This PR includes a workflow with a job that builds the package docs in the same way as the Red Hat internal Jenkins job. The action also includes a step that creates a downloadable archive of the build output.

This is a first step towards opening up the publishing process to the community. As a follow up we need to figure out the deploy side.

Part of https://github.com/ansible/docsite/issues/179