### PR TITLE
[Stable 2.14] Bump wntrblm/nox from 2023.04.22 to 2024.03.02

### DIFF
--- a/.github/workflows/reusable-nox.yml
+++ b/.github/workflows/reusable-nox.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
       - name: Setup nox
-        uses: wntrblm/nox@2023.04.22
+        uses: wntrblm/nox@2024.03.02
         with:
           python-versions: "${{ matrix.python-versions }}"
       - name: Graft ansible-core


### PR DESCRIPTION
Manual backport of https://github.com/ansible/ansible-documentation/pull/1177

Bumps [wntrblm/nox](https://github.com/wntrblm/nox) from 2023.04.22 to 2024.03.02.
- [Release notes](https://github.com/wntrblm/nox/releases)
- [Changelog](https://github.com/wntrblm/nox/blob/main/CHANGELOG.md)
- [Commits](https://github.com/wntrblm/nox/compare/2023.04.22...2024.03.02)

---
updated-dependencies:
- dependency-name: wntrblm/nox dependency-type: direct:production ...