### PR TITLE
Update documentation about `vars:` in `roles:` for 2.15+

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
@@ -151,7 +151,9 @@ You can pass other keywords to the ``roles`` option:
 
 When you add a tag to the ``role`` option, Ansible applies the tag to ALL tasks within the role.
 
-When using ``vars:`` within the ``roles:`` section of a playbook, the variables are added to the play variables, making them available to all tasks within the play before and after the role. This behavior can be changed by :ref:`DEFAULT_PRIVATE_ROLE_VARS`.
+.. note::
+
+   Prior to ``ansible-core`` 2.15, ``vars:`` within the ``roles:`` section of a playbook are added to the play variables, making them available to all tasks within the play before and after the role. This behavior can be changed by :ref:`DEFAULT_PRIVATE_ROLE_VARS`. On more recent versions, ``vars:`` do not leak into the play's variable scope.
 
 Including roles: dynamic reuse
 ------------------------------


### PR DESCRIPTION
This was spotted in https://github.com/ansible/ansible/issues/82765. This toggle was a workaround for some generally unexpected behavior that was fixed in 2.15.0 by https://github.com/ansible/ansible/commit/0b678d5036f64f95d50d73d3d27a523a2b264050. `vars:` in the play's `roles:` are scoped to the role now and this toggle has no effect on it.

Do we want to keep this as a historical note for a while, or should I delete it?