### PR TITLE
Trim down the docs banners

### DIFF
--- a/docs/docsite/.templates/banner.html
+++ b/docs/docsite/.templates/banner.html
@@ -41,7 +41,7 @@
         /* temp extra banner to advertise something */
         banner += extra_banner;
 
-        msg += 'This is the <b>latest</b> (stable) community documentation. Red Hat customers, see <a href="https://access.redhat.com/support/policy/updates/ansible-automation-platform">Ansible Automation Platform Life Cycle</a>';
+        msg += 'This is the <b>latest</b> (stable) Ansible community documentation. For Red Hat Ansible Automation Platform subscriptions, see <a href="https://access.redhat.com/support/policy/updates/ansible-automation-platform">Life Cycle</a> for version details';
       } else if (startsWith(current_url_path, "/ansible/2.9/")) {
         msg += 'You are reading the latest Red Hat released version of the Ansible documentation. Community users can use this version, or select <b>latest</b> from the version selector to the left for the most recent community version.';
       } else if (startsWith(current_url_path, "/ansible/devel/")) {

--- a/docs/docsite/.templates/banner.html
+++ b/docs/docsite/.templates/banner.html
@@ -41,7 +41,7 @@
         /* temp extra banner to advertise something */
         banner += extra_banner;
 
-        msg += 'This is the <b>latest</b> (stable) Ansible community documentation. For Red Hat Ansible Automation Platform subscriptions, see <a href="https://access.redhat.com/support/policy/updates/ansible-automation-platform">Life Cycle</a> for version details';
+        msg += 'This is the <b>latest</b> (stable) Ansible community documentation. For Red Hat Ansible Automation Platform subscriptions, see <a href="https://access.redhat.com/support/policy/updates/ansible-automation-platform">Life Cycle</a> for version details.';
       } else if (startsWith(current_url_path, "/ansible/2.9/")) {
         msg += 'You are reading the latest Red Hat released version of the Ansible documentation. Community users can use this version, or select <b>latest</b> from the version selector to the left for the most recent community version.';
       } else if (startsWith(current_url_path, "/ansible/devel/")) {

--- a/docs/docsite/.templates/banner.html
+++ b/docs/docsite/.templates/banner.html
@@ -16,12 +16,13 @@
     var banner = '';
       var extra_banner = '';
     /*use extra_banner for when we want something extra, like a survey or Community Day notice */
-    var extra_banner =
+   /*  var extra_banner =
       '<div id="latest_extra_banner_id" class="admonition important">' +
         '<p style="padding-bottom: 1.2rem;">' +
         'Discuss Ansible in the new <a href="https://forum.ansible.com/t/welcome-to-the-ansible-community/5">Ansible Forum!</a>' +
         '</p>' +
       '</div>';
+      */
     // Create a banner if we're not on the official docs site
     if (location.host == "docs.testing.ansible.com") {
       document.write('<div id="testing_banner_id" class="admonition important">' +

--- a/docs/docsite/.templates/banner.html
+++ b/docs/docsite/.templates/banner.html
@@ -41,7 +41,7 @@
         /* temp extra banner to advertise something */
         banner += extra_banner;
 
-        msg += 'This is the <b>latest</b> (stable) community version of the Ansible documentation. For Red Hat customers, see <a href="https://www.ansible.com/compare"> the difference between Ansible community projects and Red Hat supported products</a> or <a href="https://access.redhat.com/support/policy/updates/ansible-automation-platform">Ansible Automation Platform Life Cycle</a> for subscriptions.';
+        msg += 'This is the <b>latest</b> (stable) community documentation. Red Hat customers, see <a href="https://access.redhat.com/support/policy/updates/ansible-automation-platform">Ansible Automation Platform Life Cycle</a>';
       } else if (startsWith(current_url_path, "/ansible/2.9/")) {
         msg += 'You are reading the latest Red Hat released version of the Ansible documentation. Community users can use this version, or select <b>latest</b> from the version selector to the left for the most recent community version.';
       } else if (startsWith(current_url_path, "/ansible/devel/")) {

--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -263,12 +263,12 @@ html_context = {
 html_title = (
     'Ansible Core Documentation' if (
         tags.has('all') or tags.has('core_lang') or tags.has('core')
-    ) else 'Ansible Documentation' if tags.has('ansible')
+    ) else 'Ansible Community Documentation' if tags.has('ansible')
     else '<UNKNOWN>'
 )
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-html_short_title = 'Documentation'
+# html_short_title = 'Community Documentation'
 
 # The name of an image file (within the static path) to place at the top of
 # the sidebar.


### PR DESCRIPTION
Fixes #1155

- removes forum banner
- snips out excess on the latest banner to make it a one-liner instead of two.
- Adds community to the Documentation title.