### PR TITLE
The ipaddr/ipv4/ipv6 filters have moved from netcommon to utils

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_filters.rst
@@ -1240,7 +1240,7 @@ These filters help you with common network tasks.
 
 .. note::
 
-	These filters have migrated to the `ansible.netcommon <https://galaxy.ansible.com/ansible/netcommon>`_ collection. Follow the installation instructions to install that collection.
+	These filters have migrated to the `ansible.utils <https://galaxy.ansible.com/ansible/utils>`_ collection. Follow the installation instructions to install that collection.
 
 .. _ipaddr_filter:
 
@@ -1271,7 +1271,7 @@ address. For example, to get the IP address itself from a CIDR, you can use:
   # => 192.0.2.1
 
 More information about :ansplugin:`ansible.utils.ipaddr#filter` filter and complete usage guide can be found
-in :ref:`playbooks_filters_ipaddr`.
+in :ref:`plugins_in_ansible.utils`.
 
 .. _network_filters:
 

--- a/docs/docsite/rst/playbook_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_filters.rst
@@ -1253,24 +1253,24 @@ To test if a string is a valid IP address:
 
 .. code-block:: yaml+jinja
 
-  {{ myvar | ansible.netcommon.ipaddr }}
+  {{ myvar | ansible.utils.ipaddr }}
 
 You can also require a specific IP protocol version:
 
 .. code-block:: yaml+jinja
 
-  {{ myvar | ansible.netcommon.ipv4 }}
-  {{ myvar | ansible.netcommon.ipv6 }}
+  {{ myvar | ansible.utils.ipv4 }}
+  {{ myvar | ansible.utils.ipv6 }}
 
 IP address filter can also be used to extract specific information from an IP
 address. For example, to get the IP address itself from a CIDR, you can use:
 
 .. code-block:: yaml+jinja
 
-  {{ '192.0.2.1/24' | ansible.netcommon.ipaddr('address') }}
+  {{ '192.0.2.1/24' | ansible.utils.ipaddr('address') }}
   # => 192.0.2.1
 
-More information about :ansplugin:`ansible.netcommon.ipaddr#filter` filter and complete usage guide can be found
+More information about :ansplugin:`ansible.utils.ipaddr#filter` filter and complete usage guide can be found
 in :ref:`playbooks_filters_ipaddr`.
 
 .. _network_filters:


### PR DESCRIPTION
Two things I wasn't sure about and hence didn't touch:

1. what to do with the `versionadded:: 1.9` as it is now part of  a (new) collection, with its own version
2. if the reference ```:ref:`playbooks_filters_ipaddr` ``` is still a good idea as the document `` redirects to ```:ref:`plugins_in_ansible.utils` ```