### PR TITLE
Update playbooks_blocks.rst

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_blocks.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_blocks.rst
@@ -192,7 +192,7 @@ These can be inspected in the ``rescue`` section:
   tasks:
     - name: Attempt and graceful roll back demo
       block:
-        - name: Do something
+        - name: Do Something
           ansible.builtin.shell: grep $(whoami) /etc/hosts
 
         - name: Force a failure, if previous one succeeds


### PR DESCRIPTION
In rescue block we are looking for 'Do Something' , but the task name is 'do something' . Due to the case difference, rescue is getting skipped as condition is not getting met