### PR TITLE
use ruff check <path> syntax in noxfile

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -31,7 +31,7 @@ def static(session: nox.Session):
     Run static checkers
     """
     install(session, req="static")
-    session.run("ruff", *session.posargs, *LINT_FILES)
+    session.run("ruff", "check", *session.posargs, *LINT_FILES)
 
 
 @nox.session


### PR DESCRIPTION
The `ruff <path>` syntax is deprecated in favour of `ruff check <path>` and nox issues a warning when ruff is updated to version 0.3. This PR updates the ruff syntax in the noxfile.

Relates to https://github.com/ansible/ansible-documentation/pull/1172