### PR TITLE
[Needs SC vote before merging] SC: update collection inclusion procedure

### DIFF
--- a/docs/docsite/rst/community/steering/community_steering_committee.rst
+++ b/docs/docsite/rst/community/steering/community_steering_committee.rst
@@ -146,10 +146,14 @@ When reviewing community collection `inclusion requests <https://github.com/ansi
 
 #. For a collection to be included in the Ansible community package, the collection:
 
-  * MUST be reviewed and approved as compliant with the requirements by at least one Steering Committee member.
+  * MUST be reviewed and approved as compliant with the requirements by at least two Steering Committee members.
+
+    * At least one of the reviews checks compliance with the entire checklist.
+    * All subsequent reviews can focus only on compliance with documentation and development conventions.
+
   * Reviewers must not be involved significantly in development of the collection. They MUST declare any potential conflict of interest (for example, being friends/relatives/coworkers of the maintainers/authors, being users of the collection, or having contributed to that collection recently or in the past).
 
-#. After the collection gets one or more Committee member approvals, a Committee member creates a `community topic <https://forum.ansible.com/new-topic?category=project&tags=community-wg>`_ linked to the corresponding inclusion request. The issue's description says that the collection has been approved by one or more Committee members and establishes a date (a week by default) when the inclusion decision will be considered made.
+#. After the collection gets two Committee member approvals, a Committee member creates a `community topic <https://forum.ansible.com/new-topic?category=project&tags=community-wg>`_ linked to the corresponding inclusion request. The issue's description says that the collection has been approved by the Committee and establishes a date (a week by default) when the inclusion decision will be considered made.
 
   * The inclusion automatically gets suspended if the Committee members raise concerns or start another inclusion review within this time period.
   * When there are no more objections or ongoing inclusion reviews, the inclusion date gets prolonged for another week.

--- a/docs/docsite/rst/community/steering/community_steering_committee.rst
+++ b/docs/docsite/rst/community/steering/community_steering_committee.rst
@@ -146,13 +146,15 @@ When reviewing community collection `inclusion requests <https://github.com/ansi
 
 #. For a collection to be included in the Ansible community package, the collection:
 
-  * MUST be reviewed and approved by at least two persons, where at least one person is a Steering Committee member.
-  * For a Non-Steering Committee review to be counted for inclusion, it MUST be checked and approved by *another* Steering Committee member.
-  * Reviewers must not be involved significantly in development of the collection. They must declare any potential conflict of interest (for example, being friends/relatives/coworkers of the maintainers/authors, being users of the collection, or having contributed to that collection recently or in the past).
+  * MUST be reviewed and approved as compliant with the requirements by at least one Steering Committee member.
+  * Reviewers must not be involved significantly in development of the collection. They MUST declare any potential conflict of interest (for example, being friends/relatives/coworkers of the maintainers/authors, being users of the collection, or having contributed to that collection recently or in the past).
 
-#. After the collection gets two or more Committee member approvals, a Committee member creates a `community topic <https://forum.ansible.com/new-topic?category=project&tags=community-wg>`_ linked to the corresponding inclusion request. The issue's description says that the collection has been approved by two or more Committee members and establishes a date (a week by default) when the inclusion decision will be considered made. This time period can be used to raise concerns.
+#. After the collection gets one or more Committee member approvals, a Committee member creates a `community topic <https://forum.ansible.com/new-topic?category=project&tags=community-wg>`_ linked to the corresponding inclusion request. The issue's description says that the collection has been approved by one or more Committee members and establishes a date (a week by default) when the inclusion decision will be considered made.
 
-#. If no objections are raised up to the established date, the inclusion request is considered successfully resolved. In this case, a Committee member:
+  * The inclusion automatically gets suspended if the Committee members raise concerns or start another inclusion review within this time period.
+  * When there are no more objections or ongoing inclusion reviews, the inclusion date gets prolonged for another week.
+
+#. If the inclusion has not been suspended by the established date, the inclusion request is considered successfully resolved. In this case, a Committee member:
 
   #. Declares the decision in the topic and in the inclusion request.
   #. Moves the request to the ``Resolved reviews`` category.


### PR DESCRIPTION
# Issues we need to solve

- There's an influx of new inclusion [requests](https://github.com/ansible-collections/ansible-inclusion/discussions/)
- I review them but i spend more time and energy to ping the committee to conduct the second review
- This is not good and frustrating for the collection maintainers: they do work to make their content compliant
- In short, the two reviews and two SC approvals scheme doesn't work and is not gonna work if there no other committed volunteer from SC who will review stuff on a regular basis (if someone wants, please raise your hand)

# Solution

- Change the process so that if another person from SC wants to conduct the second review they can go ahead otherwise one review and approval is imo enough.
- I expect someone raises concerns about possible quality deterioration but the two reviews scheme just doesn't work - I regularly published and publish calls for help but there's no interest. We should trust each other, really. If someone has doubts and wants to re-check that, say, a collection has CI running regularly, they can do it.
- We should not make people wait or we should stop including new stuff

Let's discuss the above (copied) in the [related topic](https://forum.ansible.com/t/steering-committee-update-collection-inclusion-procedure/4833).