### PR TITLE
SC: move community_topics_workflow.md to docs.ansible.com

### DIFF
--- a/docs/docsite/rst/community/steering/community_steering_committee.rst
+++ b/docs/docsite/rst/community/steering/community_steering_committee.rst
@@ -99,7 +99,7 @@ Depending on a topic you want to discuss with the Community and the Committee, a
 Community topics workflow
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Committee uses the `Community-topics workflow <https://github.com/ansible-community/community-topics/blob/main/community_topics_workflow.md>`_ to asynchronously discuss and vote on the `community topics <https://forum.ansible.com/tags/c/project/7/community-wg>`_.
+The Committee uses the :ref:`community_topics_workflow` to asynchronously discuss and vote on the `community topics <https://forum.ansible.com/tags/c/project/7/community-wg>`_.
 
 The quorum, the minimum number of Committee members who must vote on a topic in order for a decision to be officially made, is half of the whole number of the Committee members. If the quorum number contains a fractional part, it is rounded up to the next whole number. For example, if there are thirteen members currently in the committee, the quorum will be seven.
 

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -54,7 +54,7 @@ Voting stage
 * Depending on the topic complexity, 1-2 weeks after the discussion was opened, the Committee person formulates vote options based on the prior discussion and gives participants a reasonable amount of time to propose changes to the options (no longer than a week). The person summarizes the options in a comment and also establishes a date when the vote begins if there are no objections about the options or vote date.
 * In the vote date, the vote starts with a comment from a Committee person who opens the vote and establishes a date when the vote ends ($CURRENT_DATE + no longer than 21 days; Usually it should not exceed 14 days. 21 days should only be used if it is known that a lot of interested persons will likely not have time to vote in a 14 day period).
 * The Committee person labels the topic with the ``active-vote`` tag.
-* The Committee person adds ``[Vote ends on $YYYY-MM-DD]`` to the beginning of the topic's description.
+* The Committee person adds ``[Vote ends on $YYYY-MM-DD]`` to the beginning of the topic description.
 * A vote is actually two polls, one for the Steering Committee, one for everyone else. To create a vote in a topic:
 
   * Create a new post in the topic.

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -30,7 +30,7 @@ Workflow
 
 .. note::
 
-  This is a rough scenario and it can vary depending on a topic's complexity and other nuances, for example, when there is a mass agreement up-front.
+  This is a rough scenario and it can vary depending on a topic's complexity and other nuances, for example, when there is a mass agreement upfront.
 
 Preparation stage
 -----------------

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -80,7 +80,7 @@ Voting stage
 Voting result stage
 -------------------
 
-* The next day after the last day of the vote, the Committee person:
+* The day after the last day of the vote, the Committee person:
 
   * Closes the polls.
 

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -52,7 +52,7 @@ Voting stage
 ------------
 
 * Depending on the topic complexity, 1-2 weeks after the discussion was opened, the Committee person formulates vote options based on the prior discussion and gives participants a reasonable amount of time to propose changes to the options (no longer than a week). The person summarizes the options in a comment and also establishes a date when the vote begins if there are no objections about the options or vote date.
-* In the vote date, the vote starts with the comment of a Committee person which opens the vote and establishes a date when the vote ends ($CURRENT_DATE + no longer than 21 days; usually it should not exceed 14 days, 21 days should only be used if it is known that a lot of interested persons will likely not have time to vote in a 14 days period).
+* In the vote date, the vote starts with a comment from a Committee person who opens the vote and establishes a date when the vote ends ($CURRENT_DATE + no longer than 21 days; Usually it should not exceed 14 days. 21 days should only be used if it is known that a lot of interested persons will likely not have time to vote in a 14 day period).
 * The Committee person labels the topic with the ``active-vote`` tag.
 * The Committee person adds ``[Vote ends on $YYYY-MM-DD]`` to the beginning of the topic's description.
 * A vote is actually two polls, one for the Steering Committee, one for everyone else. To create a vote in a topic:

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -12,7 +12,7 @@ Ansible community topics workflow
 Overview
 --------
 
-This document describes the Ansible community topics workflow (hereinafter ``Workflow``) to provide guidance on successful resolving topics in the asynchronous way.
+This document describes the Ansible community topics workflow (herein after ``Workflow``) to provide guidance on successful resolving topics in an asynchronous way.
 
 The Workflow is a set of actions that need to be done successively within the corresponding time frames.
 

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -67,7 +67,7 @@ Voting stage
 
   * Title it "Steering Committee vote" and "Limit voting" to the ``Steering Committee``.
 
-  * Do not set the close date because this cannot be changed later.
+  * Do not set the close date because it cannot be changed later.
 
   * Results should be "Always Visible" unless there is some good reason for the SC votes not to be public.
 

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -92,7 +92,7 @@ Voting result stage
 
   * Creates a summary comment declaring the vote result.
 
-* The vote's result and the final decision are announced via the `Bullhorn newsletter <https://forum.ansible.com/c/news/bullhorn/17>`_.
+* The vote result and final decision are announced via the `Bullhorn newsletter <https://forum.ansible.com/c/news/bullhorn/17>`_.
 
 
 Implementation stage

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -100,7 +100,7 @@ Implementation stage
 
 * If the topic implies some actions (if it does not, just mark this as complete), the Committee person:
 
-  * Assigns the topic to a person responsible for performing the actions.
+  * Assigns the topic to the person who is responsible for performing the actions.
 
   * Add the ``being-implemented`` tag to the topic.
 

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -1,0 +1,126 @@
+..
+   THIS DOCUMENT IS OWNED BY THE ANSIBLE COMMUNITY STEERING COMMITTEE. ALL CHANGES MUST BE APPROVED BY THE STEERING COMMITTEE!
+   For small changes (fixing typos, language errors, etc.) create a PR and ping @ansible/steering-committee.
+   For other changes, create a `community topic <https://forum.ansible.com/new-topic?category=project&tags=community-wg>`_ to discuss them.
+   (Creating a draft PR for this file and mentioning it in the community topic is also OK.)
+
+.. _community_topics_workflow:
+
+Ansible community topics workflow
+=================================
+
+Overview
+--------
+
+This document describes the Ansible community topics workflow (hereinafter ``Workflow``) to provide guidance on successful resolving topics in the asynchronous way.
+
+The Workflow is a set of actions that need to be done successively within the corresponding time frames.
+
+.. note::
+
+   If you have any ideas on how the Workflow can be improved, please create an issue in this repository or pull request against this document.
+
+Creating a topic
+----------------
+
+Any person can `create a topic <https://forum.ansible.com/new-topic?title=topic%20title&body=topic%20body&category=project&tags=community-wg>`_ tagged with ``community-wg`` under the ``Project Discussions`` category in the `Ansible Forum <https://forum.ansible.com/>`_. A :ref:`Steering Committee member<steering_members>` can tag the forum post with `community-wg-nextmtg` to put it on the meeting agenda.
+
+Workflow
+========
+
+.. note::
+
+  This is a rough scenario and it can vary depending on a topic's complexity and other nuances, for example, when there is a mass agreement up-front.
+
+Preparation stage
+-----------------
+
+A Committee person checks the topic's content, asks the author/other persons to provide additional information if needed.
+
+Discussion stage
+----------------
+
+* If the topic is ready to be discussed, the Committee person:
+
+  * Adds the ``community-wg-nextmtg`` tag if it needs to be discussed in the meeting.
+
+  * Opens the discussion by adding a comment asking the Community and the Committee to take part in it.
+
+* No synchronous discussion is needed (there are no blockers, complications, confusion, or impasses).
+
+Voting stage
+------------
+
+* Depending on the topic's complexity, 1-2 weeks after the discussion was opened, the Committee person formulates vote options based on the prior discussion and gives participants reasonable amount of time to propose changes to the options (no longer than a week). The person summarizes the options in a comment and also establishes a date when the vote begins if there are no objections about the options / vote date.
+* In the vote date, the vote starts with the comment of a Committee person which opens the vote and establishes a date when the vote ends ($CURRENT_DATE + no longer than 21 days; usually it should not exceed 14 days, 21 days should only be used if it is known that a lot of interested persons will likely not have time to vote in a 14 days period).
+* The Committee person labels the topic with the ``active-vote`` tag.
+* The Committee person adds ``[Vote ends on $YYYY-MM-DD]`` to the beginning of the topic's description.
+* A vote is actually two polls, one for the Steering Committee, one for everyone else. To create a vote in a topic:
+
+  * Create a new post in the topic.
+
+  * Click the ``gear`` button in the composer and select ``Build Poll``.
+
+  * Click the ``gear`` in the Poll Builder for advanced mode.
+
+  * Set up the options (generally this will be Single Choice but other poll types can be used).
+
+  * Title it "Steering Committee vote" and "Limit voting" to the ``Steering Committee``.
+
+  * Do not set the close date because this cannot be changed later.
+
+  * Results should be "Always Visible" unless there is some good reason for the SC votes not to be public.
+
+  * Submit the poll (the BBcode will appear in the post) and then repeat the above for the second poll.
+
+    * The title should be "Community vote".
+
+    * No group limitation.
+
+Voting result stage
+-------------------
+
+* The next day after the last day of the vote, the Committee person:
+
+  * Closes the polls.
+
+  * Removes the ``active-vote`` tag.
+
+  * Add a comment that the vote ended.
+
+  * Changes the beginning of the topic's description to ``[Vote ended]``.
+
+  * Creates a summary comment declaring the vote result.
+
+* The vote's result and the final decision are announced via the `Bullhorn newsletter <https://forum.ansible.com/c/news/bullhorn/17>`_.
+
+
+Implementation stage
+--------------------
+
+* If the topic implies some actions (if it does not, just mark this as complete), the Committee person:
+
+  * Assigns the topic to a person responsible for performing the actions.
+
+  * Add the ``being-implemented`` tag to the topic.
+
+  * After the topic is implemented, the assignee:
+
+  * Comments on the topic that the work is done.
+
+  * Removes the ``being-implemented`` tag.
+
+  * Add the ``implemented`` tag.
+
+* If the topic implies actions related to the future Ansible Community package releases (for example, a collection exclusion), the Committee person:
+
+  * Adds the ``scheduled-for-future-release`` tag to the topic.
+
+  * Checks if there is a corresponding milestone in the `ansible-build-data <https://github.com/ansible-community/ansible-build-data/milestones>`_ repository. If there is no milestone, the person creates it.
+
+  * Creates an issue in ansible-build-data that references the topic in community-topics, and adds it to the milestone.
+
+Tools
+=====
+
+We have some `scripts <https://github.com/ansible-community/community-topics/tree/main/scripts>`_ that can be used to create Ansible community announcements on Bullhorn and similar.

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -51,7 +51,7 @@ Discussion stage
 Voting stage
 ------------
 
-* Depending on the topic's complexity, 1-2 weeks after the discussion was opened, the Committee person formulates vote options based on the prior discussion and gives participants reasonable amount of time to propose changes to the options (no longer than a week). The person summarizes the options in a comment and also establishes a date when the vote begins if there are no objections about the options / vote date.
+* Depending on the topic complexity, 1-2 weeks after the discussion was opened, the Committee person formulates vote options based on the prior discussion and gives participants a reasonable amount of time to propose changes to the options (no longer than a week). The person summarizes the options in a comment and also establishes a date when the vote begins if there are no objections about the options or vote date.
 * In the vote date, the vote starts with the comment of a Committee person which opens the vote and establishes a date when the vote ends ($CURRENT_DATE + no longer than 21 days; usually it should not exceed 14 days, 21 days should only be used if it is known that a lot of interested persons will likely not have time to vote in a 14 days period).
 * The Committee person labels the topic with the ``active-vote`` tag.
 * The Committee person adds ``[Vote ends on $YYYY-MM-DD]`` to the beginning of the topic's description.

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -123,4 +123,4 @@ Implementation stage
 Tools
 =====
 
-We have some `scripts <https://github.com/ansible-community/community-topics/tree/main/scripts>`_ that can be used to create Ansible community announcements on Bullhorn and similar.
+We have some `scripts <https://github.com/ansible-community/community-topics/tree/main/scripts>`_ that can be used to create Ansible community announcements in the Bullhorn and similar places.

--- a/docs/docsite/rst/community/steering/community_topics_workflow.rst
+++ b/docs/docsite/rst/community/steering/community_topics_workflow.rst
@@ -35,7 +35,7 @@ Workflow
 Preparation stage
 -----------------
 
-A Committee person checks the topic's content, asks the author/other persons to provide additional information if needed.
+A Committee person checks the topic content and asks the author, or other persons, to provide additional information if needed.
 
 Discussion stage
 ----------------

--- a/docs/docsite/rst/community/steering/steering_index.rst
+++ b/docs/docsite/rst/community/steering/steering_index.rst
@@ -18,3 +18,4 @@ This section focuses on the guidelines and membership of the Ansible Community S
    community_steering_committee
    steering_committee_membership
    steering_committee_past_members
+   community_topics_workflow

--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -142,6 +142,7 @@ exclude_patterns += [] if tags.has('all') else [
     'community/maintainers_guidelines.rst',
     'community/maintainers_workflow.rst',
     'community/steering/community_steering_committee.rst',
+    'community/steering/community_topics_workflow.rst',
     'community/steering/steering_committee_membership.rst',
     'community/steering/steering_committee_past_members.rst',
     'community/steering/steering_index.rst',


### PR DESCRIPTION
- This PR creates an rst copy of https://github.com/ansible-community/community-topics/blob/main/community_topics_workflow.md which is the only thing we use in that repo
- After this PR is merged, we could proceed on the way to archive that repo (move Mario's scripts, close/re-create the topics on the forum, archive the repo).
- This PR doesn't change anything except the link to Bullhorn.
- I believe no SC vote is needed to merge it