### PR TITLE
Muni tech writers:  Ansible include_task search documentation incorrect #357 

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbook_pathing.rst
+++ b/docs/docsite/rst/playbook_guide/playbook_pathing.rst
@@ -21,10 +21,12 @@ Task paths
 
 Relative paths used in a task typically refer to remote files and directories on the managed nodes. However, paths passed to lookup plugins and some paths used in action plugins such as the "src" path for the :ansplugin:`template <ansible.builtin.template#module>` and :ansplugin:`copy <ansible.builtin.copy#module>` modules refer to local files and directories on the control node.
 
-Resolving local relative paths
-------------------------------
+
+Resolving local lookup and action plugin relative paths
+-------------------------------------------------------
 
 When you specify a relative path for a local file, Ansible will try to find that file first in the current task's role, then in other roles that included or depend on the current role, then relative to the file in which the task is defined, and finally relative to the current play. It will take the first matching file that it finds. This way, if multiple files with the same file name exist, Ansible will find the file that is closest to the current task and that is most likely to be file you wanted.
+
 
 Specifically, Ansible tries to find the file
 
@@ -37,7 +39,26 @@ Specifically, Ansible tries to find the file
 3. Like 1, in the current task file's directory.
 4. Like 1, in the current play file's directory.
 
-Ansible does not search the current working directory. (The directory you're in when you execute Ansible.) Also, Ansible will only search within a role if you actually included it with an `include_role` or `import_role` task or a dependency. If you instead use `include`, `include_task` or `import_task` to include just the tasks from a specific file but not the full role, Ansible will not search that role in steps 1 and 2.
+Ansible does not search the current working directory. (The directory you're in when you execute Ansible.).
+
+Resolving local relative tasks paths
+------------------------------------
+
+Ansible will only search for task files within a role if you actually included them with an `include_role` or `import_role`. If you instead use `include`, `include_task` or `import_task` to include just the tasks from a specific file but not the full role, Ansible will only search for the task in the current role.
+
+In this case, Ansible tries to find the file
+
+1. In the current rule.
+
+   1. In the "tasks" directory.
+   2. Directly in its directory.
+
+2. Like 1, in the current task file's directory.
+3. Like 1, in the current play file's directory.
+
+
+Debugging search paths
+----------------------
 
 When you execute Ansible, the variable `ansible_search_path` will contain the paths searched, in the order they were searched in but without listing their subdirectories. If you run Ansible in verbosity level 5 by passing the `-vvvvv` argument, Ansible will report each directory as it searches, except when it searches for a tasks file.
 

--- a/docs/docsite/rst/playbook_guide/playbook_pathing.rst
+++ b/docs/docsite/rst/playbook_guide/playbook_pathing.rst
@@ -19,38 +19,36 @@ By default, these should be relative to the config file. Some are specifically r
 Task paths
 ==========
 
-Relative paths used in a task typically refer to remote files and directories on the managed nodes. However, paths passed to lookup plugins and some paths used in action plugins such as the "src" path for the :ansplugin:`template <ansible.builtin.template#module>` and :ansplugin:`copy <ansible.builtin.copy#module>` modules refer to local files and directories on the control node.
+Relative paths used in a task typically refer to remote files and directories on the managed nodes. However, paths passed to lookup plugins and some paths used in action plugins such as the "src" path for the :ansplugin:``template <ansible.builtin.template#module>`` and :ansplugin:``copy <ansible.builtin.copy#module>`` modules refer to local files and directories on the control node.
 
-
-Resolving local lookup and action plugin relative paths
--------------------------------------------------------
+How lookup and action plugins resolve local relative paths
+----------------------------------------------------------
 
 When you specify a relative path for a local file, Ansible will try to find that file first in the current task's role, then in other roles that included or depend on the current role, then relative to the file in which the task is defined, and finally relative to the current play. It will take the first matching file that it finds. This way, if multiple files with the same file name exist, Ansible will find the file that is closest to the current task and that is most likely to be file you wanted.
 
-
-Specifically, Ansible tries to find the file
+Specifically, Ansible tries to find the file in the following order:
 
 1. In the current role.
 
    1. In its appropriate subdirectory—"files", "vars", "templates" or "tasks", depending on the kind of file Ansible is searching for.
    2. Directly in its directory.
    
-2. Like 1, in the parent role that called into this current role with `include_role`, `import_role`, or with a role dependency. If the parent role has its own parent role, Ansible will repeat this step with that role.
+2. Like 1, in the parent role that called into this current role with ``include_role``, ``import_role``, or with a role dependency. If the parent role has its own parent role, Ansible will repeat this step with that role.
 3. Like 1, in the current task file's directory.
 4. Like 1, in the current play file's directory.
 
 Ansible does not search the current working directory. (The directory you're in when you execute Ansible.).
 
-Resolving local relative tasks paths
-------------------------------------
+Resolving local relative paths for task files
+---------------------------------------------
 
-Ansible will only search for task files within a role if you actually included them with an `include_role` or `import_role`. If you instead use `include`, `include_task` or `import_task` to include just the tasks from a specific file but not the full role, Ansible will only search for the task in the current role.
+Ansible searches for task files within a role only if you include them with an ``include_role`` or ``import_role`` statement. If you use ``include``, ``include_task``, or ``import_task`` statement to include only the tasks from a specific file, but not the full role, Ansible searches for the task in the current role.
 
-In this case, Ansible tries to find the file
+In this case, Ansible tries to find the file in the following order:
 
 1. In the current rule.
 
-   1. In the "tasks" directory.
+   1. In the ``tasks`` directory.
    2. Directly in its directory.
 
 2. Like 1, in the current task file's directory.
@@ -60,7 +58,7 @@ In this case, Ansible tries to find the file
 Debugging search paths
 ----------------------
 
-When you execute Ansible, the variable `ansible_search_path` will contain the paths searched, in the order they were searched in but without listing their subdirectories. If you run Ansible in verbosity level 5 by passing the `-vvvvv` argument, Ansible will report each directory as it searches, except when it searches for a tasks file.
+When you execute Ansible, the variable ``ansible_search_path`` will contain the paths searched, in the order they were searched in but without listing their subdirectories. If you run Ansible in verbosity level 5 by passing the ``-vvvvv`` argument, Ansible will report each directory as it searches, except when it searches for a tasks file.
 
 
 .. note::  The current working directory might vary depending on the connection plugin and if the action is local or remote. For the remote it is normally the directory on which the login shell puts the user. For local it is either the directory you executed ansible from or in some cases the playbook directory.


### PR DESCRIPTION
This is a solution for the issue #357.

I attempted to dissolve the ambiguity of how `include_task` relative paths are resolved by splitting the section into two, one for lookup plugin paths and one for tasks. In the latter, I included an amended list of lookup steps so that it is clear that task files will not be searched in the parent roles.

I had several conflicting ideas on how to tackle this and am not at all sure if I chose well, so any review/feedback is very much appreciated :)