### PR TITLE
ansible-core 2.17 porting guide: remote Python version support

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.17.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.17.rst
@@ -25,7 +25,7 @@ No notable changes
 Command Line
 ============
 
-No notable changes
+* Python 2.7 and Python 3.6 are no longer supported remote versions. Python 3.7+ is now required for target execution.
 
 
 Deprecated


### PR DESCRIPTION
See ansible/ansible/pull/83054