### PR TITLE
MUNI tech writers: Mention ANSIBLE_CONNECTION_PATH option on Connection plugins page (#793)

### DIFF
--- a/docs/docsite/rst/plugins/connection.rst
+++ b/docs/docsite/rst/plugins/connection.rst
@@ -9,7 +9,7 @@ Connection plugins
 
 Connection plugins allow Ansible to connect to the target hosts so it can execute tasks on them. Ansible ships with many connection plugins, but only one can be used per host at a time.
 
-By default, Ansible ships with several connection plugins. The most commonly used are the :ref:`paramiko SSH<paramiko_connection>`, native ssh (just called :ref:`ssh<ssh_connection>`), and :ref:`local<local_connection>` connection types.  All of these can be used in playbooks and with :command:`/usr/bin/ansible` to decide how you want to talk to remote machines. If necessary, you can :ref:`create custom connection plugins <developing_connection_plugins>`.
+By default, Ansible ships with several connection plugins. The most commonly used are the :ref:`paramiko SSH<paramiko_connection>`, native ssh (just called :ref:`ssh<ssh_connection>`), and :ref:`local<local_connection>` connection types.  All of these can be used in playbooks and with :command:`/usr/bin/ansible` to decide how you want to talk to remote machines. If necessary, you can :ref:`create custom connection plugins <developing_connection_plugins>`. To configure these plugins, you might use :ref:`ANSIBLE_CONNECTION_PATH<ANSIBLE_CONNECTION_PATH>` option.
 
 The basics of these connection types are covered in the :ref:`getting started<intro_getting_started>` section.
 

--- a/docs/docsite/rst/plugins/connection.rst
+++ b/docs/docsite/rst/plugins/connection.rst
@@ -9,7 +9,7 @@ Connection plugins
 
 Connection plugins allow Ansible to connect to the target hosts so it can execute tasks on them. Ansible ships with many connection plugins, but only one can be used per host at a time.
 
-By default, Ansible ships with several connection plugins. The most commonly used are the :ref:`paramiko SSH<paramiko_connection>`, native ssh (just called :ref:`ssh<ssh_connection>`), and :ref:`local<local_connection>` connection types.  All of these can be used in playbooks and with :command:`/usr/bin/ansible` to decide how you want to talk to remote machines. If necessary, you can :ref:`create custom connection plugins <developing_connection_plugins>`. To configure these plugins, you might use :ref:`ANSIBLE_CONNECTION_PATH<ANSIBLE_CONNECTION_PATH>` option.
+By default, Ansible ships with several connection plugins. The most commonly used are the :ref:`paramiko SSH<paramiko_connection>`, native ssh (just called :ref:`ssh<ssh_connection>`), and :ref:`local<local_connection>` connection types.  All of these can be used in playbooks and with :command:`/usr/bin/ansible` to decide how you want to talk to remote machines. If necessary, you can :ref:`create custom connection plugins <developing_connection_plugins>`. To establish the connection, you can use an ``ansible-connection`` script referenced in :ref:`ANSIBLE_CONNECTION_PATH<ANSIBLE_CONNECTION_PATH>`. To change the connection plugin used for tasks, you can use the ``connection`` keyword.  
 
 The basics of these connection types are covered in the :ref:`getting started<intro_getting_started>` section.
 

--- a/docs/docsite/rst/plugins/connection.rst
+++ b/docs/docsite/rst/plugins/connection.rst
@@ -9,7 +9,7 @@ Connection plugins
 
 Connection plugins allow Ansible to connect to the target hosts so it can execute tasks on them. Ansible ships with many connection plugins, but only one can be used per host at a time.
 
-By default, Ansible ships with several connection plugins. The most commonly used are the :ref:`paramiko SSH<paramiko_connection>`, native ssh (just called :ref:`ssh<ssh_connection>`), and :ref:`local<local_connection>` connection types.  All of these can be used in playbooks and with :command:`/usr/bin/ansible` to decide how you want to talk to remote machines. If necessary, you can :ref:`create custom connection plugins <developing_connection_plugins>`. You can use the ``ANSIBLE_CONNECTION_PATH`` environment variable to specify a custom directory for the ``ansible-connection`` script along with other files related to connections during remote execution. To change the connection plugin for your tasks, you can use the ``connection`` keyword.  
+By default, Ansible ships with several connection plugins. The most commonly used are the :ref:`paramiko SSH<paramiko_connection>`, native ssh (just called :ref:`ssh<ssh_connection>`), and :ref:`local<local_connection>` connection types.  All of these can be used in playbooks and with :command:`/usr/bin/ansible` to decide how you want to talk to remote machines. If necessary, you can :ref:`create custom connection plugins <developing_connection_plugins>`. To change the connection plugin for your tasks, you can use the ``connection`` keyword.  
 
 The basics of these connection types are covered in the :ref:`getting started<intro_getting_started>` section.
 

--- a/docs/docsite/rst/plugins/connection.rst
+++ b/docs/docsite/rst/plugins/connection.rst
@@ -20,14 +20,6 @@ The basics of these connection types are covered in the :ref:`getting started<in
 
 Because SSH is the default protocol used in system administration and the protocol most used in Ansible, SSH options are included in the command line tools. See :ref:`ansible-playbook` for more details.
 
-.. _enabling_connection:
-
-Adding connection plugins
--------------------------
-
-You can extend Ansible to support other transports (such as SNMP or message bus) by dropping a custom plugin
-into the ``connection_plugins`` directory.
-
 .. _using_connection:
 
 Using connection plugins

--- a/docs/docsite/rst/plugins/connection.rst
+++ b/docs/docsite/rst/plugins/connection.rst
@@ -9,7 +9,7 @@ Connection plugins
 
 Connection plugins allow Ansible to connect to the target hosts so it can execute tasks on them. Ansible ships with many connection plugins, but only one can be used per host at a time.
 
-By default, Ansible ships with several connection plugins. The most commonly used are the :ref:`paramiko SSH<paramiko_connection>`, native ssh (just called :ref:`ssh<ssh_connection>`), and :ref:`local<local_connection>` connection types.  All of these can be used in playbooks and with :command:`/usr/bin/ansible` to decide how you want to talk to remote machines. If necessary, you can :ref:`create custom connection plugins <developing_connection_plugins>`. To establish the connection, you can use an ``ansible-connection`` script referenced in :ref:`ANSIBLE_CONNECTION_PATH<ANSIBLE_CONNECTION_PATH>`. To change the connection plugin used for tasks, you can use the ``connection`` keyword.  
+By default, Ansible ships with several connection plugins. The most commonly used are the :ref:`paramiko SSH<paramiko_connection>`, native ssh (just called :ref:`ssh<ssh_connection>`), and :ref:`local<local_connection>` connection types.  All of these can be used in playbooks and with :command:`/usr/bin/ansible` to decide how you want to talk to remote machines. If necessary, you can :ref:`create custom connection plugins <developing_connection_plugins>`. You can use the ``ANSIBLE_CONNECTION_PATH`` environment variable to specify a custom directory for the ``ansible-connection`` script along with other files related to connections during remote execution. To change the connection plugin for your tasks, you can use the ``connection`` keyword.  
 
 The basics of these connection types are covered in the :ref:`getting started<intro_getting_started>` section.
 


### PR DESCRIPTION
The ANSIBLE_CONNECTION_PATH option for configuring the plugins is mentioned on the Connection plugins page (#793).

The same link is also mentioned in the section Using connection plugins. Therefore, I added this information only to the beginning of the page.