### PR TITLE
Integrate ansible-creator and devtools into the developing collections guide

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_collections_creating.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_creating.rst
@@ -88,7 +88,7 @@ Creating collections with ansible-creator
 
 .. note::
 
-   Installing ansible-creator using the `Ansible Development Tools <https://github.com/ansible/ansible-dev-tools>`_ package is recommended.
+   Installing ``ansible-creator`` using the `Ansible Development Tools <https://github.com/ansible/ansible-dev-tools>`_ package is recommended.
 
 After `installing <https://ansible.readthedocs.io/projects/creator/installing/#installation>`_ ``ansible-creator`` you can initialize a project in one of the following ways:
 

--- a/docs/docsite/rst/dev_guide/developing_collections_creating.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_creating.rst
@@ -81,6 +81,15 @@ To learn more about the ``ansible-galaxy`` command-line tool, see the :ref:`ansi
 
 .. _creating_collection_skeletons:
 
+Creating a collection using the ansible-creator tool
+====================================================
+
+The `ansible-creator <https://github.com/ansible/ansible-creator/>`_ tool is designed for effortlessly scaffolding your Ansible content.
+After `installing <https://ansible.readthedocs.io/projects/creator/installing/#installation>`_ ``ansible-creator`` you have two options to interact with it to create a foundational structure for the project:
+
+* Follow the `CLI instructions <https://ansible.readthedocs.io/projects/creator/installing/#initialize-ansible-collection-init-subcommand>`_.
+* To interact with the GUI, `setup <https://ansible.readthedocs.io/projects/creator/collection_creation/#step-1-installing-ansible-creator-in-the-environment>`_ Visual Studio Code and the Ansible extension, then follow the `GUI instructions <https://ansible.readthedocs.io/projects/creator/collection_creation/#step-2-initializing-collection-by-filling-an-interactive-form>`_.
+
 Creating a collection from a custom template
 ============================================
 
@@ -117,6 +126,8 @@ To initialize a collection using the new template, pass the path to the skeleton
        Learn how to install and use collections.
    :ref:`collection_structure`
        Directories and files included in the collection skeleton
+   `Ansible Development Tools (ADT) <https://github.com/ansible/ansible-dev-tools>`_
+       Python package of tools to create and test ansible content.
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        The development mailing list
    :ref:`communication_irc`

--- a/docs/docsite/rst/dev_guide/developing_collections_creating.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_creating.rst
@@ -116,11 +116,11 @@ To initialize a collection using the new template, pass the path to the skeleton
 Creating collections with ansible-creator
 =========================================
 
-`ansible-creator <https://github.com/ansible/ansible-creator/>`_ is designed to quickly scaffold an Ansible collection project.
+`ansible-creator <https://ansible.readthedocs.io/projects/creator/>`_ is designed to quickly scaffold an Ansible collection project.
 
 .. note::
 
-   The `Ansible Development Tools <https://github.com/ansible/ansible-dev-tools>`_ package offers a convenient way to install ``ansible-creator`` along with a curated set of tools for developing automation content.
+   The `Ansible Development Tools <https://ansible.readthedocs.io/projects/dev-tools/>`_ package offers a convenient way to install ``ansible-creator`` along with a curated set of tools for developing automation content.
 
 After `installing <https://ansible.readthedocs.io/projects/creator/installing/#installation>`_ ``ansible-creator`` you can initialize a project in one of the following ways:
 
@@ -133,7 +133,7 @@ After `installing <https://ansible.readthedocs.io/projects/creator/installing/#i
        Learn how to install and use collections.
    :ref:`collection_structure`
        Directories and files included in the collection skeleton
-   `Ansible Development Tools (ADT) <https://github.com/ansible/ansible-dev-tools>`_
+   `Ansible Development Tools (ADT) <https://ansible.readthedocs.io/projects/dev-tools/>`_
        Python package of tools to create and test Ansible content.
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        The development mailing list

--- a/docs/docsite/rst/dev_guide/developing_collections_creating.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_creating.rst
@@ -6,7 +6,7 @@ Creating collections
 
 To create a collection:
 
-#. Create a :ref:`new collection<creating_new_collections>`, optionally using a custom :ref:`collection template<creating_collection_skeletons>`, with the ``ansible-galaxy collection init`` command.
+#. Create a :ref:`new collection<creating_new_collections>`, optionally using a custom :ref:`collection template<creating_collection_from_custom_template>`, with the ``ansible-galaxy collection init`` command.
 #. Add modules and other content to the collection.
 #. Build the collection into a collection artifact with :ref:`ansible-galaxy collection build<building_collections>`.
 #. Publish the collection artifact to Galaxy with :ref:`ansible-galaxy collection publish<publishing_collections>`.
@@ -79,21 +79,7 @@ Currently the ``ansible-galaxy collection`` command implements the following sub
 
 To learn more about the ``ansible-galaxy`` command-line tool, see the :ref:`ansible-galaxy` man page.
 
-.. _creating_collection_skeletons:
-
-Creating collections with ansible-creator
-=========================================
-
-`ansible-creator <https://github.com/ansible/ansible-creator/>`_ is designed to quickly scaffold an Ansible collection project.
-
-.. note::
-
-   We recommend you install ``ansible-creator`` through the `Ansible Development Tools <https://github.com/ansible/ansible-dev-tools>`_ package.
-
-After `installing <https://ansible.readthedocs.io/projects/creator/installing/#installation>`_ ``ansible-creator`` you can initialize a project in one of the following ways:
-
-* Use the `init <https://ansible.readthedocs.io/projects/creator/installing/#initialize-ansible-collection-init-subcommand>`_ subcommand.
-* Use ``ansible-creator`` with the `Ansible extension <https://ansible.readthedocs.io/projects/creator/collection_creation/#step-1-installing-ansible-creator-in-the-environment>`_ in Visual Studio Code.
+.. _creating_collection_from_custom_template:
 
 Creating a collection from a custom template
 ============================================
@@ -124,6 +110,22 @@ To initialize a collection using the new template, pass the path to the skeleton
 .. note::
 
    The default collection skeleton uses an internal filter ``comment_ify`` that isn't accessibly to ``--collection-skeleton``. Use ``ansible-doc -t filter|test --list`` to see available plugins.
+
+.. _creating_collection_with_ansible-creator:
+
+Creating collections with ansible-creator
+=========================================
+
+`ansible-creator <https://github.com/ansible/ansible-creator/>`_ is designed to quickly scaffold an Ansible collection project.
+
+.. note::
+
+   We recommend you install ``ansible-creator`` through the `Ansible Development Tools <https://github.com/ansible/ansible-dev-tools>`_ package.
+
+After `installing <https://ansible.readthedocs.io/projects/creator/installing/#installation>`_ ``ansible-creator`` you can initialize a project in one of the following ways:
+
+* Use the `init <https://ansible.readthedocs.io/projects/creator/installing/#initialize-ansible-collection-init-subcommand>`_ subcommand.
+* Use ``ansible-creator`` with the `Ansible extension <https://ansible.readthedocs.io/projects/creator/collection_creation/#step-1-installing-ansible-creator-in-the-environment>`_ in Visual Studio Code.
 
 .. seealso::
 

--- a/docs/docsite/rst/dev_guide/developing_collections_creating.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_creating.rst
@@ -81,14 +81,19 @@ To learn more about the ``ansible-galaxy`` command-line tool, see the :ref:`ansi
 
 .. _creating_collection_skeletons:
 
-Creating a collection using the ansible-creator tool
-====================================================
+Creating collections with ansible-creator
+=========================================
 
-The `ansible-creator <https://github.com/ansible/ansible-creator/>`_ tool is designed for effortlessly scaffolding your Ansible content.
-After `installing <https://ansible.readthedocs.io/projects/creator/installing/#installation>`_ ``ansible-creator`` you have two options to interact with it to create a foundational structure for the project:
+`ansible-creator <https://github.com/ansible/ansible-creator/>`_ is designed to quickly scaffold an Ansible collection project.
 
-* Follow the `CLI instructions <https://ansible.readthedocs.io/projects/creator/installing/#initialize-ansible-collection-init-subcommand>`_.
-* To interact with the GUI, `setup <https://ansible.readthedocs.io/projects/creator/collection_creation/#step-1-installing-ansible-creator-in-the-environment>`_ Visual Studio Code and the Ansible extension, then follow the `GUI instructions <https://ansible.readthedocs.io/projects/creator/collection_creation/#step-2-initializing-collection-by-filling-an-interactive-form>`_.
+.. note::
+
+   Installing ansible-creator using the `Ansible Development Tools <https://github.com/ansible/ansible-dev-tools>`_ package is recommended.
+
+After `installing <https://ansible.readthedocs.io/projects/creator/installing/#installation>`_ ``ansible-creator`` you can initialize a project in one of the following ways:
+
+* Use the `init <https://ansible.readthedocs.io/projects/creator/installing/#initialize-ansible-collection-init-subcommand>`_ subcommand.
+* To interact with the GUI, `setup <https://ansible.readthedocs.io/projects/creator/collection_creation/#step-1-installing-ansible-creator-in-the-environment>`_ Visual Studio Code and the Ansible extension, then open VS Code in an environment/project where you installed ``ansible-creator`` and then follow the instructions in the Ansible extension.
 
 Creating a collection from a custom template
 ============================================

--- a/docs/docsite/rst/dev_guide/developing_collections_creating.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_creating.rst
@@ -88,12 +88,12 @@ Creating collections with ansible-creator
 
 .. note::
 
-   Installing ``ansible-creator`` using the `Ansible Development Tools <https://github.com/ansible/ansible-dev-tools>`_ package is recommended.
+   We recommend you install ``ansible-creator`` through the `Ansible Development Tools <https://github.com/ansible/ansible-dev-tools>`_ package.
 
 After `installing <https://ansible.readthedocs.io/projects/creator/installing/#installation>`_ ``ansible-creator`` you can initialize a project in one of the following ways:
 
 * Use the `init <https://ansible.readthedocs.io/projects/creator/installing/#initialize-ansible-collection-init-subcommand>`_ subcommand.
-* To interact with the GUI, `setup <https://ansible.readthedocs.io/projects/creator/collection_creation/#step-1-installing-ansible-creator-in-the-environment>`_ Visual Studio Code and the Ansible extension, then open VS Code in an environment/project where you installed ``ansible-creator`` and then follow the instructions in the Ansible extension.
+* Use ``ansible-creator`` with the `Ansible extension <https://ansible.readthedocs.io/projects/creator/collection_creation/#step-1-installing-ansible-creator-in-the-environment>`_ in Visual Studio Code.
 
 Creating a collection from a custom template
 ============================================
@@ -132,7 +132,7 @@ To initialize a collection using the new template, pass the path to the skeleton
    :ref:`collection_structure`
        Directories and files included in the collection skeleton
    `Ansible Development Tools (ADT) <https://github.com/ansible/ansible-dev-tools>`_
-       Python package of tools to create and test ansible content.
+       Python package of tools to create and test Ansible content.
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        The development mailing list
    :ref:`communication_irc`

--- a/docs/docsite/rst/dev_guide/developing_collections_creating.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_creating.rst
@@ -120,7 +120,7 @@ Creating collections with ansible-creator
 
 .. note::
 
-   We recommend you install ``ansible-creator`` through the `Ansible Development Tools <https://github.com/ansible/ansible-dev-tools>`_ package.
+   The `Ansible Development Tools <https://github.com/ansible/ansible-dev-tools>`_ package offers a convenient way to install ``ansible-creator`` along with a curated set of tools for developing automation content.
 
 After `installing <https://ansible.readthedocs.io/projects/creator/installing/#installation>`_ ``ansible-creator`` you can initialize a project in one of the following ways:
 


### PR DESCRIPTION
This branch adds a section mentioning ansible-creator as a way to generate collection structure. Mentioned in #1294 