### PR TITLE
MUNI tech writers: absolute path referencing mentioned (#96)

### DIFF
--- a/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
+++ b/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
@@ -120,7 +120,7 @@ Note that using this strategy in your inventory still requires *all vault passwo
 Avoid configuration-dependent content
 -------------------------------------
 
-To ensure that your automation project is easy to understand, modify, and share with others, you should avoid configuration-dependent content. For example, rather than referencing an ``ansible.cfg`` as the root of a project, you should use magic variables such as ``playbook_dir`` or ``role_name`` to determine paths relative to known locations within your project directory. This can help to keep automation content flexible, reusable, and easy to maintain.
+To ensure that your automation project is easy to understand, modify, and share with others, you should avoid configuration-dependent content. For example, rather than referencing an ``ansible.cfg`` as the root of a project, you can use magic variables such as ``playbook_dir`` or ``role_name`` to determine paths relative to known locations within your project directory. This can help to keep automation content flexible, reusable, and easy to maintain. For more information, see :ref:`special variables<special_variables>`.
 
 .. _execution_tips:
 

--- a/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
+++ b/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
@@ -26,6 +26,11 @@ Customize the CLI output
 
 You can change the output from Ansible CLI commands using :ref:`callback_plugins`.
 
+Avoid configuration-dependent content
+-------------------------------------
+
+To ensure that your automation project is easy to understand, modify, and share with others, you should avoid configuration-dependent content. For example, rather than referencing an ``ansible.cfg`` as the root of a project, you can use magic variables such as ``playbook_dir`` or ``role_name`` to determine paths relative to known locations within your project directory. This can help to keep automation content flexible, reusable, and easy to maintain. For more information, see :ref:`special variables<special_variables>`.
+
 .. _playbook_tips:
 
 Playbook tips
@@ -116,11 +121,6 @@ When running a playbook, Ansible finds the variables in the unencrypted file, wh
 There is no limit to the number of variable and vault files or their names.
 
 Note that using this strategy in your inventory still requires *all vault passwords to be available* (for example for ``ansible-playbook`` or `AWX/Ansible Tower <https://github.com/ansible/awx/issues/223#issuecomment-768386089>`_) when run with that inventory.
-
-Avoid configuration-dependent content
--------------------------------------
-
-To ensure that your automation project is easy to understand, modify, and share with others, you should avoid configuration-dependent content. For example, rather than referencing an ``ansible.cfg`` as the root of a project, you can use magic variables such as ``playbook_dir`` or ``role_name`` to determine paths relative to known locations within your project directory. This can help to keep automation content flexible, reusable, and easy to maintain. For more information, see :ref:`special variables<special_variables>`.
 
 .. _execution_tips:
 

--- a/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
+++ b/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
@@ -120,7 +120,7 @@ Note that using this strategy in your inventory still requires *all vault passwo
 Use absolute paths in your playbooks
 ------------------------------------
 
-To make reorganising your files more convenient, you can use absolute paths for referenced files in your playbooks.
+To make reorganizing your files more convenient, you can use absolute paths for referenced files in your playbooks.
 The global Ansible variables might help determine the absolute paths, as the example below demonstrates.
 
 The example expects the ``ansible.cfg`` file to be in the root of the folder.
@@ -128,6 +128,7 @@ The example expects the ``ansible.cfg`` file to be in the root of the folder.
 #. Set the following variables for the `all` group:
 
 .. code-block:: yaml
+
     ansible_repo_path: "{{ ansible_config_file[:-11] }}"
     files_path: "{{ ansible_repo_path }}/playbooks/files"
     templates_path: "{{ ansible_repo_path }}/playbooks/templates"
@@ -137,6 +138,7 @@ The example expects the ``ansible.cfg`` file to be in the root of the folder.
 #. Use these variables to reference a file (``playbooks/files/foo.conf``) as follows.
 
 .. code-block:: yaml
+
     - name: File copy
       ansible.builtin.copy:
         src: {{ files_path }}/foo.conf

--- a/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
+++ b/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
@@ -123,13 +123,13 @@ Use absolute paths in your playbooks
 To make reorganizing your files more convenient, you can use absolute paths for referenced files in your playbooks.
 The global Ansible variables might help determine the absolute paths, as the example below demonstrates.
 
-The example expects the ``ansible.cfg`` file to be in the root of the folder.
+#. Set an environment variable 'PROJECT_ROOT' to the actual path of the project root.
 
 #. Set the following variables for the `all` group:
 
 .. code-block:: yaml
 
-    ansible_repo_path: "{{ ansible_config_file[:-11] }}"
+    ansible_repo_path: "{{ lookup('env', 'PROJECT_ROOT') }}"
     files_path: "{{ ansible_repo_path }}/playbooks/files"
     templates_path: "{{ ansible_repo_path }}/playbooks/templates"
     tasks_path: "{{ ansible_repo_path }}/playbooks/tasks"
@@ -143,6 +143,8 @@ The example expects the ``ansible.cfg`` file to be in the root of the folder.
       ansible.builtin.copy:
         src: {{ files_path }}/foo.conf
         dest: /etc/foo.conf
+
+This way, you can change the root of the project without having to change your playbooks.
 
 .. _execution_tips:
 

--- a/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
+++ b/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
@@ -117,34 +117,10 @@ There is no limit to the number of variable and vault files or their names.
 
 Note that using this strategy in your inventory still requires *all vault passwords to be available* (for example for ``ansible-playbook`` or `AWX/Ansible Tower <https://github.com/ansible/awx/issues/223#issuecomment-768386089>`_) when run with that inventory.
 
-Use absolute paths in your playbooks
-------------------------------------
+Avoid configuration-dependent content
+-------------------------------------
 
-To make reorganizing your files more convenient, you can use absolute paths for referenced files in your playbooks.
-The global Ansible variables might help determine the absolute paths, as the example below demonstrates.
-
-#. Set an environment variable 'PROJECT_ROOT' to the actual path of the project root.
-
-#. Set the following variables for the `all` group:
-
-.. code-block:: yaml
-
-    ansible_repo_path: "{{ lookup('env', 'PROJECT_ROOT') }}"
-    files_path: "{{ ansible_repo_path }}/playbooks/files"
-    templates_path: "{{ ansible_repo_path }}/playbooks/templates"
-    tasks_path: "{{ ansible_repo_path }}/playbooks/tasks"
-    vaults_path: "{{ ansible_repo_path }}/playbooks/vaults"
-
-#. Use these variables to reference a file (``playbooks/files/foo.conf``) as follows.
-
-.. code-block:: yaml
-
-    - name: File copy
-      ansible.builtin.copy:
-        src: {{ files_path }}/foo.conf
-        dest: /etc/foo.conf
-
-This way, you can change the root of the project without having to change your playbooks.
+To ensure that your automation project is easy to understand, modify, and share with others, you should avoid configuration-dependent content. For example, rather than referencing an ``ansible.cfg`` as the root of a project, you should use magic variables such as ``playbook_dir`` or ``role_name`` to determine paths relative to known locations within your project directory. This can help to keep automation content flexible, reusable, and easy to maintain.
 
 .. _execution_tips:
 

--- a/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
+++ b/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
@@ -117,11 +117,11 @@ There is no limit to the number of variable and vault files or their names.
 
 Note that using this strategy in your inventory still requires *all vault passwords to be available* (for example for ``ansible-playbook`` or `AWX/Ansible Tower <https://github.com/ansible/awx/issues/223#issuecomment-768386089>`_) when run with that inventory.
 
-Use relative paths in your playbooks
+Use absolute paths in your playbooks
 ------------------------------------
 
-To make reorganising your files more convenient, you can use relative paths for referenced files in your playbooks.
-The global Ansible variables might help determine the relative paths, as the example below demonstrates.
+To make reorganising your files more convenient, you can use absolute paths for referenced files in your playbooks.
+The global Ansible variables might help determine the absolute paths, as the example below demonstrates.
 
 The example expects the ``ansible.cfg`` file to be in the root of the folder.
 

--- a/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
+++ b/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
@@ -117,6 +117,31 @@ There is no limit to the number of variable and vault files or their names.
 
 Note that using this strategy in your inventory still requires *all vault passwords to be available* (for example for ``ansible-playbook`` or `AWX/Ansible Tower <https://github.com/ansible/awx/issues/223#issuecomment-768386089>`_) when run with that inventory.
 
+Use relative paths in your playbooks
+------------------------------------
+
+To make reorganising your files more convenient, you can use relative paths for referenced files in your playbooks.
+The global Ansible variables might help determine the relative paths, as the example below demonstrates.
+
+The example expects the ``ansible.cfg`` file to be in the root of the folder.
+
+#. Set the following variables for the `all` group:
+
+.. code-block:: yaml
+    ansible_repo_path: "{{ ansible_config_file[:-11] }}"
+    files_path: "{{ ansible_repo_path }}/playbooks/files"
+    templates_path: "{{ ansible_repo_path }}/playbooks/templates"
+    tasks_path: "{{ ansible_repo_path }}/playbooks/tasks"
+    vaults_path: "{{ ansible_repo_path }}/playbooks/vaults"
+
+#. Use these variables to reference a file (``playbooks/files/foo.conf``) as follows.
+
+.. code-block:: yaml
+    - name: File copy
+      ansible.builtin.copy:
+        src: {{ files_path }}/foo.conf
+        dest: /etc/foo.conf
+
 .. _execution_tips:
 
 Execution tricks


### PR DESCRIPTION
This PR is related to #96. 

I mentioned the absolute path referencing in ansible_tips_tricks.rst as it could be connected to the Inventory tips on this page. 