### PR TITLE
[Stable-2.17] Bump wntrblm/nox from 2024.03.02 to 2024.04.15

### DIFF
--- a/.github/workflows/reusable-nox.yml
+++ b/.github/workflows/reusable-nox.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
       - name: Setup nox
-        uses: wntrblm/nox@2024.03.02
+        uses: wntrblm/nox@2024.04.15
         with:
           python-versions: "${{ matrix.python-versions }}"
       - name: Graft ansible-core

--- a/.github/workflows/reusable-pip-compile.yml
+++ b/.github/workflows/reusable-pip-compile.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           python docs/bin/clone-core.py
       - name: Set up nox
-        uses: wntrblm/nox@2024.03.02
+        uses: wntrblm/nox@2024.04.15
         with:
           python-versions: "3.9"
       - name: Set up git committer


### PR DESCRIPTION
Manual backport of #1304

Bumps [wntrblm/nox](https://github.com/wntrblm/nox) from 2024.03.02 to 2024.04.15.
- [Release notes](https://github.com/wntrblm/nox/releases)
- [Changelog](https://github.com/wntrblm/nox/blob/main/CHANGELOG.md)
- [Commits](https://github.com/wntrblm/nox/compare/2024.03.02...2024.04.15)

---
updated-dependencies:
- dependency-name: wntrblm/nox dependency-type: direct:production ...