### PR TITLE
Muni tech writers: Ansible include_task search documentation incorrect #357

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbook_pathing.rst
+++ b/docs/docsite/rst/playbook_guide/playbook_pathing.rst
@@ -33,16 +33,16 @@ Specifically, Ansible tries to find the file
    1. In its appropriate subdirectory—"files", "vars", "templates" or "tasks", depending on the kind of file Ansible is searching for.
    2. Directly in its directory.
    
-2. Like 1, in the parent role that called into this current role with `include_role`, `import_role`, or with a role dependency. If the parent role has its own parent role, Ansible will repeat this step with that role.
+2. Like 1, in the parent role that called into this current role with ``include_role``, ``import_role``, or with a role dependency. If the parent role has its own parent role, Ansible will repeat this step with that role.
 3. Like 1, in the current task file's directory.
 4. Like 1, in the current play file's directory.
 
-Ansible does not search the current working directory. (The directory you're in when you execute Ansible.) Also, Ansible will only search within a role if you actually included it with an `include_role` or `import_role` task or a dependency. If you instead use `include`, `include_task` or `import_task` to include just the tasks from a specific file but not the full role, Ansible will not search that role in steps 1 and 2.
+Ansible does not search the current working directory. (The directory you're in when you execute Ansible.) Also, Ansible will only search within a role if you actually included it with an ``include_role`` or ``import_role`` task or a dependency. If you instead use ``include``, ``include_task`` or ``import_task`` to include just the tasks from a specific file but not the full role, Ansible will not search that role in steps 1 and 2.
 
 Troubleshooting search paths
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When you execute Ansible, the variable `ansible_search_path` will contain the paths searched, in the order they were searched in but without listing their subdirectories. If you run Ansible in verbosity level 5 by passing the `-vvvvv` argument, Ansible will report each directory as it searches, except when it searches for a tasks file.
+When you execute Ansible, the variable ``ansible_search_path`` will contain the paths searched, in the order they were searched in but without listing their subdirectories. If you run Ansible in verbosity level 5 by passing the ``-vvvvv`` argument, Ansible will report each directory as it searches, except when it searches for a tasks file.
 
 
 .. note::  The current working directory might vary depending on the connection plugin and if the action is local or remote. For the remote it is normally the directory on which the login shell puts the user. For local it is either the directory you executed ansible from or in some cases the playbook directory.

--- a/docs/docsite/rst/playbook_guide/playbook_pathing.rst
+++ b/docs/docsite/rst/playbook_guide/playbook_pathing.rst
@@ -39,12 +39,11 @@ Specifically, Ansible tries to find the file in the following order:
 
 Ansible does not search for local files in the current working directory; in other words, the directory from which you execute Ansible.
 
+.. note:: The current working directory might vary depending on the connection plugin and if the action is local or remote. For the remote it is normally the directory on which the login shell puts the user. For local it is either the directory you executed ansible from or in some cases the playbook directory.
+
 .. note:: When resolving local relative paths for tasks files, Ansible uses the context of the role that includes tasks with an ``include_role`` or ``import_role`` statement. If you import the tasks with ``include_task``, or ``import_task`` statements, Ansible uses the context of the importing file.
 
 Troubleshooting search paths
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When you execute Ansible, the variable ``ansible_search_path`` will contain the paths searched, in the order they were searched in but without listing their subdirectories. If you run Ansible in verbosity level 5 by passing the ``-vvvvv`` argument, Ansible will report each directory as it searches, except when it searches for a tasks file.
-
-
-.. note::  The current working directory might vary depending on the connection plugin and if the action is local or remote. For the remote it is normally the directory on which the login shell puts the user. For local it is either the directory you executed ansible from or in some cases the playbook directory.

--- a/docs/docsite/rst/playbook_guide/playbook_pathing.rst
+++ b/docs/docsite/rst/playbook_guide/playbook_pathing.rst
@@ -21,8 +21,8 @@ Task paths
 
 Relative paths used in a task typically refer to remote files and directories on the managed nodes. However, paths passed to lookup plugins and some paths used in action plugins such as the "src" path for the :ansplugin:`template <ansible.builtin.template#module>` and :ansplugin:`copy <ansible.builtin.copy#module>` modules refer to local files and directories on the control node.
 
-Resolving local relative paths
-------------------------------
+How plugins resolve local relative paths
+----------------------------------------
 
 When you specify a relative path for a local file, Ansible will try to find that file first in the current task's role, then in other roles that included or depend on the current role, then relative to the file in which the task is defined, and finally relative to the current play. It will take the first matching file that it finds. This way, if multiple files with the same file name exist, Ansible will find the file that is closest to the current task and that is most likely to be file you wanted.
 
@@ -38,6 +38,9 @@ Specifically, Ansible tries to find the file
 4. Like 1, in the current play file's directory.
 
 Ansible does not search the current working directory. (The directory you're in when you execute Ansible.) Also, Ansible will only search within a role if you actually included it with an `include_role` or `import_role` task or a dependency. If you instead use `include`, `include_task` or `import_task` to include just the tasks from a specific file but not the full role, Ansible will not search that role in steps 1 and 2.
+
+Troubleshooting search paths
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When you execute Ansible, the variable `ansible_search_path` will contain the paths searched, in the order they were searched in but without listing their subdirectories. If you run Ansible in verbosity level 5 by passing the `-vvvvv` argument, Ansible will report each directory as it searches, except when it searches for a tasks file.
 

--- a/docs/docsite/rst/playbook_guide/playbook_pathing.rst
+++ b/docs/docsite/rst/playbook_guide/playbook_pathing.rst
@@ -30,20 +30,26 @@ Specifically, Ansible tries to find the file in the following order:
 
 1. In the current role.
 
-   1. In its appropriate subdirectory—"files", "vars", "templates" or "tasks", depending on the kind of file Ansible is searching for.
+   1. In its appropriate subdirectory: "files", "vars", "templates", or "tasks"; depending on the kind of file Ansible is searching for.
    2. Directly in its directory.
-   
+
 2. Like 1, in the parent role that called into this current role with ``include_role``, ``import_role``, or with a role dependency. If the parent role has its own parent role, Ansible will repeat this step with that role.
 3. Like 1, in the current task file's directory.
 4. Like 1, in the current play file's directory.
 
 Ansible does not search for local files in the current working directory; in other words, the directory from which you execute Ansible.
 
-.. note:: The current working directory might vary depending on the connection plugin and if the action is local or remote. For the remote it is normally the directory on which the login shell puts the user. For local it is either the directory you executed ansible from or in some cases the playbook directory.
+.. note::
 
-.. note:: When resolving local relative paths for tasks files, Ansible uses the context of the role that includes tasks with an ``include_role`` or ``import_role`` statement. If you import the tasks with ``include_task``, or ``import_task`` statements, Ansible uses the context of the importing file.
+   * The current working directory might vary depending on the connection plugin and if the action is local or remote.
+     For the remote it is normally the directory on which the login shell puts the user.
+     For local it is either the directory you executed ansible from or in some cases the playbook directory.
+   * Search path context is additive, meaning that Ansible uses a "stack" of contexts when resolving file paths.
+     When resolving local relative paths for files in tasks, the context of the role that includes tasks with an ``include_role`` or ``import_role`` statement gets highest precedence in the stack.
+     If you import the tasks with ``include_task``, or ``import_task`` statements, Ansible uses the context of the importing file.
 
 Troubleshooting search paths
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When you execute Ansible, the variable ``ansible_search_path`` will contain the paths searched, in the order they were searched in but without listing their subdirectories. If you run Ansible in verbosity level 5 by passing the ``-vvvvv`` argument, Ansible will report each directory as it searches, except when it searches for a tasks file.
+When you execute Ansible, the variable ``ansible_search_path`` will contain the paths searched, in the order they were searched in but without listing their subdirectories.
+If you run Ansible in verbosity level 5 by passing the ``-vvvvv`` argument, Ansible will report each directory as it searches, except when it searches for a tasks file.

--- a/docs/docsite/rst/playbook_guide/playbook_pathing.rst
+++ b/docs/docsite/rst/playbook_guide/playbook_pathing.rst
@@ -21,8 +21,8 @@ Task paths
 
 Relative paths used in a task typically refer to remote files and directories on the managed nodes. However, paths passed to lookup plugins and some paths used in action plugins such as the "src" path for the :ansplugin:`template <ansible.builtin.template#module>` and :ansplugin:`copy <ansible.builtin.copy#module>` modules refer to local files and directories on the control node.
 
-How plugins resolve local relative paths
-----------------------------------------
+Resolving local relative paths
+------------------------------
 
 When you specify a relative path for a local file, Ansible will try to find that file first in the current task's role, then in other roles that included or depend on the current role, then relative to the file in which the task is defined, and finally relative to the current play. It will take the first matching file that it finds. This way, if multiple files with the same file name exist, Ansible will find the file that is closest to the current task and that is most likely to be file you wanted.
 

--- a/docs/docsite/rst/playbook_guide/playbook_pathing.rst
+++ b/docs/docsite/rst/playbook_guide/playbook_pathing.rst
@@ -37,7 +37,8 @@ Specifically, Ansible tries to find the file
 3. Like 1, in the current task file's directory.
 4. Like 1, in the current play file's directory.
 
-Ansible does not search the current working directory. (The directory you're in when you execute Ansible.) Also, Ansible will only search within a role if you actually included it with an ``include_role`` or ``import_role`` task or a dependency. If you instead use ``include``, ``include_task`` or ``import_task`` to include just the tasks from a specific file but not the full role, Ansible will not search that role in steps 1 and 2.
+Ansible does not search for local files in the current working directory, in other words, the directory from which you execute Ansible.
+Ansible will only search within a role if you actually included it with an ``include_role`` or ``import_role`` task or a dependency. If you instead use ``include``, ``include_task`` or ``import_task`` to include just the tasks from a specific file but not the full role, Ansible will not search that role in steps 1 and 2.
 
 Troubleshooting search paths
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/docsite/rst/playbook_guide/playbook_pathing.rst
+++ b/docs/docsite/rst/playbook_guide/playbook_pathing.rst
@@ -26,7 +26,7 @@ How plugins resolve local relative paths
 
 When you specify a relative path for a local file, Ansible will try to find that file first in the current task's role, then in other roles that included or depend on the current role, then relative to the file in which the task is defined, and finally relative to the current play. It will take the first matching file that it finds. This way, if multiple files with the same file name exist, Ansible will find the file that is closest to the current task and that is most likely to be file you wanted.
 
-Specifically, Ansible tries to find the file
+Specifically, Ansible tries to find the file in the following order:
 
 1. In the current role.
 
@@ -38,7 +38,8 @@ Specifically, Ansible tries to find the file
 4. Like 1, in the current play file's directory.
 
 Ansible does not search for local files in the current working directory, in other words, the directory from which you execute Ansible.
-Ansible will only search within a role if you actually included it with an ``include_role`` or ``import_role`` task or a dependency. If you instead use ``include``, ``include_task`` or ``import_task`` to include just the tasks from a specific file but not the full role, Ansible will not search that role in steps 1 and 2.
+
+.. note:: When resolving local relative paths for tasks files, Ansible uses the context of the role that includes tasks with an ``include_role`` or ``import_role`` statement. If you import the tasks with ``include_task``, or ``import_task`` statements, Ansible uses the context of the importing file.
 
 Troubleshooting search paths
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/docsite/rst/playbook_guide/playbook_pathing.rst
+++ b/docs/docsite/rst/playbook_guide/playbook_pathing.rst
@@ -37,7 +37,7 @@ Specifically, Ansible tries to find the file in the following order:
 3. Like 1, in the current task file's directory.
 4. Like 1, in the current play file's directory.
 
-Ansible does not search for local files in the current working directory, in other words, the directory from which you execute Ansible.
+Ansible does not search for local files in the current working directory; in other words, the directory from which you execute Ansible.
 
 .. note:: When resolving local relative paths for tasks files, Ansible uses the context of the role that includes tasks with an ``include_role`` or ``import_role`` statement. If you import the tasks with ``include_task``, or ``import_task`` statements, Ansible uses the context of the importing file.
 

--- a/docs/docsite/rst/playbook_guide/playbook_pathing.rst
+++ b/docs/docsite/rst/playbook_guide/playbook_pathing.rst
@@ -43,7 +43,7 @@ Ansible does not search for local files in the current working directory; in oth
 
    * The current working directory might vary depending on the connection plugin and if the action is local or remote.
      For the remote it is normally the directory on which the login shell puts the user.
-     For local it is either the directory you executed ansible from or in some cases the playbook directory.
+     For local it is either the directory you executed Ansible from or in some cases the playbook directory.
    * Search path context is additive, meaning that Ansible uses a "stack" of contexts when resolving file paths.
      When resolving local relative paths for files in tasks, the context of the role that includes tasks with an ``include_role`` or ``import_role`` statement gets highest precedence in the stack.
      If you import the tasks with ``include_task``, or ``import_task`` statements, Ansible uses the context of the importing file.


### PR DESCRIPTION
Hi, this (draft) PR concerns the issue #357 and addresses the comments made to the previous PR #1263 
I have made the changes suggested and requested in the comments, and I hope that this one is in better shape.

mainly, I pulled the information about the distinction between the contexts that are used for lookups under a single note to (hopefully) make it compliant with the comment https://github.com/ansible/ansible-documentation/pull/1263#discussion_r1567565138