### PR TITLE
Remove additional references to smart connections

### DIFF
--- a/examples/scripts/uptime.py
+++ b/examples/scripts/uptime.py
@@ -53,7 +53,7 @@ class ResultsCollectorJSONCallback(CallbackBase):
 def main():
     host_list = ['localhost', 'www.example.com', 'www.google.com']
     # since the API is constructed for CLI it expects certain options to always be set in the context object
-    context.CLIARGS = ImmutableDict(connection='smart', module_path=['/to/mymodules', '/usr/share/ansible'], forks=10, become=None,
+    context.CLIARGS = ImmutableDict(module_path=['/to/mymodules', '/usr/share/ansible'], forks=10, become=None,
                                     become_method=None, become_user=None, check=False, diff=False, verbosity=0)
     # required for
     # https://github.com/ansible/ansible/blob/devel/lib/ansible/inventory/manager.py#L204


### PR DESCRIPTION
Follows up on #1042 and #1258 by removing additional references to the `smart` connection type in the example uptime script and FAQ.