### PR TITLE
Add examples to clarify inventory plugin usage

### DIFF
--- a/docs/docsite/rst/plugins/inventory.rst
+++ b/docs/docsite/rst/plugins/inventory.rst
@@ -55,8 +55,8 @@ To start using an inventory plugin with a YAML configuration source, create a fi
 
 .. note:: Inventory plugins have required name patterns they must conform to. For example
 
-  An inventory using the ``kubevirt.core.kubevirt`` inventory plugin must have a filename ``*.kubevirt.yml``
-  An inventory using the ``servicenow.servicenow.now`` inventory plugin must have a filename ``*.servicenow.yml``
+  An inventory that includes the ``kubevirt.core.kubevirt`` inventory plugin must use the ``*.kubevirt.yml`` filename pattern. 
+  An inventory that includes the ``servicenow.servicenow.now`` inventory plugin must use the ``*.servicenow.yml`` filename pattern.
 
 
 .. code-block:: yaml

--- a/docs/docsite/rst/plugins/inventory.rst
+++ b/docs/docsite/rst/plugins/inventory.rst
@@ -53,7 +53,7 @@ To use an inventory plugin, you must provide an inventory source. Most of the ti
 To start using an inventory plugin with a YAML configuration source, create a file with the accepted file name schema documented for the plugin in question, then add ``plugin: plugin_name``. Use the fully qualified name if the plugin is in a collection.
 
 
-.. note:: Inventory plugins have required name patterns they must conform to. For example
+.. note:: Inventory plugins have required name patterns to which they must conform, for example:
 
   An inventory that includes the ``kubevirt.core.kubevirt`` inventory plugin must use the ``*.kubevirt.yml`` filename pattern. 
   An inventory that includes the ``servicenow.servicenow.now`` inventory plugin must use the ``*.servicenow.yml`` filename pattern.

--- a/docs/docsite/rst/plugins/inventory.rst
+++ b/docs/docsite/rst/plugins/inventory.rst
@@ -52,6 +52,13 @@ To use an inventory plugin, you must provide an inventory source. Most of the ti
 
 To start using an inventory plugin with a YAML configuration source, create a file with the accepted file name schema documented for the plugin in question, then add ``plugin: plugin_name``. Use the fully qualified name if the plugin is in a collection.
 
+
+.. note:: Inventory plugins have required name patterns they must conform to. For example
+
+  An inventory using the ``kubevirt.core.kubevirt`` inventory plugin must have a filename ``*.kubevirt.yml``
+  An inventory using the ``servicenow.servicenow.now`` inventory plugin must have a filename ``*.servicenow.yml``
+
+
 .. code-block:: yaml
 
    # demo.aws_ec2.yml


### PR DESCRIPTION
Adding an example to the inventory plugin docs, as we hit many issues setting up kubevirt inventories and it was related to filenames