### PR TITLE
update symlink step syntax in docs build workflow

### DIFF
--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -92,7 +92,7 @@ jobs:
       working-directory: build-directory/docs/docsite
 
     - name: Create latest symlink
-      if: ${{ github.event.inputs.latest-symlink == 'true'}}
+      if: fromJSON(github.event.inputs.latest-symlink)
       run: ln -s "${VERSION}" _build/html/latest
       working-directory: build-directory/docs/docsite
 

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -92,7 +92,7 @@ jobs:
       working-directory: build-directory/docs/docsite
 
     - name: Create latest symlink
-      if: github.event.inputs.latest-symlink
+      if: ${{ github.event.inputs.latest-symlink == 'true'}}
       run: ln -s "${VERSION}" _build/html/latest
       working-directory: build-directory/docs/docsite
 


### PR DESCRIPTION
this change fixes an issue with the docs build workflow so that the input to create a symlink is applied correctly, otherwise the symlink is always created