### PR TITLE
add steps to deploy doc build assets

### DIFF
--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -52,9 +52,9 @@ on:
         - production
         - test
       deployment-branch:
-        description: Branch in the destination repo
+        description: Branch name for prod deployment
         required: true
-        default: main
+        default: devel
 
 
 env:

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -132,8 +132,8 @@ jobs:
     env:
       dest-repo: owner/repo-name  # TODO create repo and specify here
       dest-branch: main  # TODO specify repo branch here
-      user-email: username@example.com  # TODO specify email for commit
-      user-name: username  # TODO specify username for commit
+      user-email: "41898282+github-actions[bot]@users.noreply.github.com"
+      user-name: "github-actions[bot]"
     steps:
     - name: Download the build archive
       uses: actions/download-artifact@v4

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -39,10 +39,18 @@ on:
         type: boolean
         description: Add latest symlink
         required: true
-      production:
+      deploy:
         type: boolean
-        description: Deploy build to production
+        description: Deploy the build
         required: true
+      deployment-environment:
+        type: choice
+        description: Deployment environment
+        required: true
+        default: test
+        options:
+        - production
+        - test
 
 
 env:
@@ -126,6 +134,7 @@ jobs:
         retention-days: 7
 
   deploy-package-docs:
+    if: fromJSON(github.event.inputs.deploy)
     needs: build-package-docs
     runs-on: ubuntu-latest
     environment:
@@ -156,7 +165,6 @@ jobs:
         private_key: ${{ secrets.BOT_APP_KEY }}  # TODO create bot app id key
 
     - name: Checkout the deploy directory
-      if: fromJSON(github.event.inputs.production)
       uses: actions/checkout@v4
       with:
         repository: ${{ env.dest-repo }}
@@ -164,15 +172,14 @@ jobs:
         path: deploy-directory
         token: ${{ steps.create_token.outputs.token }}
 
-    - name: Copy the generated HTML and assets
-      if: fromJSON(github.event.inputs.production)
+    - name: Copy the generated HTML and assets for production
+      if: ${{ github.event.inputs.deployment-environment == 'production' }}
       run: >-
         rsync -av --delete --mkpath
         extracted-docs/
         deploy-directory/docs-build
 
     - name: Add generated HTML and assets
-      if: fromJSON(github.event.inputs.production)
       run: |
         git config --local user.email "${{ env.user-email }}"
         git config --local user.name "${{ env.user-name }}"
@@ -180,7 +187,6 @@ jobs:
       working-directory: deploy-directory
 
     - name: Commit generated HTML and assets
-      if: fromJSON(github.event.inputs.production)
       run: >-
         git commit -m "Push docs build $(date '+%Y-%m-%d')-${{
           github.run_id
@@ -192,7 +198,6 @@ jobs:
       working-directory: deploy-directory
 
     - name: Push build to deploy repository
-      if: fromJSON(github.event.inputs.production)
       uses: ad-m/github-push-action@v0.8.0
       with:
         github_token: ${{ steps.create_token.outputs.token }}

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -51,11 +51,6 @@ on:
         options:
         - production
         - test
-      deployment-branch:
-        description: Branch name for prod deployment
-        required: true
-        default: devel
-
 
 env:
   PACKAGE_VERSION: ${{ github.event.inputs.ansible-package-version }}
@@ -145,9 +140,10 @@ jobs:
       name: deploy-package-docs
       url: https://github.com/ansible/ansible-documentation
     env:
-      dest-repo: ansible-community/package-doc-builds
-      user-email: "41898282+github-actions[bot]@users.noreply.github.com"
-      user-name: "github-actions[bot]"
+      TARGET: ${{ github.event.inputs.deployment-environment }}
+      DEST_REPO: ansible-community/package-doc-builds
+      USER_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
+      USER_NAME: "github-actions[bot]"
     steps:
     - name: Download the build archive
       uses: actions/download-artifact@v4
@@ -161,19 +157,20 @@ jobs:
         tar -xvzf ansible-package-docs-html-*.tar.gz -C extracted-docs
 
     - name: Set the production branch
-      if: ${{ github.event.inputs.deployment-environment == 'production' }}
-      run: |
-        echo "BRANCH=${{ github.event.inputs.deployment-branch }}" >> $GITHUB_ENV
+      if: env.TARGET == 'production'
+      run: >-
+        echo "BRANCH=${{
+          github.event.inputs.repository-branch
+        }}" >> $GITHUB_ENV
 
     - name: Set the test branch
-      if: ${{ github.event.inputs.deployment-environment == 'test' }}
-      run: |
-        echo "BRANCH=gh-pages" >> $GITHUB_ENV
+      if: env.TARGET == 'test'
+      run: echo "BRANCH=gh-pages" >> $GITHUB_ENV
 
     - name: Checkout the deploy directory
       uses: actions/checkout@v4
       with:
-        repository: ${{ env.dest-repo }}
+        repository: ${{ env.DEST_REPO }}
         ref: ${{ env.BRANCH }}
         path: deploy-directory
         fetch-depth: 0
@@ -187,7 +184,7 @@ jobs:
         deploy-directory/docs
 
     - name: Create a norobots.txt file for the test site
-      if: ${{ github.event.inputs.deployment-environment == 'test' }}
+      if: env.TARGET == 'test'
       run: |
         touch norobots.txt
         echo "User-agent: *" > norobots.txt
@@ -196,8 +193,8 @@ jobs:
 
     - name: Configure the git user
       run: |
-        git config --local user.email "${{ env.user-email }}"
-        git config --local user.name "${{ env.user-name }}"
+        git config --local user.email "${{ env.USER_EMAIL }}"
+        git config --local user.name "${{ env.USER_NAME }}"
       working-directory: deploy-directory
 
     - name: Git add the generated HTML and assets

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -151,10 +151,10 @@ jobs:
         name: package-docs-build
 
     - name: Extract the tarball
-      run: |
-        set -xeEuo pipefail
-        mkdir -pv extracted-docs
-        tar -xvzf ansible-package-docs-html-*.tar.gz -C extracted-docs
+      run: >-
+        tar -xvzf
+        ansible-package-docs-html-*.tar.gz
+        --one-top-level
 
     - name: Set the production branch
       if: env.TARGET == 'production'
@@ -180,7 +180,7 @@ jobs:
     - name: Copy the generated HTML and assets for production
       run: >-
         rsync -av --delete --mkpath
-        extracted-docs/
+        ansible-package-docs-html-*/
         deploy-directory/docs
 
     - name: Create a norobots.txt file for the test site

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -160,22 +160,39 @@ jobs:
         mkdir -pv extracted-docs
         tar -xvzf ansible-package-docs-html-*.tar.gz -C extracted-docs
 
+    - name: Set the production branch
+      if: ${{ github.event.inputs.deployment-environment == 'production' }}
+      run: |
+        echo "BRANCH=${{ github.event.inputs.deployment-branch }}" >> $GITHUB_ENV
+
+    - name: Set the test branch
+      if: ${{ github.event.inputs.deployment-environment == 'test' }}
+      run: |
+        echo "BRANCH=gh-pages" >> $GITHUB_ENV
+
     - name: Checkout the deploy directory
       uses: actions/checkout@v4
       with:
         repository: ${{ env.dest-repo }}
-        ref: ${{ github.event.inputs.deployment-branch }}
+        ref: ${{ env.BRANCH }}
         path: deploy-directory
         fetch-depth: 0
-        ssh-key: ${{ secrets.DEPLOYDOCS }} # TODO
+        ssh-key: ${{ secrets.DEPLOY_DOC_BUILD }}
         persist-credentials: true
 
     - name: Copy the generated HTML and assets for production
-      if: ${{ github.event.inputs.deployment-environment == 'production' }}
       run: >-
         rsync -av --delete --mkpath
         extracted-docs/
-        deploy-directory/docs-build
+        deploy-directory/docs
+
+    - name: Create a norobots.txt file for the test site
+      if: ${{ github.event.inputs.deployment-environment == 'test' }}
+      run: |
+        touch norobots.txt
+        echo "User-agent: *" > norobots.txt
+        echo "Disallow: /" >> norobots.txt
+      working-directory: deploy-directory/docs
 
     - name: Configure the git user
       run: |
@@ -184,7 +201,7 @@ jobs:
       working-directory: deploy-directory
 
     - name: Git add the generated HTML and assets
-      run: git add ./docs-build --all --force
+      run: git add ./docs --all --force
       working-directory: deploy-directory
 
     - name: Commit generated HTML and assets

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -158,10 +158,10 @@ jobs:
 
     - name: Set the production branch
       if: env.TARGET == 'production'
+      env:
+        BRANCH_NAME: ${{ github.event.inputs.repository-branch }}
       run: >-
-        echo "BRANCH=${{
-          github.event.inputs.repository-branch
-        }}" >> "${GITHUB_ENV}"
+        echo "BRANCH=${BRANCH_NAME}" >> "${GITHUB_ENV}"
 
     - name: Set the test branch
       if: env.TARGET == 'test'

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -161,11 +161,11 @@ jobs:
       run: >-
         echo "BRANCH=${{
           github.event.inputs.repository-branch
-        }}" >> $GITHUB_ENV
+        }}" >> "${GITHUB_ENV}"
 
     - name: Set the test branch
       if: env.TARGET == 'test'
-      run: echo "BRANCH=gh-pages" >> $GITHUB_ENV
+      run: echo "BRANCH=gh-pages" >> "${GITHUB_ENV}"
 
     - name: Checkout the deploy directory
       uses: actions/checkout@v4

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -52,7 +52,6 @@ on:
         - production
         - test
 
-
 env:
   PACKAGE_VERSION: ${{ github.event.inputs.ansible-package-version }}
   LANGUAGE: ${{ github.event.inputs.language }}

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -188,10 +188,11 @@ jobs:
 
     - name: Commit generated HTML and assets
       run: >-
+        git diff-index --quiet HEAD ||
         git commit -m "Push docs build $(date '+%Y-%m-%d')-${{
           github.run_id
         }}-${{
-          github.run_number
+           github.run_number
         }}-${{
           github.run_attempt
         }}"

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -52,6 +52,7 @@ on:
         - production
         - test
 
+
 env:
   PACKAGE_VERSION: ${{ github.event.inputs.ansible-package-version }}
   LANGUAGE: ${{ github.event.inputs.language }}

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -142,7 +142,8 @@ jobs:
 
     - name: Extract the tarball
       run: |
-        mkdir -p extracted-docs
+        set -xeEuo pipefail
+        mkdir -pv extracted-docs
         tar -xvzf ansible-package-docs-html-*.tar.gz -C extracted-docs
 
     - name: Generate temp GITHUB_TOKEN

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -39,6 +39,10 @@ on:
         type: boolean
         description: Add latest symlink
         required: true
+      production:
+        type: boolean
+        description: Deploy build to production
+        required: true
 
 
 env:
@@ -120,3 +124,76 @@ jobs:
         name: package-docs-build
         path: build-directory/docs/docsite/ansible-package-docs-html-*.tar.gz
         retention-days: 7
+
+  deploy-package-docs:
+    needs: build-package-docs
+    runs-on: ubuntu-latest
+    environment:  # TODO create environment and specify it here
+    env:
+      dest-repo: owner/repo-name  # TODO create repo and specify here
+      dest-branch: main  # TODO specify repo branch here
+      user-email: username@example.com  # TODO specify email for commit
+      user-name: username  # TODO specify username for commit
+    steps:
+    - name: Download the build archive
+      uses: actions/download-artifact@v4
+      with:
+        name: package-docs-build
+
+    - name: Extract the tarball
+      run: |
+        mkdir -p extracted-docs
+        tar -xvzf ansible-package-docs-html-*.tar.gz -C extracted-docs
+
+    - name: Generate temp GITHUB_TOKEN
+      id: create_token
+      uses: tibdex/github-app-token@v2
+      with:
+        app_id: ${{ secrets.BOT_APP_ID }}  # TODO create bot app id secret
+        private_key: ${{ secrets.BOT_APP_KEY }}  # TODO create bot app id key
+
+    - name: Checkout the deploy directory
+      if: fromJSON(github.event.inputs.production)
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ env.dest-repo }}
+        ref: ${{ env.dest-branch }}
+        path: deploy-directory
+        token: ${{ steps.create_token.outputs.token }}
+
+    - name: Copy the generated HTML and assets
+      if: fromJSON(github.event.inputs.production)
+      run: >-
+        rsync -av --delete --mkpath
+        extracted-docs/
+        deploy-directory/docs-build
+
+    - name: Add generated HTML and assets
+      if: fromJSON(github.event.inputs.production)
+      run: |
+        git config --local user.email "${{ env.user-email }}"
+        git config --local user.name "${{ env.user-name }}"
+        git add . --all --force
+      working-directory: deploy-directory
+
+    - name: Commit generated HTML and assets
+      if: fromJSON(github.event.inputs.production)
+      run: >-
+        git commit -m "Push docs build $(date '+%Y-%m-%d')-${{
+          github.run_id
+        }}-${{
+          github.run_number
+        }}-${{
+          github.run_attempt
+        }}"
+      working-directory: deploy-directory
+
+    - name: Push build to deploy repository
+      if: fromJSON(github.event.inputs.production)
+      uses: ad-m/github-push-action@v0.8.0
+      with:
+        github_token: ${{ steps.create_token.outputs.token }}
+        repository: ${{ env.dest-repo }}
+        branch: ${{ env.dest-branch }}
+        directory: deploy-directory
+        force: true

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -128,7 +128,9 @@ jobs:
   deploy-package-docs:
     needs: build-package-docs
     runs-on: ubuntu-latest
-    environment:  # TODO create environment and specify it here
+    environment:
+      name: deploy-package-docs
+      url: https://github.com/ansible/ansible-documentation
     env:
       dest-repo: owner/repo-name  # TODO create repo and specify here
       dest-branch: main  # TODO specify repo branch here

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -51,6 +51,10 @@ on:
         options:
         - production
         - test
+      deployment-branch:
+        description: Branch in the destination repo
+        required: true
+        default: main
 
 
 env:
@@ -141,8 +145,7 @@ jobs:
       name: deploy-package-docs
       url: https://github.com/ansible/ansible-documentation
     env:
-      dest-repo: owner/repo-name  # TODO create repo and specify here
-      dest-branch: main  # TODO specify repo branch here
+      dest-repo: ansible-community/package-doc-builds
       user-email: "41898282+github-actions[bot]@users.noreply.github.com"
       user-name: "github-actions[bot]"
     steps:
@@ -157,20 +160,15 @@ jobs:
         mkdir -pv extracted-docs
         tar -xvzf ansible-package-docs-html-*.tar.gz -C extracted-docs
 
-    - name: Generate temp GITHUB_TOKEN
-      id: create_token
-      uses: tibdex/github-app-token@v2
-      with:
-        app_id: ${{ secrets.BOT_APP_ID }}  # TODO create bot app id secret
-        private_key: ${{ secrets.BOT_APP_KEY }}  # TODO create bot app id key
-
     - name: Checkout the deploy directory
       uses: actions/checkout@v4
       with:
         repository: ${{ env.dest-repo }}
-        ref: ${{ env.dest-branch }}
+        ref: ${{ github.event.inputs.deployment-branch }}
         path: deploy-directory
-        token: ${{ steps.create_token.outputs.token }}
+        fetch-depth: 0
+        ssh-key: ${{ secrets.DEPLOYDOCS }} # TODO
+        persist-credentials: true
 
     - name: Copy the generated HTML and assets for production
       if: ${{ github.event.inputs.deployment-environment == 'production' }}
@@ -179,11 +177,14 @@ jobs:
         extracted-docs/
         deploy-directory/docs-build
 
-    - name: Add generated HTML and assets
+    - name: Configure the git user
       run: |
         git config --local user.email "${{ env.user-email }}"
         git config --local user.name "${{ env.user-name }}"
-        git add . --all --force
+      working-directory: deploy-directory
+
+    - name: Git add the generated HTML and assets
+      run: git add ./docs-build --all --force
       working-directory: deploy-directory
 
     - name: Commit generated HTML and assets
@@ -199,10 +200,5 @@ jobs:
       working-directory: deploy-directory
 
     - name: Push build to deploy repository
-      uses: ad-m/github-push-action@v0.8.0
-      with:
-        github_token: ${{ steps.create_token.outputs.token }}
-        repository: ${{ env.dest-repo }}
-        branch: ${{ env.dest-branch }}
-        directory: deploy-directory
-        force: true
+      run: git push origin
+      working-directory: deploy-directory

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: deploy-package-docs
-      url: https://github.com/ansible/ansible-documentation
+      url: ${{ env.ENV_URL }}
     env:
       TARGET: ${{ github.event.inputs.deployment-environment }}
       DEST_REPO: ansible-community/package-doc-builds
@@ -156,16 +156,22 @@ jobs:
         ansible-package-docs-html-*.tar.gz
         --one-top-level
 
-    - name: Set the production branch
+    - name: Set the production branch and url
       if: env.TARGET == 'production'
       env:
         BRANCH_NAME: ${{ github.event.inputs.repository-branch }}
-      run: >-
+        PROD_URL: https://ansible.readthedocs.io/projects/ansible/en
+      run: |
         echo "BRANCH=${BRANCH_NAME}" >> "${GITHUB_ENV}"
+        echo "ENV_URL=${PROD_URL}/${BRANCH_NAME}" >> "${GITHUB_ENV}"
 
-    - name: Set the test branch
+    - name: Set the test branch and url
       if: env.TARGET == 'test'
-      run: echo "BRANCH=gh-pages" >> "${GITHUB_ENV}"
+      env:
+        TEST_URL: https://ansible-community.github.io/package-doc-builds
+      run: |
+        echo "BRANCH=gh-pages" >> "${GITHUB_ENV}"
+        echo "ENV_URL=${TEST_URL}" >> "${GITHUB_ENV}"
 
     - name: Checkout the deploy directory
       uses: actions/checkout@v4

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -193,8 +193,8 @@ jobs:
 
     - name: Configure the git user
       run: |
-        git config --local user.email "${{ env.USER_EMAIL }}"
-        git config --local user.name "${{ env.USER_NAME }}"
+        git config --local user.email "${USER_EMAIL}"
+        git config --local user.name "${USER_NAME}"
       working-directory: deploy-directory
 
     - name: Git add the generated HTML and assets


### PR DESCRIPTION
This PR updates the workflow to build package docs with an input to push generated HTML and other assets to a remote repository. After the build is pushed to the remote, a Python script copies the assets to the ReadTheDocs `html` directory. The push also triggers the ReadTheDocs automatic build.

Note that this PR is in draft state because it contains my personal GitHub config details and a reference to a temporary token. Before this gets merged, we'll need to figure out the best way to replace those bits. Additionally, we'll need to figure out how to limit access to the workflow so that only members of the `community-docs-maintainers` group can run it.

For an example of how this works, see this job in my fork: https://github.com/oraNod/ansible-documentation/actions/runs/8837905175/job/24267821667

The push goes to this repository that holds the Python script: https://github.com/oraNod/ansible-docs-deploy

And here is the example ReadTheDocs project: https://readthedocs.org/projects/oranod-ansible-docs-deploy/

You can find the published docs here: https://oranod-ansible-docs-deploy.readthedocs.io/en/latest/