### PR TITLE
update codespell ignore lines

### DIFF
--- a/.codespellignorelines
+++ b/.codespellignorelines
@@ -13,3 +13,6 @@ see the `Active Directory Certificate Services documentation <https://docs.micro
         role_type: ANS
     # => "$6$43927$lQxPKz2M2X.NWO.gK.t7phLwOKQMcSq72XxDZQ0XzYV6DlL1OD72h417aj16OnHTGxNzhftXJQBcjbunLEepM0"
     table#network-platform-table thead tr th.head {
+# Following lines from the generated file docs/docsite/rst/reference_appendices/config.rst
+:Description: This setting changes the behaviour of mismatched host patterns, it allows you to force a fatal error, a warning or just ignore it.
+    This setting changes the behaviour of mismatched host patterns, it allows you to force a fatal error, a warning or just ignore it.


### PR DESCRIPTION
This change ignores spelling issues in two lines from the generated docs/docssite/rst/reference_appendices/config.rst file.