### PR TITLE
Fix typos in style guide

### DIFF
--- a/docs/docsite/rst/dev_guide/style_guide/index.rst
+++ b/docs/docsite/rst/dev_guide/style_guide/index.rst
@@ -183,7 +183,7 @@ Long pages, or pages with multiple levels of headings, can also include a local 
 
 .. note::
 
-	Avoid raw URLs. RST and sphinx allow ::code:`https://my.example.com`, but this is unhelpful for those using screen readers. ``:ref:`` links automatically pick up the heading from the anchor, but for external links, always use the ::code:`\`link title <link-url>\`_` format.
+	Avoid raw URLs. RST and sphinx allow :code:`https://my.example.com`, but this is unhelpful for those using screen readers. ``:ref:`` links automatically pick up the heading from the anchor, but for external links, always use the :code:`\`link title <link-url>\`_` format.
 
 .. _adding_anchors_rst:
 

--- a/docs/docsite/rst/dev_guide/style_guide/index.rst
+++ b/docs/docsite/rst/dev_guide/style_guide/index.rst
@@ -183,7 +183,7 @@ Long pages, or pages with multiple levels of headings, can also include a local 
 
 .. note::
 
-	Avoid raw URLs. RST and sphinx allow ::code:`https://my.example.com`, but this is unhelpful for those using screen readers. ``:ref:`` links automatically pick up the heading from the anchor, but for external links, always use the ::code:`link title <link-url>`_` format.
+	Avoid raw URLs. RST and sphinx allow ::code:`https://my.example.com`, but this is unhelpful for those using screen readers. ``:ref:`` links automatically pick up the heading from the anchor, but for external links, always use the ::code:`\`link title <link-url>\`_` format.
 
 .. _adding_anchors_rst:
 


### PR DESCRIPTION
Adds an escaped ` character before the external link and removes doubled colons.
Discussed in https://github.com/ansible/ansible-documentation/pull/1302#issuecomment-2082874118 , and https://github.com/ansible/ansible-documentation/pull/1368#discussion_r1585533984