### PR TITLE
New section on combining variables added

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_variables.rst
@@ -182,6 +182,9 @@ Combining variables
 
 To merge variables that contain lists or dictionaries, you can use the following approaches.
 
+Combining list variables
+------------------------
+
 You can use the `set_fact` module to combine lists into a new `merged_list` variable as follows:
 
 .. code-block:: yaml
@@ -202,6 +205,8 @@ You can use the `set_fact` module to combine lists into a new `merged_list` vari
       ansible.builtin.set_fact:
         merged_list: "{{ list1 + list2 }}"
 
+Combining dictionary variables
+------------------------------
 
 To merge dictionaries use the ``combine`` filter, for example:
 
@@ -225,6 +230,8 @@ To merge dictionaries use the ``combine`` filter, for example:
 
 For more details, see :ansplugin:`ansible.builtin.combine#filter` .
 
+Using the merge_variables lookup
+--------------------------------
 
 To merge variables that match the given prefixes, suffixes, or regular expressions, you can use the ``community.general.merge_variables`` lookup, for example:
 

--- a/docs/docsite/rst/playbook_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_variables.rst
@@ -510,33 +510,59 @@ Instead of worrying about variable precedence, we encourage you to think about h
 Combining variables
 ===================
 
-If you need to combine variables from different groups or hosts you can use the following approaches.
+To merge variables that contain lists or dictionaries, you can use the following approaches.
 
-To merge lists, use:
-
-.. code-block:: yaml
-
-    merged_list: '{{ list1 + list2 }}'
-
-
-To merge dictionaries use ``combine`` filter. For example:
+You can use the `set_fact` module to combine lists into a new `merged_list` variable as follows:
 
 .. code-block:: yaml
 
-    merged_dict: "{{ dict1 | ansible.builtin.combine(dict2) }}"
+    vars:
+      list1:
+      - apple
+      - banana
+      - fig
+
+      list2:
+      - peach
+      - plum
+      - pear
+    
+    tasks:
+    - name: Combine list1 and list2 into a merged_list var
+      ansible.builtin.set_fact:
+        merged_list: "{{ list1 + list2 }}"
+
+
+To merge dictionaries use the ``combine`` filter, for example:
+
+.. code-block:: yaml
+
+    vars:
+      dict1:
+        name: Leeroy Jenkins
+        age: 25
+        occupation: Astronaut
+
+      dict2:
+        location: Galway
+        country: Ireland
+        postcode: H71 1234
+
+    tasks:
+    - name: Combine dict1 and dict2 into a merged_dict var
+      ansible.builtin.set_fact:
+        merged_dict: "{{ dict1 | ansible.builtin.combine(dict2) }}"
 
 For more details, see :ansplugin:`ansible.builtin.combine#filter` .
 
 
-To merge variables that match the given prefixes, suffixes, or regular expressions use ``merge_variables`` lookup. For example:
+To merge variables that match the given prefixes, suffixes, or regular expressions, you can use the ``community.general.merge_variables`` lookup, for example:
 
 .. code-block:: yaml
 
     merged_variable: "{{ lookup('community.general.merge_variables', '__my_pattern', pattern_type='suffix') }}"
 
-For more details, see `merge_variables lookup` .
-
-.. _merge_variables lookup: https://docs.ansible.com/ansible/latest/collections/community/general/merge_variables_lookup.html
+For more details and example usage, refer to the `community.general.merge_variables lookup documentation <https://docs.ansible.com/ansible/latest/collections/community/general/merge_variables_lookup.html>`_.
 
 
 Using advanced variable syntax

--- a/docs/docsite/rst/playbook_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_variables.rst
@@ -177,6 +177,63 @@ Both of these examples reference the same value ("one"). Bracket notation always
 
 ``add``, ``append``, ``as_integer_ratio``, ``bit_length``, ``capitalize``, ``center``, ``clear``, ``conjugate``, ``copy``, ``count``, ``decode``, ``denominator``, ``difference``, ``difference_update``, ``discard``, ``encode``, ``endswith``, ``expandtabs``, ``extend``, ``find``, ``format``, ``fromhex``, ``fromkeys``, ``get``, ``has_key``, ``hex``, ``imag``, ``index``, ``insert``, ``intersection``, ``intersection_update``, ``isalnum``, ``isalpha``, ``isdecimal``, ``isdigit``, ``isdisjoint``, ``is_integer``, ``islower``, ``isnumeric``, ``isspace``, ``issubset``, ``issuperset``, ``istitle``, ``isupper``, ``items``, ``iteritems``, ``iterkeys``, ``itervalues``, ``join``, ``keys``, ``ljust``, ``lower``, ``lstrip``, ``numerator``, ``partition``, ``pop``, ``popitem``, ``real``, ``remove``, ``replace``, ``reverse``, ``rfind``, ``rindex``, ``rjust``, ``rpartition``, ``rsplit``, ``rstrip``, ``setdefault``, ``sort``, ``split``, ``splitlines``, ``startswith``, ``strip``, ``swapcase``, ``symmetric_difference``, ``symmetric_difference_update``, ``title``, ``translate``, ``union``, ``update``, ``upper``, ``values``, ``viewitems``, ``viewkeys``, ``viewvalues``, ``zfill``.
 
+Combining variables
+===================
+
+To merge variables that contain lists or dictionaries, you can use the following approaches.
+
+You can use the `set_fact` module to combine lists into a new `merged_list` variable as follows:
+
+.. code-block:: yaml
+
+    vars:
+      list1:
+      - apple
+      - banana
+      - fig
+
+      list2:
+      - peach
+      - plum
+      - pear
+    
+    tasks:
+    - name: Combine list1 and list2 into a merged_list var
+      ansible.builtin.set_fact:
+        merged_list: "{{ list1 + list2 }}"
+
+
+To merge dictionaries use the ``combine`` filter, for example:
+
+.. code-block:: yaml
+
+    vars:
+      dict1:
+        name: Leeroy Jenkins
+        age: 25
+        occupation: Astronaut
+
+      dict2:
+        location: Galway
+        country: Ireland
+        postcode: H71 1234
+
+    tasks:
+    - name: Combine dict1 and dict2 into a merged_dict var
+      ansible.builtin.set_fact:
+        merged_dict: "{{ dict1 | ansible.builtin.combine(dict2) }}"
+
+For more details, see :ansplugin:`ansible.builtin.combine#filter` .
+
+
+To merge variables that match the given prefixes, suffixes, or regular expressions, you can use the ``community.general.merge_variables`` lookup, for example:
+
+.. code-block:: yaml
+
+    merged_variable: "{{ lookup('community.general.merge_variables', '__my_pattern', pattern_type='suffix') }}"
+
+For more details and example usage, refer to the `community.general.merge_variables lookup documentation <https://docs.ansible.com/ansible/latest/collections/community/general/merge_variables_lookup.html>`_.
+
 .. _registered_variables:
 
 Registering variables
@@ -506,64 +563,6 @@ Variables set in one role are available to later roles. You can set variables in
           In this example, variables defined in 'common_settings' are available to 'something' and 'something_else' tasks, but tasks in 'something' have foo set at 12, even if 'common_settings' sets foo to 20.
 
 Instead of worrying about variable precedence, we encourage you to think about how easily or how often you want to override a variable when deciding where to set it. If you are not sure what other variables are defined, and you need a particular value, use ``--extra-vars`` (``-e``) to override all other variables.
-
-Combining variables
-===================
-
-To merge variables that contain lists or dictionaries, you can use the following approaches.
-
-You can use the `set_fact` module to combine lists into a new `merged_list` variable as follows:
-
-.. code-block:: yaml
-
-    vars:
-      list1:
-      - apple
-      - banana
-      - fig
-
-      list2:
-      - peach
-      - plum
-      - pear
-    
-    tasks:
-    - name: Combine list1 and list2 into a merged_list var
-      ansible.builtin.set_fact:
-        merged_list: "{{ list1 + list2 }}"
-
-
-To merge dictionaries use the ``combine`` filter, for example:
-
-.. code-block:: yaml
-
-    vars:
-      dict1:
-        name: Leeroy Jenkins
-        age: 25
-        occupation: Astronaut
-
-      dict2:
-        location: Galway
-        country: Ireland
-        postcode: H71 1234
-
-    tasks:
-    - name: Combine dict1 and dict2 into a merged_dict var
-      ansible.builtin.set_fact:
-        merged_dict: "{{ dict1 | ansible.builtin.combine(dict2) }}"
-
-For more details, see :ansplugin:`ansible.builtin.combine#filter` .
-
-
-To merge variables that match the given prefixes, suffixes, or regular expressions, you can use the ``community.general.merge_variables`` lookup, for example:
-
-.. code-block:: yaml
-
-    merged_variable: "{{ lookup('community.general.merge_variables', '__my_pattern', pattern_type='suffix') }}"
-
-For more details and example usage, refer to the `community.general.merge_variables lookup documentation <https://docs.ansible.com/ansible/latest/collections/community/general/merge_variables_lookup.html>`_.
-
 
 Using advanced variable syntax
 ==============================

--- a/docs/docsite/rst/playbook_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_variables.rst
@@ -507,6 +507,38 @@ Variables set in one role are available to later roles. You can set variables in
 
 Instead of worrying about variable precedence, we encourage you to think about how easily or how often you want to override a variable when deciding where to set it. If you are not sure what other variables are defined, and you need a particular value, use ``--extra-vars`` (``-e``) to override all other variables.
 
+Combining variables
+===================
+
+If you need to combine variables from different groups or hosts you can use the following approaches.
+
+To merge lists, use:
+
+.. code-block:: yaml
+
+    merged_list: '{{ list1 + list2 }}'
+
+
+To merge dictionaries use ``combine`` filter. For example:
+
+.. code-block:: yaml
+
+    merged_dict: "{{ dict1 | ansible.builtin.combine(dict2) }}"
+
+For more details, see :ansplugin:`ansible.builtin.combine#filter` .
+
+
+To merge variables that match the given prefixes, suffixes, or regular expressions use ``merge_variables`` lookup. For example:
+
+.. code-block:: yaml
+
+    merged_variable: "{{ lookup('community.general.merge_variables', '__my_pattern', pattern_type='suffix') }}"
+
+For more details, see `merge_variables lookup` .
+
+.. _merge_variables lookup: https://docs.ansible.com/ansible/latest/collections/community/general/merge_variables_lookup.html
+
+
 Using advanced variable syntax
 ==============================
 


### PR DESCRIPTION
I added a new section on combining variables as @oraNod advised in issue #80 .
I had some trouble adding references to these pages:
https://docs.ansible.com/ansible/latest/collections/ansible/builtin/combine_filter.html (line 528)
https://docs.ansible.com/ansible/latest/collections/community/general/merge_variables_lookup.html (line 539)