### PR TITLE
Fix typos in style guide (#1368) [stable-2.15]

### DIFF
--- a/docs/docsite/rst/dev_guide/style_guide/index.rst
+++ b/docs/docsite/rst/dev_guide/style_guide/index.rst
@@ -183,7 +183,7 @@ Long pages, or pages with multiple levels of headers, can also include a local T
 
 .. note::
 
-	Avoid raw URLs. RST and sphinx allow ::code:`https://my.example.com`, but this is unhelpful for those using screen readers. ``:ref:`` links automatically pick up the header from the anchor, but for external links, always use the ::code:`link title <link-url>`_` format.
+	Avoid raw URLs. RST and sphinx allow :code:`https://my.example.com`, but this is unhelpful for those using screen readers. ``:ref:`` links automatically pick up the header from the anchor, but for external links, always use the :code:`\`link title <link-url>\`_` format.
 
 .. _adding_anchors_rst:
 


### PR DESCRIPTION
* doc: fix external link typo in style guide

* doc: remove extra colons from style guide

(cherry picked from commit 186be843998a0d3436671bff7e1867edaefc5c0f)