### PR TITLE
Update playbooks_reuse_roles.rst

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
@@ -714,7 +714,7 @@ Sharing roles: Ansible Galaxy
 
 The client ``ansible-galaxy`` is included in Ansible. The Galaxy client allows you to download roles from Ansible Galaxy and provides an excellent default framework for creating your own roles.
 
-Read the `Ansible Galaxy documentation <https://galaxy.ansible.com/docs/>`_ page for more information. A page that refers back to this one frequently is the Galaxy Roles document which explains the required metadata your role needs for use in Galaxy <https://galaxy.ansible.com/docs/contributing/creating_role.html>.
+Read the `Ansible Galaxy documentation <https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/>`_ page for more information.
 
 .. seealso::
 


### PR DESCRIPTION
Fixes  https://github.com/ansible/ansible-documentation/issues/1369

Updated the link for the Ansible Galaxy documentation to reflect the  link to galaxy-ng documentation.

Decided to remove the line completely ('A page that refers back to this one frequently is the...' ) which referred to a documentation page that no longer exists, as it seemed superfluous and slightly confusing.