### PR TITLE
Update release table for 2.17

### DIFF
--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -155,14 +155,14 @@ Dates listed indicate the start date of the maintenance cycle.
      - End Of Life
      - Control Node Python
      - Target Python / PowerShell
-   * - 2.17
+   * - `2.17`_
      - | GA: 20 May 2024
        | Critical: 04 Nov 2024
        | Security: 19 May 2025
      - Nov 2025
      - | Python 3.10 - 3.12
      - | Python 3.7 - 3.12
-       | PowerShell TBD
+       | PowerShell 3 - 5.1
    * - `2.16`_
      - | GA: 06 Nov 2023
        | Critical: 20 May 2024
@@ -317,6 +317,7 @@ Dates listed indicate the start date of the maintenance cycle.
 .. _2.14: https://github.com/ansible/ansible/blob/stable-2.14/changelogs/CHANGELOG-v2.14.rst
 .. _2.15: https://github.com/ansible/ansible/blob/stable-2.15/changelogs/CHANGELOG-v2.15.rst
 .. _2.16: https://github.com/ansible/ansible/blob/stable-2.16/changelogs/CHANGELOG-v2.16.rst
+.. _2.17: https://github.com/ansible/ansible/blob/stable-2.17/changelogs/CHANGELOG-v2.17.rst
 
 
 


### PR DESCRIPTION
Part of https://github.com/ansible/ansible-documentation/issues/1249

Can be merged and then backport to 2.17 only.