### PR TITLE
Remove depreciated platforms reference

### DIFF
--- a/docs/docsite/rst/galaxy/user_guide.rst
+++ b/docs/docsite/rst/galaxy/user_guide.rst
@@ -347,16 +347,6 @@ The following shows an example ``meta/main.yml`` file with dependent roles:
       company: "Midwestern Mac, LLC"
       license: "license (BSD, MIT)"
       min_ansible_version: 2.4
-      platforms:
-      - name: EL
-        versions:
-        - all
-      - name: Debian
-        versions:
-        - all
-      - name: Ubuntu
-        versions:
-        - all
       galaxy_tags:
         - web
         - system


### PR DESCRIPTION
Assuming I understand this correctly, per https://github.com/ansible/ansible/issues/82453, the platforms api is no longer in use. This meta information example is inaccurate on latest ansible versions and results in an ` ERROR! 'platforms' is not a valid attribute for a RoleMetadata #1 ` error. 

To rectify this, I removed the problematic lines.