### PR TITLE
[stable-2.17] set correct version for 2.17 release

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -44,7 +44,7 @@ assert applied_tags_count == 1, (
 
 VERSION = (
      # Controls branch version for core releases
-    'devel' if tags.has('core_lang') or tags.has('core') else
+    '2.17' if tags.has('core_lang') or tags.has('core') else
     # Controls branch version for Ansible package releases
     'devel' if tags.has('ansible') or tags.has('all')
     else '<UNKNOWN>'


### PR DESCRIPTION
Part of #1249 

This PR is for 2.17 branch only and cannot be a backport.

It can be merged as soon as approved.