### PR TITLE
update version switcher to support 2.17

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -239,7 +239,7 @@ html_context = {
     'current_version': version,
     'latest_version': (
         'devel' if tags.has('all') else
-        '2.16' if tags.has('core_lang') or tags.has('core') else
+        '2.17' if tags.has('core_lang') or tags.has('core') else
         '9' if tags.has('ansible')
         else '<UNKNOWN>'
     ),
@@ -247,7 +247,7 @@ html_context = {
     'available_versions': (
         ('devel',) if tags.has('all') else
         ('2.15_ja', '2.14_ja', '2.13_ja',) if tags.has('core_lang') else
-        ('2.16', '2.15', '2.14', 'devel',) if tags.has('core') else
+        ('2.17', '2.16', '2.15', 'devel',) if tags.has('core') else
         ('latest', '2.9', 'devel') if tags.has('ansible')
         else '<UNKNOWN>'
     ),


### PR DESCRIPTION
Part of #1249

Updates sections of conf.py to support 2.17 in the version switcher logic

DO NOT MERGE until release happens.