### PR TITLE
Revert "[2.15] update version switcher to suppor 2.17 (#1464)"

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -239,7 +239,7 @@ html_context = {
     'current_version': version,
     'latest_version': (
         'devel' if tags.has('all') else
-        '2.17' if tags.has('core_lang') or tags.has('core') else
+        '2.16' if tags.has('core_lang') or tags.has('core') else
         '2.10' if tags.has('2.10') else
         '8' if tags.has('ansible')
         else '<UNKNOWN>'
@@ -248,7 +248,7 @@ html_context = {
     'available_versions': (
         ('devel',) if tags.has('all') else
         ('2.15_ja', '2.14_ja', '2.13_ja',) if tags.has('core_lang') else
-        ('2.17', '2.16', '2.15', 'devel',) if tags.has('core') else
+        ('2.16', '2.15', '2.14', 'devel',) if tags.has('core') else
         ('latest', '2.9', '2.9_ja', '2.8', 'devel') if tags.has('2.10') else
         ('latest', '2.9', 'devel') if tags.has('ansible')
         else '<UNKNOWN>'


### PR DESCRIPTION
Reverts ansible/ansible-documentation#1487 - somehow it's wrong and marking the release as EOL'd when published to test.