### PR TITLE
revert mistaken EOL on 2.15 docs

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -227,7 +227,7 @@ html_theme_options = {
 html_context = {
     'display_github': 'True',
     'show_sphinx': False,
-    'is_eol': True,
+    'is_eol': False,
     'github_user': 'ansible',
     'github_repo': 'ansible-documentation',
     'github_version': 'devel',


### PR DESCRIPTION
Incorrectly EOL'd by https://github.com/ansible/ansible-documentation/pull/968.

Looks like we need more complex logic there if we want to EOL package docs so they don't EOL the underlying core docs.