### PR TITLE
Update collection_checklist.md links to point to new location

### DIFF
--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -529,7 +529,7 @@ To be included in the `ansible` package, collections must meet the following cri
 * :ref:`Development conventions <module_dev_conventions>`.
 * `Collection requirements <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html>`_ (this document).
 
-  * The `Collection Inclusion Criteria Checklist <https://github.com/ansible-collections/overview/blob/main/collection_checklist.md>`_ covers most of the criteria from this document.
+  * The `Collection Inclusion Criteria Checklist <https://github.com/ansible-collections/ansible-inclusion/blob/main/collection_checklist.md>`_ covers most of the criteria from this document.
 * :ref:`Ansible documentation format <module_documenting>` and the :ref:`style guide <style-guide>`.
 * To pass the Ansible :ref:`sanity tests <testing-sanity>`.
 * To have :ref:`unit <unit-tests>`_and / or :ref:`integration tests <integration-tests>` according to the corresponding sections of this document.

--- a/docs/docsite/rst/community/steering/community_steering_committee.rst
+++ b/docs/docsite/rst/community/steering/community_steering_committee.rst
@@ -98,7 +98,7 @@ Depending on a topic you want to discuss with the Community and the Committee, a
 
 * :ref:`code_of_conduct`.
 * :ref:`collections_requirements`.
-* `Ansible Collection Inclusion Checklist <https://github.com/ansible-collections/overview/blob/main/collection_checklist.md>`_.
+* `Ansible Collection Inclusion Checklist <https://github.com/ansible-collections/ansible-inclusion/blob/main/collection_checklist.md>`_.
 
 .. _community_topics_workflow:
 
@@ -146,7 +146,7 @@ When reviewing community collection `inclusion requests <https://github.com/ansi
 
   The Steering Committee can reject a collection inclusion request or exclude a collection from the Ansible package even when the collection satisfies the requirements if the Steering Committee agrees that presence of the collection will significantly deteriorate the Ansible package user experience or the package build process. In case of rejection/removal, the collection maintainers receive comprehensive feedback from the Committee explaining the reasons of starting the process. In case the reasons are fixable, the feedback will contain information what the maintainers need to change.
 
-#. A Committee member who conducts the inclusion review copies the `Ansible community collection checklist <https://github.com/ansible-collections/overview/blob/main/collection_checklist.md>`_ into a corresponding `discussion <https://github.com/ansible-collections/ansible-inclusion/discussions>`_.
+#. A Committee member who conducts the inclusion review copies the `Ansible community collection checklist <https://github.com/ansible-collections/ansible-inclusion/blob/main/collection_checklist.md>`_ into a corresponding `discussion <https://github.com/ansible-collections/ansible-inclusion/discussions>`_.
 
 #. In the course of the review, the Committee member marks items as completed or leaves a comment saying whether the reviewer expects an issue to be addressed or whether it is optional (for example, it could be **MUST FIX:** <what> or **SHOULD FIX:** <what> under an item).
 


### PR DESCRIPTION
Update collection_checklist.md links to point to new location

Relates to https://forum.ansible.com/t/reduce-fragmentation-moving-stuff-to-the-forum-and-archiving-repos/5141/2

I don't think it's worth distracting anyone to review this, so I'll merge it if CI is green.