### PR TITLE
Porting Guide 2.17.0 adding assert details

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.17.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.17.rst
@@ -19,7 +19,30 @@ This document is part of a collection on porting. The complete list of porting g
 Playbook
 ========
 
-No notable changes
+* Conditionals - due to mitigation of security issue CVE-2023-5764 in ansible-core 2.16.1,
+  conditional expressions with embedded template blocks can fail with the message
+  "``Conditional is marked as unsafe, and cannot be evaluated.``" when an embedded template
+  consults data from untrusted sources like module results or vars marked ``!unsafe``.
+  Conditionals with embedded templates can be a source of malicious template injection when
+  referencing untrusted data, and can nearly always be rewritten without embedded
+  templates. Playbook task conditional keywords such as ``when`` and ``until`` have long
+  displayed warnings discouraging use of embedded templates in conditionals; this warning
+  has been expanded to non-task conditionals as well, such as the ``assert`` action.
+
+  .. code-block:: yaml
+
+     - name: task with a module result (always untrusted by Ansible)
+       shell: echo "hi mom"
+       register: untrusted_result
+
+     # don't do it this way...
+     # - name: insecure conditional with embedded template consulting untrusted data
+     #   assert:
+     #     that: '"hi mom" is in {{ untrusted_result.stdout }}'
+
+     - name: securely access untrusted values directly as Jinja variables instead
+       assert:
+         that: '"hi mom" is in untrusted_result.stdout'
 
 
 Command Line


### PR DESCRIPTION
resolves #1491 This change brings details into the 2.17.0 porting guide that were mentioned in the changelog.

Once this is approved and merged, I'll create a corresponding PR for the build-data repo.