### PR TITLE
fix minor typo in Makefile

### DIFF
--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -89,14 +89,14 @@ gettext: gettext_structure gettext_generate_rst
 
 generate-po:
 ifeq ($(LANGUAGES),)
-	@echo 'LANGUAGES is not defined. It is mandatory. LANGUAGES should be a comma separated list of languages to support. (Exampe: fr,es)'
+	@echo 'LANGUAGES is not defined. It is mandatory. LANGUAGES should be a comma separated list of languages to support. (Example: fr,es)'
 else
 	(cd docs/docsite/; sphinx-intl update -w 0 -d rst/locales -p "$(POTDIR)" -l $(LANGUAGES))
 endif
 
 needs-translation:
 ifeq ($(LANGUAGES),)
-	@echo 'LANGUAGES is not defined. It is mandatory. LANGUAGES should be a comma separated list of languages to support. (Exampe: fr,es)'
+	@echo 'LANGUAGES is not defined. It is mandatory. LANGUAGES should be a comma separated list of languages to support. (Example: fr,es)'
 else
 	(cd docs/docsite/; sphinx-intl stat -d rst/locales -l $(LANGUAGES) | grep -E ' [1-9][0-9]* (fuzzy|untranslated)' | sort)
 endif


### PR DESCRIPTION
The codespell version bump in https://github.com/ansible/ansible-documentation/pull/1527 picks up a typo in the Makefile which causes ci to fail. This PR fixes the typo.