### PR TITLE
docs/docsite/rst/dev_guide/developing_program_flow_modules.rst: avoid using aliases

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
@@ -660,7 +660,7 @@ This section will discuss the behavioral attributes for arguments:
 
 :aliases:
 
-  ``aliases`` accepts a list of alternative argument names for the argument, such as the case where the argument is ``name`` but the module accepts ``aliases=['pkg']`` to allow ``pkg`` to be interchangeably with ``name``. Generally avoid using aliases. Consider using them temporarily in exceptional cases like typos or inappropriate words in the original argument name with deprecation and subsequent removal of the original one using the ``deprecated_aliases`` attribute.
+  ``aliases`` accepts a list of alternative argument names for the argument, such as the case where the argument is ``name`` but the module accepts ``aliases=['pkg']`` to allow ``pkg`` to be interchangeably with ``name``. Generally avoid using aliases. Consider using them temporarily in exceptional cases such as typos or inappropriate words in the original argument name with deprecation and subsequent removal of the original one using the ``deprecated_aliases`` attribute.
 
 :options:
 

--- a/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
@@ -660,7 +660,7 @@ This section will discuss the behavioral attributes for arguments:
 
 :aliases:
 
-  ``aliases`` accepts a list of alternative argument names for the argument, such as the case where the argument is ``name`` but the module accepts ``aliases=['pkg']`` to allow ``pkg`` to be interchangeably with ``name``
+  ``aliases`` accepts a list of alternative argument names for the argument, such as the case where the argument is ``name`` but the module accepts ``aliases=['pkg']`` to allow ``pkg`` to be interchangeably with ``name``. Generally avoid using aliases. Consider using them temporarily in exceptional cases like typos or inappropriate words in the original argument name with deprecation and subsequent removal of the original one using the ``deprecated_aliases`` attribute.
 
 :options:
 

--- a/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
@@ -660,7 +660,7 @@ This section will discuss the behavioral attributes for arguments:
 
 :aliases:
 
-  ``aliases`` accepts a list of alternative argument names for the argument, such as the case where the argument is ``name`` but the module accepts ``aliases=['pkg']`` to allow ``pkg`` to be interchangeably with ``name``. Generally avoid using aliases. Consider using them temporarily in exceptional cases such as typos or inappropriate words in the original argument name with deprecation and subsequent removal of the original one using the ``deprecated_aliases`` attribute.
+  ``aliases`` accepts a list of alternative argument names for the argument, such as the case where the argument is ``name`` but the module accepts ``aliases=['pkg']`` to allow ``pkg`` to be interchangeably with ``name``. Use of aliases can make module interfaces confusing, so we recommend adding them only when necessary. If you are updating argument names to fix a typo or improve the interface, consider moving the old names to ``deprecated_aliases`` rather than keeping them around indefinitely.
 
 :options:
 


### PR DESCRIPTION
As we're seeing newly developed collections submitted for inclusion contains multiple aliases, this PR adds a recommendation to avoid using them generally.

Justification:
- Think well and choose the best name for the interface
- Having many aliases can cause confusion among users