### PR TITLE
Update release table for Ansible 10 and 9

### DIFF
--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -81,8 +81,9 @@ This table links to the changelogs for each major Ansible release. These changel
 ==================================      ==============================================      =========================
 Ansible Community Package Release       Status                                              Core version dependency
 ==================================      ==============================================      =========================
-10.0.0                                  In development (unreleased)                         2.17
-`9.x Changelogs`_                       Current                                             2.16
+11.0.0                                  In development (unreleased)                         2.18
+`10.x Changelogs`_                      Current                                             2.17
+`9.x Changelogs`_                       Minor/patch releases (EOL Nov 2024)                 2.16
 `8.x Changelogs`_                       Unmaintained (end of life)                          2.15
 `7.x Changelogs`_                       Unmaintained (end of life)                          2.14
 `6.x Changelogs`_                       Unmaintained (end of life)                          2.13
@@ -92,6 +93,7 @@ Ansible Community Package Release       Status                                  
 `2.10 Changelogs`_                      Unmaintained (end of life)                          2.10
 ==================================      ==============================================      =========================
 
+.. _10.x Changelogs: https://github.com/ansible-community/ansible-build-data/blob/main/10/CHANGELOG-v10.md
 .. _9.x Changelogs: https://github.com/ansible-community/ansible-build-data/blob/main/9/CHANGELOG-v9.rst
 .. _8.x Changelogs: https://github.com/ansible-community/ansible-build-data/blob/main/8/CHANGELOG-v8.rst
 .. _7.x Changelogs: https://github.com/ansible-community/ansible-build-data/blob/main/7/CHANGELOG-v7.rst


### PR DESCRIPTION
Adds Ansible 11 as in development, and changes Ansible 10 status to current, and ansible 9 to minor and patches only.

Part of #1250 