### PR TITLE
remove mailchimp subscribe from docs

### DIFF
--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -224,7 +224,7 @@ The Bullhorn
 ============
 
 **The Bullhorn** is our newsletter for the Ansible contributor community. You can get Bullhorn updates
-from the :ref:`ansible_forum` or `subscribe <https://eepurl.com/gZmiEP>`_ to receive it.
+from the :ref:`ansible_forum`.
 
 If you have any questions or content you would like to share, you are welcome to chat with us
 in the `Ansible Social room on Matrix<https://matrix.to/#/#social:ansible.com>, and mention


### PR DESCRIPTION
We're moving away from using mailchimp for the Bullhorn so remove from the docs.