### PR TITLE
Fix up PowerShell and Windows support lifecycle

### DIFF
--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -146,7 +146,7 @@ Support for Python 2.7 is included in ``ansible-core`` version 2.16 and earlier.
 ``ansible-core`` target node PowerShell and Windows support
 -----------------------------------------------------------
 
-``ansible-core`` on Windows supports the baseline version of PowerShell that each Windows version ships with. For example, Windows Server 2016 shipped with PowerShell 5.1 so we will support PowerShell 5.1 for the life of Windows Server 2016 support. Support for each Windows version is determined by the Windows lifecycle policy and when each version reaches the extended end date. For example Windows Server 2012 and 2012 R2 extended end date was for October 10th 2023 while Windows Server 2016 is January 12th 2027. Windows support does not align with the 3 year Extended Security Updates (``ESU``) support from Microsoft which is a paid support option for products that are past the normal end of support date from Microsoft.
+``ansible-core`` on Windows supports the baseline version of PowerShell that each Windows version ships with. For example, Windows Server 2016 shipped with PowerShell 5.1 so Ansible will support PowerShell 5.1 for the life of Windows Server 2016 support. Support for each Windows version is determined by the Windows lifecycle policy and when each version reaches the extended end date. For example Windows Server 2012 and 2012 R2 extended end date was for October 10th 2023 while Windows Server 2016 is January 12th 2027. Windows support does not align with the 3 year Extended Security Updates (``ESU``) support from Microsoft which is a paid support option for products that are past the normal end of support date from Microsoft.
 
 .. _ansible_core_support_matrix:
 

--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -54,9 +54,9 @@ The Ansible community team typically releases two major versions of the communit
 
 Starting with version 2.10, the Ansible community team guarantees maintenance for only one major community package release at a time. For example, when Ansible 4.0.0 gets released, the team will stop making new 3.x releases. Community members may maintain older versions if desired.
 
-.. note:: 
-    
-   Each Ansible EOL version may issue one final maintenance release at or shortly after the first release of the next version. When this happens, the final maintenance release is EOL at the date it releases. 
+.. note::
+
+   Each Ansible EOL version may issue one final maintenance release at or shortly after the first release of the next version. When this happens, the final maintenance release is EOL at the date it releases.
 
 
 .. note::
@@ -141,6 +141,13 @@ Starting with ``ansible-core`` version 2.16, each release includes target node s
 
 Support for Python 2.7 is included in ``ansible-core`` version 2.16 and earlier.
 
+.. _target_node_windows_support:
+
+``ansible-core`` target node PowerShell and Windows support
+-----------------------------------------------------------
+
+``ansible-core`` on Windows supports the baseline version of PowerShell that each Windows version ships with. For example, Windows Server 2016 shipped with PowerShell 5.1 so we will support PowerShell 5.1 for the life of Windows Server 2016 support. Support for each Windows version is determined by the Windows lifecycle policy and when each version reaches the extended end date. For example Windows Server 2012 and 2012 R2 extended end date was for October 10th 2023 while Windows Server 2016 is January 12th 2027. Windows support does not align with the 3 year Extended Security Updates (``ESU``) support from Microsoft which is a paid support option for products that are past the normal end of support date from Microsoft.
+
 .. _ansible_core_support_matrix:
 
 ``ansible-core`` support matrix
@@ -151,7 +158,7 @@ Dates listed indicate the start date of the maintenance cycle.
 
 .. list-table::
    :header-rows: 1
-    
+
    * - Version
      - Support
      - End Of Life
@@ -164,7 +171,7 @@ Dates listed indicate the start date of the maintenance cycle.
      - Nov 2025
      - | Python 3.10 - 3.12
      - | Python 3.7 - 3.12
-       | PowerShell 3 - 5.1
+       | PowerShell 5.1
    * - `2.16`_
      - | GA: 06 Nov 2023
        | Critical: 20 May 2024
@@ -173,7 +180,7 @@ Dates listed indicate the start date of the maintenance cycle.
      - | Python 3.10 - 3.12
      - | Python 2.7
        | Python 3.6 - 3.12
-       | Powershell 3 - 5.1
+       | Powershell 5.1
    * - `2.15`_
      - | GA: 22 May 2023
        | Critical: 06 Nov 2023
@@ -253,7 +260,7 @@ Dates listed indicate the start date of the maintenance cycle.
 ..      - May 2026
 ..      - | Python 3.11 - 3.13
 ..      - | Python 3.8 - 3.13
-..        | PowerShell TBD
+..        | PowerShell 5.1
 ..    * - 2.19
 ..      - May 2025
 ..      - Nov 2025
@@ -261,7 +268,7 @@ Dates listed indicate the start date of the maintenance cycle.
 ..      - Nov 2026
 ..      - | Python 3.11 - 3.13
 ..      - | Python 3.8 - 3.13
-..        | PowerShell TBD
+..        | PowerShell 5.1
 ..    * - 2.20
 ..      - Nov 2025
 ..      - May 2026
@@ -269,7 +276,7 @@ Dates listed indicate the start date of the maintenance cycle.
 ..      - May 2027
 ..      - | Python 3.12 - 3.14
 ..      - | Python 3.9 - 3.14
-..        | PowerShell TBD
+..        | PowerShell 5.1
 ..    * - 2.21
 ..      - May 2026
 ..      - Nov 2026
@@ -277,7 +284,7 @@ Dates listed indicate the start date of the maintenance cycle.
 ..      - Nov 2027
 ..      - | Python 3.12 - 3.14
 ..      - | Python 3.9 - 3.14
-..        | PowerShell TBD
+..        | PowerShell 5.1
 ..    * - 2.22
 ..      - Nov 2026
 ..      - May 2027
@@ -285,7 +292,7 @@ Dates listed indicate the start date of the maintenance cycle.
 ..      - May 2028
 ..      - | Python 3.13 - 3.15
 ..      - | Python 3.9 - 3.15
-..        | PowerShell TBD
+..        | PowerShell 5.1
 ..    * - 2.23
 ..      - May 2027
 ..      - Nov 2027
@@ -293,7 +300,7 @@ Dates listed indicate the start date of the maintenance cycle.
 ..      - Nov 2028
 ..      - | Python 3.13 - 3.15
 ..      - | Python 3.10 - 3.15
-..        | PowerShell TBD
+..        | PowerShell 5.1
 ..    * - 2.24
 ..      - Nov 2027
 ..      - May 2028
@@ -301,7 +308,7 @@ Dates listed indicate the start date of the maintenance cycle.
 ..      - May 2029
 ..      - | Python 3.14 - 3.16
 ..      - | Python 3.11 - 3.16
-..        | PowerShell TBD
+..        | PowerShell 5.1
 ..    * - 2.25
 ..      - May 2028
 ..      - Nov 2028
@@ -309,7 +316,7 @@ Dates listed indicate the start date of the maintenance cycle.
 ..      - Nov 2029
 ..      - | Python 3.14 - 3.16
 ..      - | Python 3.11 - 3.16
-..        | PowerShell TBD
+..        | PowerShell 5.1
 
 
 .. _2.9: https://github.com/ansible/ansible/blob/stable-2.9/changelogs/CHANGELOG-v2.9.rst


### PR DESCRIPTION
Looks like I didn't update this page correctly as it still showed we supported PowerShell 3.0 on current Ansible versions. This updates the support matrix to reflect what we actually support and further clarify the Windows support lifecycle with Ansible.