### PR TITLE
clarify how to verify collection-level docs

### DIFF
--- a/docs/docsite/rst/community/documentation_contributions.rst
+++ b/docs/docsite/rst/community/documentation_contributions.rst
@@ -74,7 +74,7 @@ A great documentation GitHub issue or PR includes:
 Verifying your documentation PR
 ================================
 
-If you make multiple changes to the documentation, or add more than a line to it, before you open a pull request, please:
+If you make multiple changes to the Ansible documentation, or add more than a line to it, before you open a pull request, please:
 
 #. Check that your text follows our :ref:`style_guide`.
 #. Test your changes for rST errors.
@@ -82,7 +82,8 @@ If you make multiple changes to the documentation, or add more than a line to it
 
 .. note::
 
-	The following sections apply to documentation sourced from the ``ansible/ansible-documentation`` repo and does not apply to documentation from an individual collection. See the collection README file for details on how to contribute to that collection.
+	The following sections apply to documentation sourced from the ``ansible/ansible-documentation`` repo and does not apply to documentation from an individual collection. See the collection README file for details on how to contribute to that collection. Collection developers can also lint their collection-level documentation. See :ref:`verify_collection_docs`   for details.
+   
 
 Setting up your environment to build documentation locally
 ----------------------------------------------------------

--- a/docs/docsite/rst/community/documentation_contributions.rst
+++ b/docs/docsite/rst/community/documentation_contributions.rst
@@ -82,7 +82,7 @@ If you make multiple changes to the Ansible documentation, or add more than a li
 
 .. note::
 
-	The following sections apply to documentation sourced from the ``ansible/ansible-documentation`` repo and does not apply to documentation from an individual collection. See the collection README file for details on how to contribute to that collection. Collection developers can also lint their collection-level documentation. See :ref:`verify_collection_docs`   for details.
+	The following sections apply to documentation sourced from the ``ansible/ansible-documentation`` repo and does not apply to documentation from an individual collection. See the collection README file for details on how to contribute to that collection. Collection developers can also lint their collection-level documentation. See :ref:`verify_collection_docs` for details.
    
 
 Setting up your environment to build documentation locally

--- a/docs/docsite/rst/dev_guide/developing_collections_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_documenting.rst
@@ -14,6 +14,16 @@ Documenting roles
 
 To document a role, you have to add a role argument spec by creating a file ``meta/argument_specs.yml`` in your role. See :ref:`role_argument_spec` for details. As an example, you can look at `the argument specs file <https://github.com/sensu/sensu-go-ansible/blob/master/roles/install/meta/argument_specs.yml>`_ of the :ansplugin:`sensu.sensu_go.install role <sensu.sensu_go.install#role>` on GitHub.
 
+
+.. _verify_collection_docs:
+
+Verifying your collection documentation
+=======================================
+
+You can use ``antsibull-docs`` to lint your collection documentation.
+See `Linting collection documentation <https://ansible.readthedocs.io/projects/antsibull-docs/collection-docs/#linting-collection-docs>`_.
+for details.
+
 .. _build_collection_docsite:
 
 Build a docsite with antsibull-docs


### PR DESCRIPTION
Based on a matrix discussion - add some hints on where to find details on locally linting collection-level documentation.