### PR TITLE
Fix typo in communication.rst

### DIFF
--- a/.codespellignorelines
+++ b/.codespellignorelines
@@ -16,3 +16,4 @@ see the `Active Directory Certificate Services documentation <https://docs.micro
 # Following lines from the generated file docs/docsite/rst/reference_appendices/config.rst
 :Description: This setting changes the behaviour of mismatched host patterns, it allows you to force a fatal error, a warning or just ignore it.
     This setting changes the behaviour of mismatched host patterns, it allows you to force a fatal error, a warning or just ignore it.
+   /msg alis LIST #ansible* -min 5

--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -85,7 +85,7 @@ Our IRC channels may require you to register your IRC nickname. If you receive a
 
 .. code-block:: text
 
-   /msg alias LIST #ansible* -min 5
+   /msg alis LIST #ansible* -min 5
 
 as described in the `libera.chat docs <https://libera.chat/guides/findingchannels>`_.
 


### PR DESCRIPTION
Fix typo in
/msg alias
This should be
/msg alis
as described in the link https://libera.chat/guides/findingchannels