### PR TITLE
use the package version as the branch name

### DIFF
--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -159,7 +159,7 @@ jobs:
     - name: Set the production branch and url
       if: env.TARGET == 'production'
       env:
-        BRANCH_NAME: ${{ github.event.inputs.repository-branch }}
+        BRANCH_NAME: ${{ github.event.inputs.ansible-package-version }}
         PROD_URL: https://ansible.readthedocs.io/projects/ansible/en
       run: |
         echo "BRANCH=${BRANCH_NAME}" >> "${GITHUB_ENV}"


### PR DESCRIPTION
This change configures the publishing workflow to use the package version as the branch name in the destination repository. For example the branch name should be "10" for the Ansible 10 package. This ensures that the resulting url for the published docs uses the version and not the branch name.