### PR TITLE
dev pip-compile: switch devel branch pip-compile to 3.11

### DIFF
--- a/.github/workflows/pip-compile-dev.yml
+++ b/.github/workflows/pip-compile-dev.yml
@@ -6,12 +6,6 @@ name: "Refresh dev dependencies"
     - cron: "0 0 * * 0"
   workflow_dispatch:
     inputs:
-      base-branch:
-        required: false
-        type: string
-      pr-branch:
-        required: false
-        type: string
       reset-branch:
         type: boolean
         default: false
@@ -28,18 +22,53 @@ name: "Refresh dev dependencies"
 
 jobs:
   refresh:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - base-branch: devel
+            pr-branch: pip-compile/devel/dev
+            nox-args: >-
+              -e 'pip-compile-3.11(formatters)'
+              'pip-compile-3.11(typing)'
+              'pip-compile-3.11(static)'
+              'pip-compile-3.11(spelling)'
+              'pip-compile-3.11(tag)'
+          - base-branch: stable-2.17
+            pr-branch: pip-compile/stable-2.17/dev
+            nox-args: >-
+              -e 'pip-compile-3.10(formatters)'
+              'pip-compile-3.10(typing)'
+              'pip-compile-3.10(static)'
+              'pip-compile-3.10(spelling)'
+          - base-branch: stable-2.16
+            pr-branch: pip-compile/stable-2.16/dev
+            nox-args: >-
+              -e 'pip-compile-3.10(formatters)'
+              'pip-compile-3.10(typing)'
+              'pip-compile-3.10(static)'
+              'pip-compile-3.10(spelling)'
+          - base-branch: stable-2.15
+            pr-branch: pip-compile/stable-2.15/dev
+            nox-args: >-
+              -e 'pip-compile-3.10(formatters)'
+              'pip-compile-3.10(typing)'
+              'pip-compile-3.10(static)'
+              'pip-compile-3.10(spelling)'
+          - base-branch: stable-2.14
+            pr-branch: pip-compile/stable-2.14/dev
+            nox-args: >-
+              -e 'pip-compile-3.10(formatters)'
+              'pip-compile-3.10(typing)'
+              'pip-compile-3.10(static)'
+              'pip-compile-3.10(spelling)'
     name: "Refresh dev dependencies"
     uses: ./.github/workflows/reusable-pip-compile.yml
     with:
       message: "ci: refresh dev dependencies"
-      base-branch: "${{ inputs.base-branch || 'devel' }}"
-      pr-branch: "${{ inputs.pr-branch || 'pip-compile/devel/dev' }}"
-      nox-args: >-
-        -e 'pip-compile-3.10(formatters)'
-        'pip-compile-3.10(typing)'
-        'pip-compile-3.10(static)'
-        'pip-compile-3.10(spelling)'
-        'pip-compile-3.10(tag)'
+      base-branch: "${{ matrix.base-branch }}"
+      pr-branch: "${{ matrix.pr-branch }}"
+      nox-args: "${{ matrix.nox-args }}"
       reset-branch: "${{ inputs.reset-branch || false }}"
-      labels: "${{ inputs.labels || 'backport-2.14,backport-2.15,backport-2.16,backport-2.17,tooling' }}"
+      labels: "${{ inputs.labels || 'no_backport,tooling' }}"
     secrets: inherit

--- a/.github/workflows/pip-compile-docs.yml
+++ b/.github/workflows/pip-compile-docs.yml
@@ -34,7 +34,7 @@ jobs:
       message: "ci: refresh docs build dependencies"
       base-branch: "${{ inputs.base-branch || 'devel' }}"
       pr-branch: "${{ inputs.pr-branch || 'pip-compile/devel/docs' }}"
-      nox-args: "-e 'pip-compile-3.10(requirements)' 'pip-compile-3.10(requirements-relaxed)'"
+      nox-args: "-e 'pip-compile-3.11(requirements)' 'pip-compile-3.11(requirements-relaxed)'"
       reset-branch: "${{ inputs.reset-branch || false }}"
       labels: "${{ inputs.labels || 'doc builds,no_backport' }}"
     secrets: inherit

--- a/.github/workflows/pip-compile-docs.yml
+++ b/.github/workflows/pip-compile-docs.yml
@@ -34,7 +34,10 @@ jobs:
       message: "ci: refresh docs build dependencies"
       base-branch: "${{ inputs.base-branch || 'devel' }}"
       pr-branch: "${{ inputs.pr-branch || 'pip-compile/devel/docs' }}"
-      nox-args: "-e 'pip-compile-3.11(requirements)' 'pip-compile-3.11(requirements-relaxed)'"
+      nox-args: >-
+        -e
+        'pip-compile-3.11(requirements)'
+        'pip-compile-3.11(requirements-relaxed)'
       reset-branch: "${{ inputs.reset-branch || false }}"
       labels: "${{ inputs.labels || 'doc builds,no_backport' }}"
     secrets: inherit

--- a/.github/workflows/reusable-pip-compile.yml
+++ b/.github/workflows/reusable-pip-compile.yml
@@ -88,6 +88,7 @@ jobs:
           base_branch: "${{ inputs.base-branch }}"
           pr_branch: "${{ inputs.pr-branch }}"
           message: "${{ inputs.message }}"
+          pr_title: "[${{ inputs.base-branch }}] ${{ inputs.message }}"
           changed_files: "${{ inputs.changed-files }}"
           labels: "${{ inputs.labels }}"
         run: |
@@ -105,7 +106,7 @@ jobs:
           then
             command=(gh pr create
               --base "${base_branch}"
-              --title "${message}"
+              --title "${pr_title}"
               --body ""
               --label dependency_update
             )

--- a/noxfile.py
+++ b/noxfile.py
@@ -88,7 +88,7 @@ requirements_files = list(
 )
 
 
-@nox.session(name="pip-compile", python=["3.10"])
+@nox.session(name="pip-compile", python=["3.11"])
 @nox.parametrize(["req"], requirements_files, requirements_files)
 def pip_compile(session: nox.Session, req: str):
     # .pip-tools.toml was introduced in v7


### PR DESCRIPTION
This adjusts the devel branch to use Python 3.11 to generate
dependencies with pip-compile. This also adjusts the pip-compile-dev
workflow to run separate jobs for the stable branches, which will still
use Python 3.10 for requirements files. It's not a very
DRY approach; Github Actions does not support loops.

Fixes: https://github.com/ansible/ansible-documentation/issues/1614
Fixes: https://github.com/ansible/ansible-documentation/issues/1450