### PR TITLE
Revert "Add example /usr/bin/env python as Python interpreter (#280)"

### DIFF
--- a/docs/docsite/rst/reference_appendices/interpreter_discovery.rst
+++ b/docs/docsite/rst/reference_appendices/interpreter_discovery.rst
@@ -49,5 +49,3 @@ auto_silent
 You can still set ``ansible_python_interpreter`` to a specific path at any
 variable level (for example, in host_vars, in vars files, in playbooks, and so on).
 Setting a specific path completely disables automatic interpreter discovery; Ansible always uses the path specified.
-
-.. seealso:: :ref:`python_3_support` for ``ansible_python_interpreter`` usage examples.

--- a/docs/docsite/rst/reference_appendices/python_3_support.rst
+++ b/docs/docsite/rst/reference_appendices/python_3_support.rst
@@ -1,5 +1,3 @@
-.. _python_3_support:
-
 ================
 Python 3 Support
 ================
@@ -69,12 +67,6 @@ Using Python 3 on the managed machines with commands and playbooks
 
     $ ansible localhost-py3 -m ping
     $ ansible-playbook sample-playbook.yml
-
-* To use the first Python found on ``PATH`` or if the Python interpreter path is not known in advance, you can use ``/usr/bin/env python`` such as:
-
-.. code-block:: shell
-
-    ansible_python_interpreter="/usr/bin/env python"
 
 
 Note that you can also use the `-e` command line option to manually


### PR DESCRIPTION
This reverts commit 07c50093a2a599d2a413b8c28872887e5f07995f.

This worked inadvertently and was corrected in https://github.com/ansible/ansible/commit/93b8b86067c57c4fe02fb829700f3ec436216fd7. I think this documentation is probably why so many people found this easter egg https://github.com/ansible/ansible/issues/83476.