### PR TITLE
fix Ansible architecture docs

### DIFF
--- a/docs/docsite/rst/dev_guide/overview_architecture.rst
+++ b/docs/docsite/rst/dev_guide/overview_architecture.rst
@@ -44,7 +44,6 @@ Here's what a plain text inventory file looks like:
 
 .. code-block:: text
 
-    ---
     [webservers]
     www1.example.com
     www2.example.com


### PR DESCRIPTION
I fixed example Inventory  ini format file contains '---' used in Yaml.
I may write ini format.