### PR TITLE
Integrate the `alls-green` action into the main GHA CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,3 +11,19 @@ on:
 jobs:
   nox:
     uses: ./.github/workflows/reusable-nox.yml
+
+  check:
+    if: always()
+
+    needs:
+      - nox
+
+    runs-on: Ubuntu-latest
+
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        allowed-failures: docs, linters
+        allowed-skips: non-voting-flaky-job
+        jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,4 @@ jobs:
     - name: Decide whether the needed jobs succeeded or failed
       uses: re-actors/alls-green@release/v1
       with:
-        allowed-failures: docs, linters
-        allowed-skips: non-voting-flaky-job
         jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     needs:
       - nox
 
-    runs-on: Ubuntu-latest
+    runs-on: ubuntu-latest
 
     steps:
     - name: Decide whether the needed jobs succeeded or failed


### PR DESCRIPTION
Resolves #1284.

Testing shows that this doesn't surfaces which part of  the nox matrix fails, but does fail the workflow when any of them do. 