### PR TITLE
Remove references to archived ansible/ansible-examples repository

### DIFF
--- a/docs/docsite/rst/playbook_guide/guide_rolling_upgrade.rst
+++ b/docs/docsite/rst/playbook_guide/guide_rolling_upgrade.rst
@@ -23,11 +23,6 @@ playbooks as a template: lamp_haproxy. This example uses a lot of Ansible featur
 and group variables, and it also comes with an orchestration playbook that can do zero-downtime
 rolling upgrades of the web application stack.
 
-.. note::
-
-   `Click here for the latest playbooks for this example
-   <https://github.com/ansible/ansible-examples/tree/master/lamp_haproxy>`_.
-
 The playbooks deploy Apache, PHP, MySQL, Nagios, and HAProxy to a CentOS-based set of servers.
 
 We're not going to cover how to run these playbooks here. Read the included README in the GitHub project along with the
@@ -312,8 +307,6 @@ This should give you a good idea of how to structure a multi-tier application wi
 
 .. seealso::
 
-   `lamp_haproxy example <https://github.com/ansible/ansible-examples/tree/master/lamp_haproxy>`_
-       The lamp_haproxy example discussed here.
    :ref:`working_with_playbooks`
        An introduction to playbooks
    :ref:`playbooks_reuse_roles`

--- a/docs/docsite/rst/playbook_guide/playbooks.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks.rst
@@ -14,9 +14,6 @@ At a more advanced level, they can sequence multi-tier rollouts involving rollin
 Playbooks are designed to be human-readable and are developed in a basic text language.
 There are multiple ways to organize playbooks and the files they include, and we'll offer up some suggestions on that and making the most out of Ansible.
 
-You should look at `Example Playbooks <https://github.com/ansible/ansible-examples>`_ while reading along with the playbook documentation.
-These illustrate best practices as well as how to put many of the various concepts together.
-
 .. toctree::
    :maxdepth: 2
 

--- a/docs/docsite/rst/playbook_guide/playbooks_delegation.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_delegation.rst
@@ -177,8 +177,6 @@ use the default remote connection type:
        An introduction to playbooks
    :ref:`playbooks_strategies`
        More ways to control how and where Ansible executes
-   `Ansible Examples on GitHub <https://github.com/ansible/ansible-examples>`_
-       Many examples of full-stack deployments
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the Google group!
    :ref:`communication_irc`

--- a/docs/docsite/rst/playbook_guide/playbooks_intro.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_intro.rst
@@ -5,7 +5,7 @@
 Ansible playbooks
 *****************
 
-Ansible Playbooks offer a repeatable, reusable, simple configuration management and multi-machine deployment system, one that is well suited to deploying complex applications. If you need to execute a task with Ansible more than once, write a playbook and put it under source control. Then you can use the playbook to push out new configuration or confirm the configuration of remote systems. The playbooks in the `ansible-examples repository <https://github.com/ansible/ansible-examples>`_ illustrate many useful techniques. You may want to look at these in another tab as you read the documentation.
+Ansible Playbooks offer a repeatable, reusable, simple configuration management and multi-machine deployment system, one that is well suited to deploying complex applications. If you need to execute a task with Ansible more than once, write a playbook and put it under source control. Then you can use the playbook to push out new configuration or confirm the configuration of remote systems.
 
 Playbooks can:
 
@@ -136,8 +136,6 @@ Assuming you load balance your checkout location, ``ansible-pull`` scales essent
 
 Run ``ansible-pull --help`` for details.
 
-There's also a `clever playbook <https://github.com/ansible/ansible-examples/blob/master/language_features/ansible_pull.yml>`_ available to configure ``ansible-pull`` through a crontab from push mode.
-
 Verifying playbooks
 ===================
 
@@ -173,7 +171,5 @@ The `ansible-lint default rules <https://ansible.readthedocs.io/projects/lint/ru
        Learn to extend Ansible by writing your own modules
    :ref:`intro_patterns`
        Learn about how to select hosts
-   `GitHub examples directory <https://github.com/ansible/ansible-examples>`_
-       Complete end-to-end playbook examples
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups

--- a/docs/docsite/rst/playbook_guide/playbooks_reuse.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_reuse.rst
@@ -220,7 +220,5 @@ Imports are processed before the play begins, so the name of the import no longe
        Tips and tricks for playbooks
    :ref:`ansible_galaxy`
        How to share roles on galaxy, role management
-   `GitHub Ansible examples <https://github.com/ansible/ansible-examples>`_
-       Complete playbook files from the GitHub project source
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups

--- a/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
@@ -760,7 +760,5 @@ Read the `Ansible Galaxy documentation <https://ansible.readthedocs.io/projects/
        Browse existing collections, modules, and plugins
    :ref:`developing_modules`
        Extending Ansible by writing your own modules
-   `GitHub Ansible examples <https://github.com/ansible/ansible-examples>`_
-       Complete playbook files from the GitHub project source
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups

--- a/docs/docsite/rst/playbook_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_variables.rst
@@ -6,7 +6,7 @@ Using Variables
 
 Ansible uses variables to manage differences between systems. With Ansible, you can execute tasks and playbooks on multiple different systems with a single command. To represent the variations among those different systems, you can create variables with standard YAML syntax, including lists and dictionaries. You can define these variables in your playbooks, in your :ref:`inventory <intro_inventory>`, in reusable :ref:`files <playbooks_reuse>` or :ref:`roles <playbooks_reuse_roles>`, or at the command line. You can also create variables during a playbook run by registering the return value or values of a task as a new variable.
 
-After you create variables, either by defining them in a file, passing them at the command line, or registering the return value or values of a task as a new variable, you can use those variables in module arguments, in :ref:`conditional "when" statements <playbooks_conditionals>`, in :ref:`templates <playbooks_templating>`, and in :ref:`loops <playbooks_loops>`. The `ansible-examples GitHub repository <https://github.com/ansible/ansible-examples>`_ contains many examples of using variables in Ansible.
+After you create variables, either by defining them in a file, passing them at the command line, or registering the return value or values of a task as a new variable, you can use those variables in module arguments, in :ref:`conditional "when" statements <playbooks_conditionals>`, in :ref:`templates <playbooks_templating>`, and in :ref:`loops <playbooks_loops>`.
 
 Once you understand the concepts and examples on this page, read about :ref:`Ansible facts <vars_and_facts>`, which are variables you retrieve from remote systems.
 

--- a/docs/docsite/rst/reference_appendices/YAMLSyntax.rst
+++ b/docs/docsite/rst/reference_appendices/YAMLSyntax.rst
@@ -270,8 +270,6 @@ value:
        Learn what playbooks can do and how to write/run them.
    `YAMLLint <http://yamllint.com/>`_
        YAML Lint (online) helps you debug YAML syntax if you are having problems
-   `GitHub examples directory <https://github.com/ansible/ansible-examples>`_
-       Complete playbook files from the GitHub project source
    `Wikipedia YAML syntax reference <https://en.wikipedia.org/wiki/YAML>`_
        A good guide to YAML syntax
    `Mailing List <https://groups.google.com/group/ansible-project>`_

--- a/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
+++ b/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
@@ -206,7 +206,5 @@ This pulls in variables from the `group_vars/os_CentOS.yml` file.
        Learn how to extend Ansible by writing your own modules
    :ref:`intro_patterns`
        Learn about how to select hosts
-   `GitHub examples directory <https://github.com/ansible/ansible-examples>`_
-       Complete playbook files from the GitHub project source
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups

--- a/docs/docsite/rst/tips_tricks/sample_setup.rst
+++ b/docs/docsite/rst/tips_tricks/sample_setup.rst
@@ -4,7 +4,7 @@
 Sample Ansible setup
 ********************
 
-You have learned about playbooks, inventory, roles, and variables. This section combines all those elements and outlines a sample setup for automating a web service. You can find more example playbooks that illustrate these patterns in our `ansible-examples repository <https://github.com/ansible/ansible-examples>`_. (NOTE: These examples do not use all of the latest features, but are still an excellent reference.).
+You have learned about playbooks, inventory, roles, and variables. This section combines all those elements and outlines a sample setup for automating a web service.
 
 The sample setup organizes playbooks, roles, inventory, and files with variables by function. Tags at the play and task level provide greater granularity and control. This is a powerful and flexible approach, but there are other ways to organize Ansible content. Your usage of Ansible should fit your needs, so feel free to modify this approach and organize your content accordingly.
 
@@ -289,7 +289,5 @@ If a playbook has a :file:`./library` directory relative to its YAML file, you c
        Learn how to extend Ansible by writing your own modules
    :ref:`intro_patterns`
        Learn about how to select hosts
-   `GitHub examples directory <https://github.com/ansible/ansible-examples>`_
-       Complete playbook files from the GitHub project source
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups


### PR DESCRIPTION
 The [Ansible playbooks examples](https://github.com/ansible/ansible-examples) repository has been publicly archived, therefore references to it in documentation are removed.

Also, there's a mention of `ansible-examples` in [examples/play.yml](https://github.com/ansible/ansible-documentation/blob/aab570123955229d8bc2fd66e7a73c5812f02044/examples/play.yml#L6), although it refers to an unrelated repository, hence ignored.

Fix #1640.