### PR TITLE
Adding daily schedule to CI build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: Ansible Docsite CI
 on:
   schedule:
     # Daily 
-    - cron: "0 7 * * *"
+    - cron: "23 7 * * *"
   push:
     branches-ignore:
       - 'patchback/**'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,9 @@
 name: Ansible Docsite CI
 
 on:
+  schedule:
+    # Daily 
+    - cron: "0 7 * * *"
   push:
     branches-ignore:
       - 'patchback/**'


### PR DESCRIPTION
Per issue #1088, adding a daily (at 0700) scheduled cron job for CI runs, to catch any issues more often than a PR