### PR TITLE
Nightly builds for package docs publishing workflow

### DIFF
--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -3,7 +3,7 @@
 name: Ansible package docs build
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '15 5 * * *'
   workflow_dispatch:
     inputs:
       repository-owner:

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -2,6 +2,8 @@
 
 name: Ansible package docs build
 on:
+  schedule:
+    - cron: '0 0 * * *'
   workflow_dispatch:
     inputs:
       repository-owner:

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -3,7 +3,7 @@
 name: Ansible package docs build
 on:
   schedule:
-    - cron: '15 5 * * *'
+    - cron: '17 5 * * *'
   workflow_dispatch:
     inputs:
       repository-owner:


### PR DESCRIPTION
As discussed at the DaWGs meeting, we want to run the package docs build every night to start catching failures early.