### PR TITLE
Remove language option from workflow

### DIFF
--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -18,14 +18,6 @@ on:
         description: Branch, tag, or commit SHA
         required: true
         default: devel
-      language:
-        type: choice
-        description: Language
-        required: true
-        default: english
-        options:
-        - english
-        - japanese
       ansible-package-version:
         type: choice
         description: Ansible community package version
@@ -94,12 +86,8 @@ jobs:
 
     - name: Set the VERSION variable
       run: |
-        if [ ${LANGUAGE} == "english" ]; then
-          echo VERSION="${PACKAGE_VERSION}" >> "${GITHUB_ENV}"
-        elif [ ${LANGUAGE} == "japanese" ]; then
-          echo VERSION="${PACKAGE_VERSION}_ja" >> "${GITHUB_ENV}"
-        fi
-
+        echo VERSION="${PACKAGE_VERSION}" >> "${GITHUB_ENV}"
+  
     - name: Build the Ansible community package docs
       run: make webdocs ANSIBLE_VERSION="${COLLECTION_LIST}"
       working-directory: build-directory/docs/docsite

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -85,8 +85,7 @@ jobs:
         >> "${GITHUB_ENV}"
 
     - name: Set the VERSION variable
-      run: |
-        echo VERSION="${PACKAGE_VERSION}" >> "${GITHUB_ENV}"
+      run: echo VERSION="${PACKAGE_VERSION}" >> "${GITHUB_ENV}"
   
     - name: Build the Ansible community package docs
       run: make webdocs ANSIBLE_VERSION="${COLLECTION_LIST}"


### PR DESCRIPTION
We no longer have translations, so remove the extra logic from the package docs build workflow.