### PR TITLE
remove the schedule from the workflow dispatch job

### DIFF
--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -2,8 +2,6 @@
 
 name: Ansible package docs build
 on:
-  schedule:
-    - cron: '17 5 * * *'
   workflow_dispatch:
     inputs:
       repository-owner:


### PR DESCRIPTION
Relates to issue #1682. This change removes the schedule to stop the workflow from failing due to null input values. We can either add this back with some expressions to set defaults for scheduled runs or create a simplified build workflow that runs on a schedule.