### PR TITLE
restore anchor in communication guide

### DIFF
--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -64,6 +64,8 @@ You can add Matrix shields to your repository's ``README.md`` using the shield i
 
   IRC channels are no longer considered official communication channels. Please use the Forum and Matrix instead.
 
+.. _general_channels:
+
 General channels
 ----------------
 
@@ -71,7 +73,7 @@ The clickable links will take you directly to the relevant Matrix room in your b
 
 - `Community social room and posting news for the Bullhorn newsletter <https://matrix.to:/#/#social:ansible.com>`_
 - `General usage and support questions <https://matrix.to:/#/#users:ansible.com>`_
-- `Discussions on developer topics and code related to features or bugs <https://matrix.to/#/#devel:ansible.com>`_ 
+- `Discussions on developer topics and code related to features or bugs <https://matrix.to/#/#devel:ansible.com>`_
 - `Discussions on community and collections related topics <https://matrix.to:/#/#community:ansible.com>`_
 
 Working group-specific channels


### PR DESCRIPTION
https://github.com/ansible/ansible-documentation/commit/b519a730cecdb7f24c9edc34736e584add4d7e31 removed an anchor from the RST file which breaks ci https://github.com/ansible/ansible-documentation/actions/runs/9935360176/job/27441383476#step:5:53