### PR TITLE
[Needs SC vote before merging] Collection requirements: add Forum-related reqs

### DIFF
--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -48,7 +48,7 @@ The :ref:`ansible_forum` is our default communication platform.
 In the context of organizing communication around Ansible collections, you need to understand the following notions:
 
 * `Tags <https://forum.ansible.com/tags>`_: together with categories, tags are the main feature used in the Forum to organize conversations around specific topics. Most Ansible projects have one or more associated tags. For Ansible collections the main tag name is usually the technology the collection targets: examples include `kubernetes <https://forum.ansible.com/tag/kubernetes>`_ for ``kubernetes.core``, `windows <https://forum.ansible.com/tag/windows>`_ for ``ansible.windows``, and `postgresql <https://forum.ansible.com/tag/postgresql>`_ for ``community.postgresql``.
-* `Forum groups <https://forum.ansible.com/g>`_: allow you to organize users, manage permissions, have a working group page that provides all related information, manage notifications including automatic tag subscription for members, mention or message the whole group, and more. An example of collection working group is the `PostgreSQL Ansible Collection Working Group <https://forum.ansible.com/g/PostgreSQLTeam>`_.
+* `Forum groups <https://forum.ansible.com/g>`_: groups allow you to organize users, manage permissions, have a working group page that provides related information, automatically subscribe members to tags, mention or message the whole group, and more. An example collection working group is the `PostgreSQL Ansible Collection Working Group <https://forum.ansible.com/g/PostgreSQLTeam>`_.
 
 See the `Working Groups - things you can ask for! <https://forum.ansible.com/t/working-groups-things-you-can-ask-for/175>`_ forum topic for more details.
 

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -68,7 +68,7 @@ Your collection:
 
 * MUST have a communication section in its README with references to the :ref:`ansible_forum` similar to the `collection_template README.md <https://github.com/ansible-collections/collection_template#communication>`_.
 
-  * The section MUST contain at least a reference to the `Get Help <https://forum.ansible.com/c/help/6>`_ forum category.
+  * The section MUST contain at least a reference to the `Get Help <https://forum.ansible.com/c/help/6>`_ forum category, potentially including a tag in the URL.
   * The section MUST contain information on which tags participants should use for collection-related topics.
   * If the collection has a forum group, the section MUST contain a reference to the group.
   * Descriptions of the references MUST welcome readers to join and participate.

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -44,7 +44,7 @@ Your collection:
 
 * MUST have a corresponding public tag in the :ref:`ansible_forum` or reuse at least one of the `existing tags <https://forum.ansible.com/tags>`_.
 
-  * In addition, the collection can `request <https://docs.ansible.com/ansible/devel/community/communication.html#requesting-a-forum-group>`_ a forum group.
+  * In addition, the collection can `request a forum group <https://docs.ansible.com/ansible/devel/community/communication.html#requesting-a-forum-group>`_.
 
      * All related tags MUST be associated with the group: everyone who joins the group will automatically get subscribed to the tags.
      * The group MUST be public and free to join by any forum user.

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -47,7 +47,7 @@ The :ref:`ansible_forum` is our default communication platform.
 
 In the context of organizing communication around Ansible collections, you need to understand the following notions:
 
-* `Tags <https://forum.ansible.com/tags>`_: together with categories, the tags is the main feature used in the Forum to organize conversations around specific kinds of topics. Most of projects in the Forum have associated tags. In case of Ansible collections, a tag name is usually based on technology the collection automates, for example, ``kubernetes``, ``windows``, or ``postgresql``.
+* `Tags <https://forum.ansible.com/tags>`_: together with categories, tags are the main feature used in the Forum to organize conversations around specific topics. Most Ansible projects have one or more associated tags. For Ansible collections the main tag name is usually the technology the collection targets: examples include `kubernetes <https://forum.ansible.com/tag/kubernetes>`_ for ``kubernetes.core``, `windows <https://forum.ansible.com/tag/windows>`_ for ``ansible.windows``, and `postgresql <https://forum.ansible.com/tag/postgresql>`_ for ``community.postgresql``.
 * `Forum groups <https://forum.ansible.com/g>`_: allow you to organize users, manage permissions, have a working group page that provides all related information, manage notifications including automatic tag subscription for members, mention or message the whole group, and more. An example of collection working group is the `PostgreSQL Ansible Collection Working Group <https://forum.ansible.com/g/PostgreSQLTeam>`_.
 
 See the `Working Groups - things you can ask for! <https://forum.ansible.com/t/working-groups-things-you-can-ask-for/175>`_ forum topic for more details.

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -59,7 +59,7 @@ Your collection:
 
 * MUST have a corresponding public tag in the :ref:`ansible_forum` or reuse at least one of the `existing tags <https://forum.ansible.com/tags>`_.
 
-  * In addition, the collection can :ref:`request a forum group<requesting_forum_group>`_.
+  * In addition, the collection can :ref:`request a forum group<requesting_forum_group>`.
 
      * All related tags MUST be associated with the group. Everyone who joins the group is automatically subscribed to the tags.
      * The group MUST be public and free to join by any forum user.

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -61,7 +61,7 @@ Your collection:
 
   * Multiple collections can share a tag if they cover similar topics; for example, ``amazon.aws`` and ``community.aws`` could both use the tag ``aws``.
 
-  * In addition, the collection can :ref:`request a forum group<requesting_forum_group>`.
+  * In addition, the collection can :ref:`request a forum group<requesting_forum_group>`. If the collection requests or already has a group:
 
      * All related tags MUST be associated with the group. Everyone who joins the group is automatically subscribed to the tags.
      * The group MUST be public and free to join by any forum user.

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -43,7 +43,7 @@ Communication and Working Groups
 Forum overview
 --------------
 
-The :ref:`ansible_forum` is our default communication platform.
+The :ref:`ansible_forum` is our asynchronous default communication platform.
 
 In the context of organizing communication around Ansible collections, you need to understand the following notions:
 

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -33,7 +33,7 @@ Keeping informed
 To track changes that affect collections:
 
 * Join the `Collection Maintainers & Contributors forum group <https://forum.ansible.com/g/CollectionMaintainer>`_.
-* Subscribe to the `Bullhorn <https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn>`_ Ansible contributor newsletter.
+* Subscribe to the :ref:`bullhorn` Ansible contributor newsletter.
 
 .. _coll_wg_reqs:
 
@@ -44,7 +44,7 @@ Your collection:
 
 * MUST have a corresponding public tag in the :ref:`ansible_forum` or reuse at least one of the `existing tags <https://forum.ansible.com/tags>`_.
 
-  * In addition, the collection can `request a forum group <https://docs.ansible.com/ansible/devel/community/communication.html#requesting-a-forum-group>`_.
+  * In addition, the collection can :ref:`request a forum group<requesting_forum_group>`.
 
      * All related tags MUST be associated with the group. Everyone who joins the group is automatically subscribed to the tags.
      * The group MUST be public and free to join by any forum user.

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -55,7 +55,7 @@ Your collection:
   * The section MUST contain information on which tags participants should use for collection-related topics.
   * If the collection has a forum group, the section MUST contain a reference to the group.
   * Maintainers of the collection MUST be subscribed to all associated tags and be members of all associated groups.
-  * Descriptions of the references MUST welcome readers to subscribe to associated tags/join the forum group and participate.
+  * Descriptions of the references MUST welcome readers to join and participate.
 
 * SHOULD have the ``Discussions`` GitHub feature disabled in favor of the Forum.
 

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -46,7 +46,7 @@ Your collection:
 
   * In addition, the collection can `request a forum group <https://docs.ansible.com/ansible/devel/community/communication.html#requesting-a-forum-group>`_.
 
-     * All related tags MUST be associated with the group: everyone who joins the group will automatically get subscribed to the tags.
+     * All related tags MUST be associated with the group. Everyone who joins the group is automatically subscribed to the tags.
      * The group MUST be public and free to join by any forum user.
 
 * MUST have a communication section in its README with references to :ref:`ansible_forum` similar to as in the `collection_template README.md <https://github.com/ansible-collections/collection_template#communication>`_.

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -40,14 +40,30 @@ To track changes that affect collections:
 Communication and Working Groups
 ================================
 
+Forum overview
+--------------
+
+The :ref:`ansible_forum` is our default communication platform.
+
+In the context of organizing communication around Ansible collections, you need to understand the following notions:
+
+* `Tags <https://forum.ansible.com/tags>`_: together with categories, the tags is the main feature used in the Forum to organize conversations around specific kinds of topics. Most of projects in the Forum have associated tags. In case of Ansible collections, a tag name is usually based on technology the collection automates, for example, ``kubernetes``, ``windows``, or ``postgresql``.
+* `Forum groups <https://forum.ansible.com/g>`_: allow you to organize users, manage permissions, have a working group page that provides all related information, manage notifications including automatic tag subscription for members, mention or message the whole group, and more. An example of collection working group is the `PostgreSQL Ansible Collection Working Group <https://forum.ansible.com/g/PostgreSQLTeam>`_.
+
+See the `Working Groups - things you can ask for! <https://forum.ansible.com/t/working-groups-things-you-can-ask-for/175>`_ forum topic for more details.
+
+Communication requirements
+--------------------------
+
 Your collection:
 
 * MUST have a corresponding public tag in the :ref:`ansible_forum` or reuse at least one of the `existing tags <https://forum.ansible.com/tags>`_.
-
   * In addition, the collection can :ref:`request a forum group<requesting_forum_group>`.
 
      * All related tags MUST be associated with the group. Everyone who joins the group is automatically subscribed to the tags.
      * The group MUST be public and free to join by any forum user.
+
+  * Use the `Requesting a tag/forum group <https://forum.ansible.com/t/requesting-a-tag-forum-group/503>`_ topic to request a tag and a forum group.
 
 * MUST have a communication section in its README with references to the :ref:`ansible_forum` similar to the `collection_template README.md <https://github.com/ansible-collections/collection_template#communication>`_.
 

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -71,8 +71,8 @@ Your collection:
   * The section MUST contain at least a reference to the `Get Help <https://forum.ansible.com/c/help/6>`_ forum category.
   * The section MUST contain information on which tags participants should use for collection-related topics.
   * If the collection has a forum group, the section MUST contain a reference to the group.
-  * Maintainers of the collection MUST be subscribed to all associated tags and be members of all associated groups.
   * Descriptions of the references MUST welcome readers to join and participate.
+  * Maintainers of the collection SHOULD be subscribed to all associated tags and be members of all associated groups.
 
 * SHOULD have the ``Discussions`` GitHub feature disabled in favor of the Forum.
 

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -58,7 +58,8 @@ Communication requirements
 Your collection:
 
 * MUST have a corresponding public tag in the :ref:`ansible_forum` or reuse at least one of the `existing tags <https://forum.ansible.com/tags>`_.
-  * In addition, the collection can :ref:`request a forum group<requesting_forum_group>`.
+
+  * In addition, the collection can :ref:`request a forum group<requesting_forum_group>`_.
 
      * All related tags MUST be associated with the group. Everyone who joins the group is automatically subscribed to the tags.
      * The group MUST be public and free to join by any forum user.

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -59,6 +59,8 @@ Your collection:
 
 * MUST have a corresponding public tag in the :ref:`ansible_forum` or reuse at least one of the `existing tags <https://forum.ansible.com/tags>`_.
 
+  * Multiple collecions can share a tag if they cover similar topics; for example, ``amazon.aws`` and ``community.aws`` could both use the tag ``aws``.
+
   * In addition, the collection can :ref:`request a forum group<requesting_forum_group>`.
 
      * All related tags MUST be associated with the group. Everyone who joins the group is automatically subscribed to the tags.

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -52,7 +52,7 @@ Your collection:
 * MUST have a communication section in its README with references to the :ref:`ansible_forum` similar to the `collection_template README.md <https://github.com/ansible-collections/collection_template#communication>`_.
 
   * The section MUST contain at least a reference to the `Get Help <https://forum.ansible.com/c/help/6>`_ forum category.
-  * The section MUST contain information which tags participants should use for collection-related topics.
+  * The section MUST contain information on which tags participants should use for collection-related topics.
   * If the collection has a forum group, the section MUST contain a reference to the group.
   * Maintainers of the collection MUST be subscribed to all associated tags and be members of all associated groups.
   * Descriptions of the references MUST welcome readers to subscribe to associated tags/join the forum group and participate.

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -33,7 +33,31 @@ Keeping informed
 To track changes that affect collections:
 
 * Join the `Collection Maintainers & Contributors forum group <https://forum.ansible.com/g/CollectionMaintainer>`_.
-* Subscribe to the `Bullhorn <https://forum.ansible.com/c/news/bullhorn/17>`_ Ansible contributor newsletter.
+* Subscribe to the `Bullhorn <https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn>`_ Ansible contributor newsletter.
+
+.. _coll_wg_reqs:
+
+Communication and Working Groups
+================================
+
+Your collection:
+
+* MUST have a corresponding public tag in the :ref:`ansible_forum` or reuse at least one of the `existing tags <https://forum.ansible.com/tags>`_.
+
+  * In addition, the collection can `request <https://docs.ansible.com/ansible/devel/community/communication.html#requesting-a-forum-group>`_ a forum group.
+
+     * All related tags MUST be associated with the group: everyone who joins the group will automatically get subscribed to the tags.
+     * The group MUST be public and free to join by any forum user.
+
+* MUST have a communication section in its README with references to :ref:`ansible_forum` similar to as in the `collection_template README.md <https://github.com/ansible-collections/collection_template#communication>`_.
+
+  * The section MUST contain at least a reference to the `Get Help <https://forum.ansible.com/c/help/6>`_ forum category.
+  * The section MUST contain information which tags participants should use for collection-related topics.
+  * If the collection has a forum group, the section MUST contain a reference to the group.
+  * Maintainers of the collection MUST be subscribed to all associated tags and be members of all associated groups.
+  * Descriptions of the references MUST welcome readers to subscribe to associated tags/join the forum group and participate.
+
+* SHOULD have the ``Discussions`` GitHub feature disabled in favor of the Forum.
 
 .. _coll_infrastructure_reqs:
 
@@ -419,14 +443,6 @@ To learn how to add tests to your collection, see:
 
 * :ref:`collection_integration_tests`
 * :ref:`collection_unit_tests`
-
-
-.. _coll_wg_reqs:
-
-Collections and Working Groups
-==============================
-
-The collections are encouraged to request a working group on the :ref:`ansible_forum`.
 
 .. _coll_migrating_reqs:
 

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -59,7 +59,7 @@ Your collection:
 
 * MUST have a corresponding public tag in the :ref:`ansible_forum` or reuse at least one of the `existing tags <https://forum.ansible.com/tags>`_.
 
-  * Multiple collecions can share a tag if they cover similar topics; for example, ``amazon.aws`` and ``community.aws`` could both use the tag ``aws``.
+  * Multiple collections can share a tag if they cover similar topics; for example, ``amazon.aws`` and ``community.aws`` could both use the tag ``aws``.
 
   * In addition, the collection can :ref:`request a forum group<requesting_forum_group>`.
 

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -59,6 +59,8 @@ Your collection:
 
 * SHOULD have the ``Discussions`` GitHub feature disabled in favor of the Forum.
 
+  * Unless GitHub discussions are currently used, this feature MUST be `disabled on the repo <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/enabling-or-disabling-github-discussions-for-a-repository>`_.
+
 .. _coll_infrastructure_reqs:
 
 Collection infrastructure

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -49,7 +49,7 @@ Your collection:
      * All related tags MUST be associated with the group. Everyone who joins the group is automatically subscribed to the tags.
      * The group MUST be public and free to join by any forum user.
 
-* MUST have a communication section in its README with references to :ref:`ansible_forum` similar to as in the `collection_template README.md <https://github.com/ansible-collections/collection_template#communication>`_.
+* MUST have a communication section in its README with references to the :ref:`ansible_forum` similar to the `collection_template README.md <https://github.com/ansible-collections/collection_template#communication>`_.
 
   * The section MUST contain at least a reference to the `Get Help <https://forum.ansible.com/c/help/6>`_ forum category.
   * The section MUST contain information which tags participants should use for collection-related topics.

--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -99,8 +99,10 @@ Working Groups are a way for Ansible community members to self-organize around p
 Our community working groups are represented in `Forum groups <https://forum.ansible.com/g>`_.
 See those links for a complete list of communications channels.
 
+.. _requesting_forum_group:
+
 Requesting a forum group
---------------------------
+------------------------
 
 To request a new working group:
 


### PR DESCRIPTION
Related to https://forum.ansible.com/t/proposal-consolidating-ansible-discussion-platforms/6812/19

- Related forum topic is https://forum.ansible.com/t/forum-to-ansible-community-package-collection-requirements/7316 but any suggestions here now are welcome
- The PR refers to collection_template README Communication section. It's being changed now in https://github.com/ansible-collections/collection_template/pull/71 <- this is how it's going to look