### PR TITLE
[backport stable-2.15] ci: refresh dev dependencies (#1707)

### DIFF
--- a/tests/static.txt
+++ b/tests/static.txt
@@ -4,5 +4,5 @@
 #
 #    pip-compile --allow-unsafe --output-file=tests/static.txt --strip-extras tests/static.in
 #
-ruff==0.5.1
+ruff==0.5.4
     # via -r tests/static.in

--- a/tests/typing.txt
+++ b/tests/typing.txt
@@ -20,7 +20,7 @@ codeowners==0.7.0
     # via -r tests/../hacking/pr_labeler/requirements.txt
 colorlog==6.8.2
     # via nox
-cryptography==42.0.8
+cryptography==43.0.0
     # via pyjwt
 deprecated==1.2.14
     # via pygithub
@@ -31,7 +31,7 @@ filelock==3.15.1
 gitdb==4.0.11
     # via gitpython
 gitpython==3.1.43
-    # via -r tests/../hacking/tagger/requirements.txt
+    # via -r tests/tag.in
 idna==3.7
     # via requests
 jinja2==3.1.4
@@ -42,7 +42,7 @@ markupsafe==2.1.5
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
-mypy==1.10.1
+mypy==1.11.0
     # via -r tests/typing.in
 mypy-extensions==1.0.0
     # via mypy
@@ -77,7 +77,7 @@ tomli==2.0.1
 typer==0.12.3
     # via
     #   -r tests/../hacking/pr_labeler/requirements.txt
-    #   -r tests/../hacking/tagger/requirements.txt
+    #   -r tests/tag.in
 typing-extensions==4.12.2
     # via
     #   codeowners


### PR DESCRIPTION
Manual backport of https://github.com/ansible/ansible-documentation/pull/1707

* ci: refresh dev dependencies

* ci: refresh dev dependencies

---------

Co-authored-by: Ansible Documentation Bot <147556122+ansible-documentation-bot[bot]@users.noreply.github.com>
(cherry picked from commit 141ca118dc7fbe17cccc4c9ba0c42645028c6766)