### PR TITLE
add note about arguments in shebang in modules

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -32,7 +32,8 @@ Python shebang & UTF-8 coding
 
 Begin your Ansible module with ``#!/usr/bin/python`` - this "shebang" allows ``ansible_python_interpreter`` to work. Follow the shebang immediately with ``# -*- coding: utf-8 -*-`` to clarify that the file is UTF-8 encoded.
 
-.. warning:: Using ``#!/usr/bin/env``, makes ``env`` the interpreter and bypasses ``ansible_<interpreter>_interpreter`` logic. Using arguments in combination with ``env`` (e.g. ``#!/usr/bin/env python``) does not work.
+.. warning:: Using ``#!/usr/bin/env``, makes ``env`` the interpreter and bypasses ``ansible_<interpreter>_interpreter`` logic.
+.. warning:: Passing arguments to the interpreter (e.g. ``#!/usr/bin/env python``) in the shebang also does not work.
 .. note:: If you develop the module using a different scripting language, adjust the interpreter accordingly (``#!/usr/bin/<interpreter>``) so ``ansible_<interpreter>_interpreter`` can work for that specific language.
 .. note:: Binary modules do not require a shebang or an interpreter.
 

--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -32,8 +32,9 @@ Python shebang & UTF-8 coding
 
 Begin your Ansible module with ``#!/usr/bin/python`` - this "shebang" allows ``ansible_python_interpreter`` to work. Follow the shebang immediately with ``# -*- coding: utf-8 -*-`` to clarify that the file is UTF-8 encoded.
 
-.. warning:: Using ``#!/usr/bin/env``, makes ``env`` the interpreter and bypasses ``ansible_<interpreter>_interpreter`` logic.
-.. warning:: Passing arguments to the interpreter (e.g. ``#!/usr/bin/env python``) in the shebang also does not work.
+.. warning::
+   - Using ``#!/usr/bin/env`` makes ``env`` the interpreter and bypasses ``ansible_<interpreter>_interpreter`` logic.
+   - Passing arguments to the interpreter in the shebang does not work (for example, ``#!/usr/bin/env python``) .
 .. note:: If you develop the module using a different scripting language, adjust the interpreter accordingly (``#!/usr/bin/<interpreter>``) so ``ansible_<interpreter>_interpreter`` can work for that specific language.
 .. note:: Binary modules do not require a shebang or an interpreter.
 

--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -32,7 +32,7 @@ Python shebang & UTF-8 coding
 
 Begin your Ansible module with ``#!/usr/bin/python`` - this "shebang" allows ``ansible_python_interpreter`` to work. Follow the shebang immediately with ``# -*- coding: utf-8 -*-`` to clarify that the file is UTF-8 encoded.
 
-.. note:: Using ``#!/usr/bin/env``, makes ``env`` the interpreter and bypasses ``ansible_<interpreter>_interpreter`` logic.
+.. warning:: Using ``#!/usr/bin/env``, makes ``env`` the interpreter and bypasses ``ansible_<interpreter>_interpreter`` logic. Using arguments in combination with ``env`` (e.g. ``#!/usr/bin/env python``) does not work.
 .. note:: If you develop the module using a different scripting language, adjust the interpreter accordingly (``#!/usr/bin/<interpreter>``) so ``ansible_<interpreter>_interpreter`` can work for that specific language.
 .. note:: Binary modules do not require a shebang or an interpreter.
 

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -182,7 +182,8 @@ Also, this works for ANY interpreter, for example ruby: ``ansible_ruby_interpret
 so you can use this for custom modules written in any scripting language and control the interpreter location.
 
 Keep in mind that if you put ``env`` in your module shebang line (``#!/usr/bin/env <other>``),
-this facility will be ignored so you will be at the mercy of the remote `$PATH`.
+this won't work and will be evaluated as one string (including the space between ``env`` and ``<other>`` space).
+Arguments are neither intended nor supported.
 
 .. _installation_faqs:
 


### PR DESCRIPTION
In https://github.com/ansible/ansible/issues/83603 the result of the discussion was that it is neither wanted nor supported to use arguments in the shebang.

Obviously, this feature is not a matter of common knowledge. I'm far from the only one who didn't know that. (e.g. [VMware's NSX-T Ansible Modules](https://github.com/vmware/ansible-for-nsxt/pull/509) or even the [test-playbook from ansible](https://github.com/ansible/test-playbooks/blob/69c2d0ff5b115bb2deabc3844b42ead96ebeecc8/library/test_scan_facts.py#L1) itself)

imho this is also due to ambiguous documentation.

With this PR, I would like to make the documentation a little clearer. I'm always open to suggestions for improvement.