### PR TITLE
[PR #1731/e2137b19 backport][stable-2.15] Update integration test guide docker flag usage

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -72,7 +72,7 @@ outside of those test subdirectories.  They will also not reconfigure or bounce 
 
 .. note:: Running integration tests within containers
 
-   To protect your system from any potential changes caused by integration tests, and to ensure a sensible set of dependencies are available we recommend that you always run integration tests with the ``--docker`` option, for example ``--docker ubuntu2004``. See the `list of supported container images <https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_data/completion/docker.txt>`_ for options (the ``default`` image is used for sanity and unit tests, as well as for platform independent integration tests such as those for cloud modules).
+   To protect your system from any potential changes caused by integration tests, and to ensure a sensible set of dependencies are available we recommend that you always run integration tests with the ``--docker`` option, for example ``--docker ubuntu2204``. Get the list of supported container images by running ``ansible-test integration --help``. You can find them in the *target docker images* section of the output. The ``default`` image is used for sanity and unit tests, as well as for platform independent integration tests such as those for cloud modules.
 
 Run as follows for all POSIX platform tests executed by our CI system in a Fedora 34 container:
 


### PR DESCRIPTION
**This is a backport of PR #1731 as merged into devel ([e2137b1](https://github.com/ansible/ansible-documentation/commit/e2137b19a5bbc9cc7406fb5f45af4b3f1a75b421)).**

The integration tests guide linked to a file in the devel branch that gets out-of-sync with the actual supported images on the user's system. Instead, we now instruct the user to run the help flag to get the list of supported images that are actually present on their system.

This relates to, and fixes, [ansible-collections/community.general#8683](https://github.com/ansible-collections/community.general/issues/8683).