### PR TITLE
Fix CI in devel

### DIFF
--- a/docs/bin/clone-core.py
+++ b/docs/bin/clone-core.py
@@ -62,8 +62,6 @@ def main(args: Args) -> None:
         "MANIFEST.in",
         "pyproject.toml",
         "requirements.txt",
-        "setup.cfg",
-        "setup.py",
     ]
 
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/checkers/docs-build.py
+++ b/tests/checkers/docs-build.py
@@ -25,8 +25,6 @@ def main():
         'MANIFEST.in',
         'pyproject.toml',
         'requirements.txt',
-        'setup.cfg',
-        'setup.py',
     ]
 
     # The tests write to the source tree, which isn't permitted for sanity tests.


### PR DESCRIPTION
ansible-core devel no longer has setup.cfg and setup.py (https://github.com/ansible/ansible/commit/68515abf97dfc769c9aed2ba457ed7b8b2580a5c), so we have to stop trying to copy them over.

This must not be backported to any stable branch since in these, setup.cfg / setup.py are still present.