### PR TITLE
[stable-2.17] tests: update pydantic version in lockfile

### DIFF
--- a/tests/requirements-relaxed.txt
+++ b/tests/requirements-relaxed.txt
@@ -83,11 +83,11 @@ packaging==24.0
     #   sphinx
 perky==0.9.2
     # via antsibull-core
-pydantic==2.7.1
+pydantic==2.8.2
     # via
     #   antsibull-core
     #   antsibull-docs
-pydantic-core==2.18.2
+pydantic-core==2.20.1
     # via pydantic
 pygments==2.18.0
     # via

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -85,11 +85,11 @@ packaging==24.0
     #   sphinx
 perky==0.9.2
     # via antsibull-core
-pydantic==2.7.1
+pydantic==2.8.2
     # via
     #   antsibull-core
     #   antsibull-docs
-pydantic-core==2.18.2
+pydantic-core==2.20.1
     # via pydantic
 pygments==2.18.0
     # via


### PR DESCRIPTION
Fixes compatibility with newer versions of Python 3.12.

Closes: https://github.com/ansible/ansible-documentation/issues/1784