### PR TITLE
Fix broken list markup in the "Installing collections" documentation.

### DIFF
--- a/docs/docsite/rst/collections_guide/collections_installing.rst
+++ b/docs/docsite/rst/collections_guide/collections_installing.rst
@@ -177,6 +177,7 @@ Installing collections adjacent to playbooks
 You can install collections locally next to your playbooks inside your project instead of in a global location on your system or on AWX.
 
 Using locally installed collections adjacent to playbooks has some benefits, such as:
+
 * Ensuring that all users of the project use the same collection version.
 * Using self-contained projects makes it easy to move across different environments. Increased portability also reduces overhead when setting up new environments. This is a benefit when deploying Ansible playbooks in cloud environments.
 * Managing collections locally lets you version them along with your playbooks.


### PR DESCRIPTION
Just noticed this formatting error while reading the documentation:

![Screenshot of the formatting error in the documentation(outlined in red)](https://github.com/user-attachments/assets/3395c789-d67c-44d1-b383-cefa5bfccbd4)
