### PR TITLE
steering_committee_membership: clarify guidelines about team represen…

### DIFF
--- a/docs/docsite/rst/community/steering/steering_committee_membership.rst
+++ b/docs/docsite/rst/community/steering/steering_committee_membership.rst
@@ -50,6 +50,10 @@ After the announcement is made, the new representative is added to the `Steering
 
 The team uses the same Community Topic for announcing subsequent representative changes. Representatives should commit to at least two months of membership.
 
+The team representative must still abide by all expectations listed in :ref:`steering_expectations`, including those surrounding participation.
+Steering Committee members are generally expected to participate in discussions — asynchronously on the forum and/or synchronously in meetings — and votes,
+even if the issue in question does not entirely pertain to the team they represent.
+
 Process
 ^^^^^^^^
 


### PR DESCRIPTION
…tatives

Based on general discussions we've been having over the past year about inactive steering committee members, I figured we should clarify the team representative section that we recently added (for Core and potentially other teams in the future).

https://forum.ansible.com/t/new-guidelines-proposal-clarify-guidelines-about-team-representatives/8094