### PR TITLE
add check-deploy job to publish workflow

### DIFF
--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -83,7 +83,7 @@ jobs:
 
     - name: Set the VERSION variable
       run: echo VERSION="${PACKAGE_VERSION}" >> "${GITHUB_ENV}"
-  
+
     - name: Build the Ansible community package docs
       run: make webdocs ANSIBLE_VERSION="${COLLECTION_LIST}"
       working-directory: build-directory/docs/docsite
@@ -108,10 +108,16 @@ jobs:
         path: build-directory/docs/docsite/ansible-package-docs-html-*.tar.gz
         retention-days: 7
 
-    - name: Log the workflow inputs if deploy checked
-      if: fromJSON(github.event.inputs.deploy)
+  check-deploy:
+    runs-on: ubuntu-latest
+    outputs:
+      deploy_build: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.deploy == 'true' }}
+    steps:
+    - run: echo "Check the deploy conditions."
+    - name: Log the workflow inputs if deployed
+      if: github.event_name == 'workflow_dispatch' && github.event.inputs.deploy == 'true'
       run: |
-        echo "## Deployment details :rocket:" >> "${GITHUB_STEP_SUMMARY}"
+        echo "## Deployment details :shipit:" >> "${GITHUB_STEP_SUMMARY}"
         echo "Publish to: ${{ github.event.inputs.deployment-environment }}" >> "${GITHUB_STEP_SUMMARY}"
         echo "Package version: ${{ github.event.inputs.ansible-package-version }}"  >> "${GITHUB_STEP_SUMMARY}"
         echo "Owner: ${{ github.event.inputs.repository-owner }}" >> "${GITHUB_STEP_SUMMARY}"
@@ -140,8 +146,10 @@ jobs:
              -d '{"msgtype": "m.text", "body": "${{ env.FAIL_MESSAGE }}"}'
 
   deploy-package-docs:
-    if: fromJSON(github.event.inputs.deploy)
-    needs: build-package-docs
+    if: needs.check-deploy.outputs.deploy_build == 'true'
+    needs:
+      - check-deploy
+      - build-package-docs
     runs-on: ubuntu-latest
     environment:
       name: deploy-package-docs

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -146,7 +146,6 @@ jobs:
   deploy-package-docs:
     needs:
       - check-deploy
-      - build-package-docs
     runs-on: ubuntu-latest
     environment:
       name: deploy-package-docs

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -112,8 +112,6 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.deploy == 'true'
     needs: build-package-docs
     runs-on: ubuntu-latest
-    outputs:
-      deploy_build: true
     steps:
     - name: Log the workflow inputs if deployed
       run: |
@@ -146,7 +144,6 @@ jobs:
              -d '{"msgtype": "m.text", "body": "${{ env.FAIL_MESSAGE }}"}'
 
   deploy-package-docs:
-    if: needs.check-deploy.outputs.deploy_build == 'true'
     needs:
       - check-deploy
       - build-package-docs

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -109,13 +109,13 @@ jobs:
         retention-days: 7
 
   check-deploy:
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.deploy == 'true'
+    needs: build-package-docs
     runs-on: ubuntu-latest
     outputs:
-      deploy_build: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.deploy == 'true' }}
+      deploy_build: true
     steps:
-    - run: echo "Check the deploy conditions."
     - name: Log the workflow inputs if deployed
-      if: github.event_name == 'workflow_dispatch' && github.event.inputs.deploy == 'true'
       run: |
         echo "## Deployment details :shipit:" >> "${GITHUB_STEP_SUMMARY}"
         echo "Publish to: ${{ github.event.inputs.deployment-environment }}" >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
This PR adds a check-deploy job to the workflow that builds and publishes the package docs. The new job checks the conditions needed to deploy the build, 1. run was triggered manually and 2. actor selected the "deploy" checkbox.

This change allows runs triggered by schedules to succeed without failure. Because the "deploy" input does not take effect on scheduled runs, the JSON is not valid for the current `if: fromJSON(github.event.inputs.deploy)` conditional.