### PR TITLE
Replace communication links with a link to communication guide, part 1

### DIFF
--- a/docs/docsite/rst/command_guide/intro_adhoc.rst
+++ b/docs/docsite/rst/command_guide/intro_adhoc.rst
@@ -225,4 +225,4 @@ Now that you understand the basic elements of Ansible execution, you are ready t
    :ref:`working_with_playbooks`
        Using Ansible for configuration management & deployment
    :ref:`Communication<communication>`
-       Questions? Help? Ideas? Visit the Ansible communication guide
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/command_guide/intro_adhoc.rst
+++ b/docs/docsite/rst/command_guide/intro_adhoc.rst
@@ -224,7 +224,5 @@ Now that you understand the basic elements of Ansible execution, you are ready t
        Browse existing collections, modules, and plugins
    :ref:`working_with_playbooks`
        Using Ansible for configuration management & deployment
-   `Mailing List <https://groups.google.com/group/ansible-project>`_
-       Questions? Help? Ideas?  Stop by the list on Google Groups
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Questions? Help? Ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/community/getting_started.rst
+++ b/docs/docsite/rst/community/getting_started.rst
@@ -21,8 +21,8 @@ Other ways to get involved
 
 Here are some other ways to connect with the Ansible community:
 
-* Find an `Ansible Meetup near me <https://www.meetup.com/topics/ansible/>`_
-   communication
+* Visit the :ref:`Ansible communication guide<communication>`.
+* Find an `Ansible Meetup near me <https://www.meetup.com/topics/ansible/>`_.
 * Learn more about Ansible:
 
   * `Read books <https://www.ansible.com/resources/ebooks>`_.
@@ -30,4 +30,3 @@ Here are some other ways to connect with the Ansible community:
   * `Attend events <https://www.ansible.com/community/events>`_.
   * `Review getting started guides <https://www.ansible.com/resources/get-started>`_.
   * `Watch videos <https://www.ansible.com/resources/videos>`_ - includes Ansible Automates, AnsibleFest & webinar recordings.
-* See where `new releases are announced <https://groups.google.com/forum/#!forum/ansible-announce>`_

--- a/docs/docsite/rst/community/getting_started.rst
+++ b/docs/docsite/rst/community/getting_started.rst
@@ -22,7 +22,7 @@ Other ways to get involved
 Here are some other ways to connect with the Ansible community:
 
 * Visit the :ref:`Ansible communication guide<communication>`.
-* Find an `Ansible Meetup near me <https://www.meetup.com/topics/ansible/>`_.
+* Find an `Ansible Meetup near you <https://www.meetup.com/topics/ansible/>`_.
 * Learn more about Ansible:
 
   * `Read books <https://www.ansible.com/resources/ebooks>`_.

--- a/docs/docsite/rst/plugins/become.rst
+++ b/docs/docsite/rst/plugins/become.rst
@@ -61,7 +61,5 @@ Use ``ansible-doc -t become <plugin name>`` to see plugin-specific documentation
        Test plugins
    :ref:`lookup_plugins`
        Lookup plugins
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Questions? Help? Ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/plugins/become.rst
+++ b/docs/docsite/rst/plugins/become.rst
@@ -62,4 +62,4 @@ Use ``ansible-doc -t become <plugin name>`` to see plugin-specific documentation
    :ref:`lookup_plugins`
        Lookup plugins
    :ref:`Communication<communication>`
-       Questions? Help? Ideas? Visit the Ansible communication guide
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/plugins/cache.rst
+++ b/docs/docsite/rst/plugins/cache.rst
@@ -134,4 +134,4 @@ Use ``ansible-doc -t cache <plugin name>`` to see plugin-specific documentation 
    :ref:`vars_plugins`
        Vars plugins
    :ref:`Communication<communication>`
-       Questions? Help? Ideas? Visit the Ansible communication guide
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/plugins/cache.rst
+++ b/docs/docsite/rst/plugins/cache.rst
@@ -133,7 +133,5 @@ Use ``ansible-doc -t cache <plugin name>`` to see plugin-specific documentation 
        Strategy plugins
    :ref:`vars_plugins`
        Vars plugins
-   `User Mailing List <https://groups.google.com/forum/#!forum/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Questions? Help? Ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/plugins/callback.rst
+++ b/docs/docsite/rst/plugins/callback.rst
@@ -110,7 +110,5 @@ Use ``ansible-doc -t callback <plugin name>`` to see plugin-specific documentati
        Strategy plugins
    :ref:`vars_plugins`
        Vars plugins
-   `User Mailing List <https://groups.google.com/forum/#!forum/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Questions? Help? Ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/plugins/callback.rst
+++ b/docs/docsite/rst/plugins/callback.rst
@@ -111,4 +111,4 @@ Use ``ansible-doc -t callback <plugin name>`` to see plugin-specific documentati
    :ref:`vars_plugins`
        Vars plugins
    :ref:`Communication<communication>`
-       Questions? Help? Ideas? Visit the Ansible communication guide
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/plugins/cliconf.rst
+++ b/docs/docsite/rst/plugins/cliconf.rst
@@ -44,4 +44,4 @@ Use ``ansible-doc -t cliconf <plugin name>`` to see plugin-specific documentatio
    :ref:`Ansible for Network Automation<network_guide>`
        An overview of using Ansible to automate networking devices.
    :ref:`Communication<communication>`
-       Questions? Help? Ideas? Visit the Ansible communication guide
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/plugins/cliconf.rst
+++ b/docs/docsite/rst/plugins/cliconf.rst
@@ -43,7 +43,5 @@ Use ``ansible-doc -t cliconf <plugin name>`` to see plugin-specific documentatio
 
    :ref:`Ansible for Network Automation<network_guide>`
        An overview of using Ansible to automate networking devices.
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible-network IRC chat channel
+   :ref:`Communication<communication>`
+       Questions? Help? Ideas? Visit the Ansible communication guide


### PR DESCRIPTION
Replace communication links with a link to communication guide, part 1

After agreeing on this, I'll do it for the rest of the docs