### PR TITLE
Replace communication links with a link to communication guide, part 2

### DIFF
--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -136,4 +136,4 @@ Ansible Automation Platform support questions
 
 Red Hat Ansible `Automation Platform <https://www.ansible.com/products/automation-platform>`_ is a subscription that contains support, certified content, and tooling for Ansible including content management, a controller, UI and REST API.
 
-If you have a question about Ansible Automation Platform, visit `Red Hat support <https://access.redhat.com/products/red-hat-ansible-automation-platform/>`_ rather than using a chat channel or the general project mailing list.
+If you have a question about Ansible Automation Platform, visit `Red Hat support <https://access.redhat.com/products/red-hat-ansible-automation-platform/>`_ rather than using community communication platforms.

--- a/docs/docsite/rst/community/documentation_contributions.rst
+++ b/docs/docsite/rst/community/documentation_contributions.rst
@@ -233,7 +233,7 @@ It is recommended to run tests on a clean copy of the repository, which is the p
 Joining the documentation working group
 =======================================
 
-The Documentation Working Group (DaWGs) meets weekly on Tuesdays in the Docs chat (using `Matrix <https://matrix.to/#/#docs:ansible.im>`_ or using IRC at `irc.libera.chat <https://libera.chat/>`_). For more information, including links to our agenda and a calendar invite, visit our `forum group <https://forum.ansible.com/g/Docs>`_.
+The Documentation Working Group (DaWGs) meets weekly on Tuesdays in the `docs:ansible.im <https://matrix.to/#/#docs:ansible.im>`_ chat room on :ref:`Matrix<communication_irc>`. For more information, including links to our agenda, visit our `forum group <https://forum.ansible.com/g/Docs>`_.
 
 .. seealso::
    :ref:`More about testing module documentation <testing_module_documentation>`

--- a/docs/docsite/rst/community/documentation_contributions.rst
+++ b/docs/docsite/rst/community/documentation_contributions.rst
@@ -233,7 +233,7 @@ It is recommended to run tests on a clean copy of the repository, which is the p
 Joining the documentation working group
 =======================================
 
-The Documentation Working Group (DaWGs) meets weekly on Tuesdays in the `docs:ansible.im <https://matrix.to/#/#docs:ansible.im>`_ chat room on :ref:`Matrix<communication_irc>`. For more information, including links to our agenda, visit our `forum group <https://forum.ansible.com/g/Docs>`_.
+The Documentation Working Group (DaWGs) meets weekly on Tuesdays in the `docs:ansible.im chat room <https://matrix.to/#/#docs:ansible.im>`_ on :ref:`Matrix<communication_irc>`. For more information, including links to our agenda, visit our `forum group <https://forum.ansible.com/g/Docs>`_.
 
 .. seealso::
    :ref:`More about testing module documentation <testing_module_documentation>`

--- a/docs/docsite/rst/community/reporting_bugs_and_features.rst
+++ b/docs/docsite/rst/community/reporting_bugs_and_features.rst
@@ -21,9 +21,9 @@ Ansible practices responsible disclosure. To report security-related bugs, send 
 Bugs in ansible-core
 --------------------
 
-Before reporting a bug, search in GitHub for `already reported issues <https://github.com/ansible/ansible/issues>`_ and `open pull requests <https://github.com/ansible/ansible/pulls>`_ to see if someone has already addressed your issue.  Unsure if you found a bug? Report the behavior on the :ref:`mailing list or community chat first <communication>`.
+Before reporting a bug, search in GitHub for `already reported issues <https://github.com/ansible/ansible/issues>`_ and `open pull requests <https://github.com/ansible/ansible/pulls>`_ to see if someone has already addressed your issue.  Unsure if you found a bug? Discuss the behavior with the community on the :ref:`Ansible Forum<ansible_forum>`.
 
-Also, use the mailing list or chat to discuss whether the problem is in ``ansible-core`` or a collection, and for "how do I do this" type questions.
+Also, use the :ref:`Ansible Forum<ansible_forum>` to discuss whether the problem is in ``ansible-core`` or a collection, and for "how do I do this" type questions.
 
 You need a free GitHub account to `report bugs <https://github.com/ansible/ansible/issues>`_ that affect:
 

--- a/docs/docsite/rst/community/reporting_collections.rst
+++ b/docs/docsite/rst/community/reporting_collections.rst
@@ -25,7 +25,7 @@ Many bugs only affect a single module or plugin. If you find a bug that affects 
   #. Click on the Issue Tracker link for that collection.
   #. Follow the contributor guidelines or instructions in the collection repo.
 
-If you are not sure whether a bug is in ansible-core or a collection, you can report the behavior on the :ref:`mailing list or community chat channel first <communication>`.
+If you are not sure whether a bug is in ansible-core or a collection, you can report the behavior on the :ref:`Ansible Forum<ansible_forum>`.
 
 Requesting a feature
 ====================

--- a/docs/docsite/rst/dev_guide/developing_api.rst
+++ b/docs/docsite/rst/dev_guide/developing_api.rst
@@ -41,7 +41,5 @@ command line tools (``lib/ansible/cli/``) is `available on GitHub <https://githu
        Getting started on developing a module
    :ref:`developing_plugins`
        How to develop plugins
-   `Development Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Mailing list for development topics
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/dev_guide/developing_collections.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections.rst
@@ -43,7 +43,5 @@ For instructions on developing modules, see :ref:`developing_modules_general`.
        Learn how to install and use collections in playbooks and roles
    :ref:`contributing_maintained_collections`
        Guidelines for contributing to selected collections
-   `Mailing List <https://groups.google.com/group/ansible-devel>`_
-       The development mailing list
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/dev_guide/developing_collections_changelogs.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_changelogs.rst
@@ -76,7 +76,5 @@ If your collection is part of Ansible, use one of the following three options  t
        Learn how to install and use collections.
    :ref:`contributing_maintained_collections`
        Guidelines for contributing to selected collections
-   `Mailing List <https://groups.google.com/group/ansible-devel>`_
-       The development mailing list
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/dev_guide/developing_collections_contributing.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_contributing.rst
@@ -60,7 +60,5 @@ You can test your changes by using this checkout of ``community.general`` in pla
        Learn how to install and use collections.
    :ref:`contributing_maintained_collections`
        Guidelines for contributing to selected collections
-   `Mailing List <https://groups.google.com/group/ansible-devel>`_
-       The development mailing list
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/dev_guide/developing_collections_creating.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_creating.rst
@@ -135,7 +135,5 @@ After `installing <https://ansible.readthedocs.io/projects/creator/installing/#i
        Directories and files included in the collection skeleton
    `Ansible Development Tools (ADT) <https://ansible.readthedocs.io/projects/dev-tools/>`_
        Python package of tools to create and test Ansible content.
-   `Mailing List <https://groups.google.com/group/ansible-devel>`_
-       The development mailing list
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/dev_guide/developing_collections_distributing.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_distributing.rst
@@ -400,7 +400,5 @@ After Galaxy uploads and accepts a collection, the website shows you the **My Im
        Learn how to install and use collections.
    :ref:`collections_galaxy_meta`
        Table of fields used in the :file:`galaxy.yml` file 
-   `Mailing List <https://groups.google.com/group/ansible-devel>`_
-       The development mailing list
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/dev_guide/developing_collections_migrating.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_migrating.rst
@@ -132,7 +132,5 @@ Ansibulbot will know how to redirect existing issues and PRs to the new repo. Th
        Learn how to install and use collections.
    :ref:`contributing_maintained_collections`
        Guidelines for contributing to selected collections
-   `Mailing List <https://groups.google.com/group/ansible-devel>`_
-       The development mailing list
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/dev_guide/developing_collections_shared.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_shared.rst
@@ -88,7 +88,5 @@ You can use git repositories for collection dependencies during local developmen
        Learn how to install and use collections.
    :ref:`contributing_maintained_collections`
        Guidelines for contributing to selected collections
-   `Mailing List <https://groups.google.com/group/ansible-devel>`_
-       The development mailing list
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/dev_guide/developing_collections_structure.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_structure.rst
@@ -299,7 +299,5 @@ See the `collection-level metadata guide <https://ansible.readthedocs.io/project
         Learn how to package and publish your collection
    :ref:`contributing_maintained_collections`
         Guidelines for contributing to selected collections
-   `Mailing List <https://groups.google.com/group/ansible-devel>`_
-        The development mailing list
-   :ref:`communication_irc`
-        How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/dev_guide/developing_collections_testing.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_testing.rst
@@ -102,7 +102,5 @@ You can specify multiple target names. Each target name is the name of a directo
        More resources on testing Ansible
    :ref:`contributing_maintained_collections`
        Guidelines for contributing to selected collections
-   `Mailing List <https://groups.google.com/group/ansible-devel>`_
-       The development mailing list
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/dev_guide/developing_core.rst
+++ b/docs/docsite/rst/dev_guide/developing_core.rst
@@ -16,7 +16,5 @@ Although ``ansible-core`` (the code hosted in the `ansible/ansible repository <h
        Learn about the Python API for task execution
    :ref:`developing_plugins`
        Learn about developing plugins
-   `Mailing List <https://groups.google.com/group/ansible-devel>`_
-       The development mailing list
-   `irc.libera.chat <https://libera.chat>`_
-       #ansible-devel IRC chat channel
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/dev_guide/developing_inventory.rst
+++ b/docs/docsite/rst/dev_guide/developing_inventory.rst
@@ -508,7 +508,5 @@ An easy way to see how this should look is using :ref:`ansible-inventory`, which
        How to develop plugins
    `AWX <https://github.com/ansible/awx>`_
        REST API endpoint and GUI for Ansible, syncs with dynamic inventory
-   `Development Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Mailing list for development topics
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/dev_guide/developing_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules.rst
@@ -45,7 +45,5 @@ If your use case isn't covered by an existing module, an action plugin, or a rol
 
    :ref:`list_of_collections`
        Browse existing collections, modules, and plugins
-   `Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Development mailing list
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
@@ -31,7 +31,7 @@ To contribute a module to most Ansible collections, you must:
 
 Additional requirements may apply for certain collections. Review the individual collection repositories for more information.
 
-Please make sure your module meets these requirements before you submit your PR/proposal. If you have questions, reach out by using the ``#ansible-devel`` chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat>`_) or the `Ansible development mailing list <https://groups.google.com/group/ansible-devel>`_.
+Please make sure your module meets these requirements before you submit your PR/proposal. If you have questions, visit the :ref:`Ansible communication guide<communication>` for information on how to reach out to the community.
 
 Contributing to Ansible: subjective requirements
 ================================================

--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -173,11 +173,7 @@ The :ref:`Community Guide <ansible_community_guide>` covers how to open a pull r
 Communication and development support
 =====================================
 
-Join the ``#ansible-devel`` chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_) for discussions surrounding Ansible development.
-
-For questions and discussions pertaining to using the Ansible product, join the ``#ansible`` channel.
-
-To find other topic-specific chat channels, look at :ref:`Community Guide, Communicating <communication_irc>`.
+Visit the :ref:`Ansible communication guide<communication>` for information on how to join the conversation.
 
 Credit
 ======

--- a/docs/docsite/rst/dev_guide/developing_modules_general_windows.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general_windows.rst
@@ -738,7 +738,4 @@ idempotent and does not report changes. For example:
 Windows communication and development support
 =============================================
 
-Join the ``#ansible-devel`` or ``#ansible-windows`` chat channels (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_) for discussions about Ansible development for Windows.
-
-For questions and discussions pertaining to using the Ansible product,
-use the ``#ansible`` channel.
+Join the :ref:`Ansible Forum<ansible_forum>` and use the `windows` tag for discussions about Ansible development for Windows.

--- a/docs/docsite/rst/dev_guide/developing_modules_in_groups.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_in_groups.rst
@@ -43,20 +43,14 @@ It is convenient if the organization and repository names on GitHub (or elsewher
 Speak to us
 ===========
 
-Circulating your ideas before coding helps you adopt good practices and avoid common mistakes. After reading the "Before you start coding" section you should have a reasonable idea of the structure of your modules. Write a list of your proposed plugin and/or module names, with a short description of what each one does. Circulate that list on IRC or a mailing list so the Ansible community can review your ideas for consistency and familiarity. Names and functionality that are consistent, predictable, and familiar make your collection easier to use.
+Circulating your ideas before coding helps you adopt good practices and avoid common mistakes. After reading the "Before you start coding" section you should have a reasonable idea of the structure of your modules. Write a list of your proposed plugin and/or module names, with a short description of what each one does. Circulate that list on the :ref:`Ansible Forum<ansible_forum>` so the Ansible community can review your ideas for consistency and familiarity. Names and functionality that are consistent, predictable, and familiar make your collection easier to use.
 
 .. _developing_in_groups_support:
 
 Where to get support
 ====================
 
-Ansible has a thriving and knowledgeable community of module developers that is a great resource for getting your questions answered.
-
-In the :ref:`ansible_community_guide` you can find how to:
-
-* Subscribe to the Mailing Lists - We suggest "Ansible Development List" and "Ansible Announce list"
-* ``#ansible-devel`` - We have found that communicating on the ``#ansible-devel`` chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_) works best for developers so we can have an interactive dialog.
-* Working group and other chat channel meetings - Join the various weekly meetings `meeting schedule page <https://github.com/ansible-community/meetings/blob/main/README.md>`_
+Ansible has a thriving and knowledgeable community of module developers that is a great resource for getting your questions answered. Visit the :ref:`Ansible communication guide<communication>` for details.
 
 Required files
 ==============
@@ -69,8 +63,6 @@ Your collection should include the following files to be usable:
 * if needed, one or more ``/plugins/module_utils/$topic.py`` files - Code shared between more than one module, such as common arguments. *Optional*
 
 When you have these files ready, review the :ref:`developing_modules_checklist` again. If you are creating a new collection, you are responsible for all procedures related to your repository, including setting rules for contributions, finding reviewers, and testing and maintaining the code in your collection.
-
-If you need help or advice, consider joining the ``#ansible-devel`` chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_). For more information, see :ref:`developing_in_groups_support` and :ref:`communication`.
 
 New to git or GitHub
 ====================

--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -568,9 +568,7 @@ For example vars plugins, see the source code for the `vars plugins included wit
        Learn about how to develop dynamic inventory sources
    :ref:`developing_modules_general`
        Learn about how to write Ansible modules
-   `Mailing List <https://groups.google.com/group/ansible-devel>`_
-       The development mailing list
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide
    :ref:`adjacent_yaml_doc`
        Alternate YAML files as documentation

--- a/docs/docsite/rst/dev_guide/developing_rebasing.rst
+++ b/docs/docsite/rst/dev_guide/developing_rebasing.rst
@@ -89,7 +89,7 @@ You should check in on the status of your PR after tests have completed to see i
 Getting help rebasing
 =====================
 
-For help with rebasing your PR, or other development related questions, join us on the #ansible-devel chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_).
+If you need any help with rebasing your PR, or you have other development related questions, visit the :ref:`Ansible communication guide<communication>` for information on how to reach out to the community.
 
 .. seealso::
 

--- a/docs/docsite/rst/dev_guide/sidecar.rst
+++ b/docs/docsite/rst/dev_guide/sidecar.rst
@@ -94,7 +94,5 @@ YAML documentation is mainly intended for filters, tests and modules. While it i
        Learn about how to develop dynamic inventory sources
    :ref:`developing_modules_general`
        Learn about how to write Ansible modules
-   `Mailing List <https://groups.google.com/group/ansible-devel>`_
-       The development mailing list
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/dev_guide/style_guide/index.rst
+++ b/docs/docsite/rst/dev_guide/style_guide/index.rst
@@ -481,5 +481,5 @@ These pages offer more help with grammatical, stylistic, and technical rules for
        How to contribute to the Ansible documentation
    :ref:`testing_documentation_locally`
        How to build the Ansible documentation
-   `irc.libera.chat <https://libera.chat>`_
-       #ansible-docs IRC chat channel
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/dev_guide/style_guide/resources.rst
+++ b/docs/docsite/rst/dev_guide/style_guide/resources.rst
@@ -1,7 +1,7 @@
 Resources
 ^^^^^^^^^
 * Follow the style of the :ref:`Ansible Documentation<ansible_documentation>`
-* Ask for advice on the ``#ansible-devel`` chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_)
+* Ask the community for advice. Visit the :ref:`Ansible communication guide<communication>` for details.
 * Review these online style guides:
 
   * `AP Stylebook <https://www.apstylebook.com>`_

--- a/docs/docsite/rst/dev_guide/testing.rst
+++ b/docs/docsite/rst/dev_guide/testing.rst
@@ -89,8 +89,7 @@ If either issue appears to be the case, you can rerun the Azure Pipelines test b
 * closing and re-opening the pull request (full rebuild)
 * making another change to the branch and pushing to GitHub
 
-If the issue persists, please contact us in the ``#ansible-devel`` chat channel (using `Matrix <https://matrix.to/#/#space:ansible.com>`_ or using IRC at `irc.libera.chat <https://libera.chat/>`_).
-
+If the issue persists, please contact the community. Visit the :ref:`Ansible communication guide<communication>` for details.
 
 How to test a PR
 ================

--- a/docs/docsite/rst/dev_guide/testing/sanity/integration-aliases.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/integration-aliases.rst
@@ -182,4 +182,4 @@ Each issue will be assigned to one of the following projects:
 Questions
 ---------
 
-For questions about integration tests reach out to @mattclay or @gundalow on GitHub or the ``#ansible-devel`` chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_).
+For questions about integration tests reach out to the community on the :ref:`Ansible Forum<ansible_forum>` by creating a topic tagged with ``ansible-test``, ``testing`` and other appropriate tags.

--- a/docs/docsite/rst/dev_guide/testing_units_modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_units_modules.rst
@@ -18,7 +18,7 @@ The document doesn't apply to other parts of Ansible for which the recommendatio
 normally closer to the Python standard. There is basic documentation for Ansible unit
 tests in the developer guide :ref:`testing_units`. This document should
 be readable for a new Ansible module author. If you find it incomplete or confusing,
-please open a bug or ask for help on the #ansible-devel chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_).
+please open a bug or ask for help on the :ref:`Ansible Forum<ansible_forum>`.
 
 What Are Unit Tests?
 ====================
@@ -279,8 +279,7 @@ Ansible special cases for unit testing
 
 There are a number of special cases for unit testing the environment of an Ansible module.
 The most common are documented below, and suggestions for others can be found by looking
-at the source code of the existing unit tests or asking on the Ansible chat channel or mailing
-lists. For more information on joining chat channels and subscribing to mailing lists, see :ref:`communication`.
+at the source code of the existing unit tests or :ref:`asking the community<communication>`.
 
 Module argument processing
 --------------------------
@@ -564,6 +563,8 @@ the code in Ansible to trigger that failure.
 
 .. seealso::
 
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide
    :ref:`testing_units`
        Ansible unit tests documentation
    :ref:`testing_running_locally`
@@ -576,8 +577,6 @@ the code in Ansible to trigger that failure.
        The documentation of the earliest supported unittest framework - from Python 2.6
    `pytest: helps you write better programs <https://docs.pytest.org/en/latest/>`_
        The documentation of pytest - the framework actually used to run Ansible unit tests
-   `Development Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Mailing list for development topics
    `Testing Your Code (from The Hitchhiker's Guide to Python!) <https://docs.python-guide.org/writing/tests/>`_
        General advice on testing Python code
    `Uncle Bob's many videos on YouTube <https://www.youtube.com/watch?v=QedpQjxBPMA&list=PLlu0CT-JnSasQzGrGzddSczJQQU7295D2>`_

--- a/docs/docsite/rst/galaxy/dev_guide.rst
+++ b/docs/docsite/rst/galaxy/dev_guide.rst
@@ -206,11 +206,9 @@ Provide the ID of the integration to be disabled. You can find the ID by using t
 
 
 .. seealso::
-  :ref:`collections`
-    Shareable collections of modules, playbooks and roles
-  :ref:`playbooks_reuse_roles`
-    All about ansible roles
-  `Mailing List <https://groups.google.com/group/ansible-project>`_
-    Questions? Help? Ideas?  Stop by the list on Google Groups
-  :ref:`communication_irc`
-    How to join Ansible chat channels
+   :ref:`collections`
+       Shareable collections of modules, playbooks and roles
+   :ref:`playbooks_reuse_roles`
+       All about ansible roles
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/inventory_guide/intro_dynamic_inventory.rst
+++ b/docs/docsite/rst/inventory_guide/intro_dynamic_inventory.rst
@@ -164,7 +164,5 @@ the dynamic groups as empty in the static inventory file. For example:
 
    :ref:`intro_inventory`
        All about static inventory files
-   `Mailing List <https://groups.google.com/group/ansible-project>`_
-       Questions? Help? Ideas?  Stop by the list on Google Groups
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/inventory_guide/intro_inventory.rst
+++ b/docs/docsite/rst/inventory_guide/intro_inventory.rst
@@ -789,7 +789,5 @@ their location.
        Examples of basic commands
    :ref:`working_with_playbooks`
        Learning Ansible's configuration, deployment, and orchestration language.
-   `Mailing List <https://groups.google.com/group/ansible-project>`_
-       Questions? Help? Ideas?  Stop by the list on Google Groups
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/inventory_guide/intro_patterns.rst
+++ b/docs/docsite/rst/inventory_guide/intro_patterns.rst
@@ -276,7 +276,5 @@ To apply your knowledge of patterns with Ansible commands and playbooks, read :r
        Examples of basic commands
    :ref:`working_with_playbooks`
        Learning the Ansible configuration management language
-   `Mailing List <https://groups.google.com/group/ansible-project>`_
-       Questions? Help? Ideas?  Stop by the list on Google Groups
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/module_plugin_guide/modules_intro.rst
+++ b/docs/docsite/rst/module_plugin_guide/modules_intro.rst
@@ -56,10 +56,7 @@ For a list of all available modules, see the :ref:`Collection docs <list_of_coll
        How to write your own modules
    :ref:`developing_api`
        Examples of using modules with the Python API
-   `Mailing List <https://groups.google.com/group/ansible-project>`_
-       Questions? Help? Ideas?  Stop by the list on Google Groups
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide
    :ref:`all_modules_and_plugins`
        All modules and plugins available
-       

--- a/docs/docsite/rst/module_plugin_guide/modules_support.rst
+++ b/docs/docsite/rst/module_plugin_guide/modules_support.rst
@@ -47,7 +47,7 @@ If you find a bug that affects a plugin in a Galaxy collection:
 
 Some partner collections may be hosted in private repositories.
 
-If you are not sure whether the behavior you see is a bug, if you have questions, if you want to discuss development-oriented topics, or if you just want to get in touch, use one of our Google mailing lists or chat channels (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_) to :ref:`communicate with Ansiblers <communication>`.
+If you are not sure whether the behavior you see is a bug, if you have questions, if you want to discuss development-oriented topics, or if you just want to get in touch, visit the :ref:`Ansible communication guide<communication>` for information on how to join the community.
 
 If you find a bug that affects a module in an Automation Hub collection:
 
@@ -64,7 +64,5 @@ All plugins that remain in ``ansible-core`` and all collections hosted in Automa
        Examples of using modules in /usr/bin/ansible
    :ref:`working_with_playbooks`
        Examples of using modules with /usr/bin/ansible-playbook
-   `Mailing List <https://groups.google.com/group/ansible-project>`_
-       Questions? Help? Ideas?  Stop by the list on Google Groups
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/network/dev_guide/developing_resource_modules_network.rst
+++ b/docs/docsite/rst/network/dev_guide/developing_resource_modules_network.rst
@@ -718,7 +718,7 @@ For more options:
 
   ansible-test network-integration --help
 
-If you need additional help or feedback, reach out in the ``#ansible-network`` chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_).
+If you need additional help or feedback, reach out to the community. Visit the :ref:`Ansible communication guide<communication>` for details.
 
 Unit test requirements
 -----------------------

--- a/docs/docsite/rst/network/getting_started/network_resources.rst
+++ b/docs/docsite/rst/network/getting_started/network_resources.rst
@@ -8,6 +8,11 @@ Resources and next steps
 .. contents::
    :local:
 
+Community
+=========
+
+Visit the :ref:`Ansible communication guide<communication>` for information on how to join the community.
+
 Documents
 =========
 
@@ -35,13 +40,7 @@ Ansible hosts module code, examples, demonstrations, and other content on GitHub
 
 - `Ansible collections <https://github.com/ansible-collections>`_ is the main repository for Ansible-maintained and community collections, including collections for network devices.
 
-
-
 Chat channels
 =============
 
-Got questions? Chat with us on:
-
-* the ``#ansible-network`` channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_)
-
-* `Ansible Network Slack <https://join.slack.com/t/ansiblenetwork/shared_invite/zt-3zeqmhhx-zuID9uJqbbpZ2KdVeTwvzw>`_ - Network & Security Automation Slack community.  Check out the #devel channel for discussions on module and plugin development.
+Visit the :ref:`Ansible communication guide<communication>` for information on how to join the conversation including available chat options.

--- a/docs/docsite/rst/os_guide/intro_bsd.rst
+++ b/docs/docsite/rst/os_guide/intro_bsd.rst
@@ -272,7 +272,5 @@ Please feel free to report any issues or incompatibilities you discover with BSD
        Learning Ansible's configuration management language
    :ref:`developing_modules`
        How to write modules
-   `Mailing List <https://groups.google.com/group/ansible-project>`_
-       Questions? Help? Ideas?  Stop by the list on Google Groups
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/os_guide/windows_dsc.rst
+++ b/docs/docsite/rst/os_guide/windows_dsc.rst
@@ -502,7 +502,5 @@ Setup IIS Website
        Tips and tricks for playbooks
    :ref:`List of Windows Modules <windows_modules>`
        Windows-specific module list, all implemented in PowerShell
-   `User Mailing List <https://groups.google.com/group/ansible-project>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/os_guide/windows_faq.rst
+++ b/docs/docsite/rst/os_guide/windows_faq.rst
@@ -243,7 +243,5 @@ host.
        An introduction to playbooks
    :ref:`playbooks_best_practices`
        Tips and tricks for playbooks
-   `User Mailing List <https://groups.google.com/group/ansible-project>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/os_guide/windows_setup.rst
+++ b/docs/docsite/rst/os_guide/windows_setup.rst
@@ -501,7 +501,5 @@ Using SSH with Windows is experimental. Currently, existing issues are:
        Tips and tricks for playbooks
     :ref:`List of Windows Modules <windows_modules>`
        Windows-specific module list, all implemented in PowerShell
-    `User Mailing List <https://groups.google.com/group/ansible-project>`_
-       Have a question?  Stop by the Google group!
-    :ref:`communication_irc`
-       How to join Ansible chat channels
+    :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/os_guide/windows_usage.rst
+++ b/docs/docsite/rst/os_guide/windows_usage.rst
@@ -513,7 +513,5 @@ guides for Windows modules differ substantially from those for standard standard
        Tips and tricks for playbooks
    :ref:`List of Windows Modules <windows_modules>`
        Windows specific module list, all implemented in PowerShell
-   `User Mailing List <https://groups.google.com/group/ansible-project>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/os_guide/windows_winrm.rst
+++ b/docs/docsite/rst/os_guide/windows_winrm.rst
@@ -1030,7 +1030,5 @@ Some of these limitations can be mitigated by doing one of the following:
        Tips and tricks for playbooks
    :ref:`List of Windows Modules <windows_modules>`
        Windows-specific module list, all implemented in PowerShell
-   `User Mailing List <https://groups.google.com/group/ansible-project>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/playbook_guide/playbooks_advanced_syntax.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_advanced_syntax.rst
@@ -116,7 +116,5 @@ You've anchored the value of ``version`` with the ``&my_version`` anchor and reu
        All about variables
    :ref:`complex_data_manipulation`
        Doing complex data manipulation in Ansible
-   `User Mailing List <https://groups.google.com/group/ansible-project>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/playbook_guide/playbooks_async.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_async.rst
@@ -183,7 +183,5 @@ To run multiple asynchronous tasks while limiting the number of tasks running co
        Options for controlling playbook execution
    :ref:`playbooks_intro`
        An introduction to playbooks
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/playbook_guide/playbooks_blocks.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_blocks.rst
@@ -218,7 +218,5 @@ These can be inspected in the ``rescue`` section:
        An introduction to playbooks
    :ref:`playbooks_reuse_roles`
        Playbook organization by roles
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/playbook_guide/playbooks_conditionals.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_conditionals.rst
@@ -600,7 +600,5 @@ Possible values (sample, not complete list):
        Tips and tricks for playbooks
    :ref:`playbooks_variables`
        All about variables
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/playbook_guide/playbooks_debugger.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_debugger.rst
@@ -336,7 +336,5 @@ With the default ``linear`` strategy enabled, Ansible halts execution while the 
        Running playbooks while debugging or testing
    :ref:`playbooks_intro`
        An introduction to playbooks
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/playbook_guide/playbooks_delegation.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_delegation.rst
@@ -177,7 +177,5 @@ use the default remote connection type:
        An introduction to playbooks
    :ref:`playbooks_strategies`
        More ways to control how and where Ansible executes
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/playbook_guide/playbooks_environment.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_environment.rst
@@ -147,7 +147,5 @@ You can also specify the environment at the task level.
 
    :ref:`playbooks_intro`
        An introduction to playbooks
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/playbook_guide/playbooks_error_handling.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_error_handling.rst
@@ -277,7 +277,5 @@ You can also use blocks to define responses to task errors. This approach is sim
        Conditional statements in playbooks
    :ref:`playbooks_variables`
        All about variables
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/playbook_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_filters.rst
@@ -2216,9 +2216,7 @@ This can then be used to reference hashes in Pod specifications:
        Playbook organization by roles
    :ref:`tips_and_tricks`
        Tips and tricks for playbooks
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide
    `Python 3 Regular expression operations <https://docs.python.org/3/library/re.html>`_
        How to use inline regular expression flags

--- a/docs/docsite/rst/playbook_guide/playbooks_intro.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_intro.rst
@@ -171,5 +171,5 @@ The `ansible-lint default rules <https://ansible.readthedocs.io/projects/lint/ru
        Learn to extend Ansible by writing your own modules
    :ref:`intro_patterns`
        Learn about how to select hosts
-   `Mailing List <https://groups.google.com/group/ansible-project>`_
-       Questions? Help? Ideas?  Stop by the list on Google Groups
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/playbook_guide/playbooks_lookups.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_lookups.rst
@@ -33,7 +33,5 @@ For more details and a list of lookup plugins in ansible-core, see :ref:`plugins
        All about variables
    :ref:`playbooks_loops`
        Looping in playbooks
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/playbook_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_loops.rst
@@ -588,7 +588,5 @@ Migrating from with_X to loop
        Conditional statements in playbooks
    :ref:`playbooks_variables`
        All about variables
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/playbook_guide/playbooks_privilege_escalation.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_privilege_escalation.rst
@@ -769,7 +769,5 @@ Limitations of become on Windows
 
 .. seealso::
 
-   `Mailing List <https://groups.google.com/forum/#!forum/ansible-project>`_
-       Questions? Help? Ideas?  Stop by the list on Google Groups
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/playbook_guide/playbooks_prompts.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_prompts.rst
@@ -118,7 +118,5 @@ Some special characters, such as ``{`` and ``%`` can create templating errors. I
        Conditional statements in playbooks
    :ref:`playbooks_variables`
        All about variables
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/playbook_guide/playbooks_reuse.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_reuse.rst
@@ -220,5 +220,5 @@ Imports are processed before the play begins, so the name of the import no longe
        Tips and tricks for playbooks
    :ref:`ansible_galaxy`
        How to share roles on galaxy, role management
-   `Mailing List <https://groups.google.com/group/ansible-project>`_
-       Questions? Help? Ideas?  Stop by the list on Google Groups
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
@@ -760,5 +760,5 @@ Read the `Ansible Galaxy documentation <https://ansible.readthedocs.io/projects/
        Browse existing collections, modules, and plugins
    :ref:`developing_modules`
        Extending Ansible by writing your own modules
-   `Mailing List <https://groups.google.com/group/ansible-project>`_
-       Questions? Help? Ideas?  Stop by the list on Google Groups
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/playbook_guide/playbooks_strategies.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_strategies.rst
@@ -248,7 +248,5 @@ As always with :ref:`delegation <playbooks_delegation>`, the action will be exec
        Running tasks on or assigning facts to specific machines
    :ref:`playbooks_reuse_roles`
        Playbook organization by roles
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/playbook_guide/playbooks_tags.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_tags.rst
@@ -479,7 +479,5 @@ If you run or skip certain tags by default, you can use the :ref:`TAGS_RUN` and 
        An introduction to playbooks
    :ref:`playbooks_reuse_roles`
        Playbook organization by roles
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/playbook_guide/playbooks_templating.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_templating.rst
@@ -61,7 +61,5 @@ Our test.j2:
        Tips and tricks for playbooks
    `Jinja2 Docs <https://jinja.palletsprojects.com/en/latest/templates/>`_
       Jinja2 documentation, includes the syntax and semantics of the templates
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/playbook_guide/playbooks_tests.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_tests.rst
@@ -536,7 +536,5 @@ When looking to determine types, it may be tempting to use the ``type_debug`` fi
        Playbook organization by roles
    :ref:`tips_and_tricks`
        Tips and tricks for playbooks
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/playbook_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_variables.rst
@@ -592,7 +592,5 @@ For information about advanced YAML syntax used to declare variables and have mo
        Tips and tricks for playbooks
    :ref:`special_variables`
        List of special variables
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/plugins/action.rst
+++ b/docs/docsite/rst/plugins/action.rst
@@ -49,7 +49,5 @@ Use ``ansible-doc <name>`` to see plugin-specific documentation and examples. Th
        Strategy plugins
    :ref:`vars_plugins`
        Vars plugins
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/plugins/connection.rst
+++ b/docs/docsite/rst/plugins/connection.rst
@@ -64,7 +64,5 @@ Use ``ansible-doc -t connection <plugin name>`` to see plugin-specific documenta
        Lookup plugins
    :ref:`vars_plugins`
        Vars plugins
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/plugins/docs_fragment.rst
+++ b/docs/docsite/rst/plugins/docs_fragment.rst
@@ -29,7 +29,5 @@ Only collection developers and maintainers use docs fragments. For more informat
        An introduction to creating Ansible modules
    :ref:`developing_collections`
        A guide to creating Ansible collections
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/plugins/filter.rst
+++ b/docs/docsite/rst/plugins/filter.rst
@@ -57,7 +57,5 @@ You can use ``ansible-doc -t filter -l`` to see the list of available plugins. U
       Test plugins
    :ref:`lookup_plugins`
        Lookup plugins
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/plugins/httpapi.rst
+++ b/docs/docsite/rst/plugins/httpapi.rst
@@ -68,7 +68,5 @@ Use ``ansible-doc -t httpapi <plugin name>`` to see plugin-specific documentatio
        An overview of using Ansible to automate networking devices.
    :ref:`Developing network modules<developing_modules_network>`
        How to develop network modules.
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible-network IRC chat channel
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/plugins/inventory.rst
+++ b/docs/docsite/rst/plugins/inventory.rst
@@ -184,7 +184,5 @@ Use ``ansible-doc -t inventory <plugin name>`` to see plugin-specific documentat
        Lookup plugins
    :ref:`vars_plugins`
        Vars plugins
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/plugins/lookup.rst
+++ b/docs/docsite/rst/plugins/lookup.rst
@@ -161,7 +161,5 @@ You can use ``ansible-doc -t lookup -l`` to see the list of available plugins. U
        Jinja2 filter plugins
    :ref:`test_plugins`
        Jinja2 test plugins
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/plugins/module.rst
+++ b/docs/docsite/rst/plugins/module.rst
@@ -37,7 +37,5 @@ For information on using modules in ad hoc tasks, see :ref:`intro_adhoc`. For in
        An introduction to creating Ansible modules
    :ref:`developing_collections`
        A guide to creating Ansible collections
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible-devel IRC chat channel
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/plugins/module_util.rst
+++ b/docs/docsite/rst/plugins/module_util.rst
@@ -29,7 +29,5 @@ For information on using module utilities, see :ref:`developing_module_utilities
        An introduction to creating Ansible modules
    :ref:`developing_collections`
        A guide to creating Ansible collections
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible-devel IRC chat channel
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/plugins/netconf.rst
+++ b/docs/docsite/rst/plugins/netconf.rst
@@ -43,7 +43,5 @@ Use ``ansible-doc -t netconf <plugin name>`` to see plugin-specific documentatio
 
    :ref:`Ansible for Network Automation<network_guide>`
        An overview of using Ansible to automate networking devices.
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible-network IRC chat channel
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/plugins/plugins.rst
+++ b/docs/docsite/rst/plugins/plugins.rst
@@ -42,7 +42,5 @@ This section covers the various types of plugins that are included with Ansible:
        Ansible configuration documentation and settings
    :ref:`command_line_tools`
        Ansible tools, description and options
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/plugins/shell.rst
+++ b/docs/docsite/rst/plugins/shell.rst
@@ -52,7 +52,5 @@ You can use ``ansible-doc -t shell -l`` to see the list of available plugins. Us
        Test plugins
    :ref:`lookup_plugins`
        Lookup plugins
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/plugins/strategy.rst
+++ b/docs/docsite/rst/plugins/strategy.rst
@@ -80,7 +80,5 @@ Use ``ansible-doc -t strategy <plugin name>`` to see plugin-specific documentati
        Test plugins
    :ref:`lookup_plugins`
        Lookup plugins
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/plugins/terminal.rst
+++ b/docs/docsite/rst/plugins/terminal.rst
@@ -36,7 +36,5 @@ Plugins are self-documenting. Each plugin should document its configuration opti
        An overview of using Ansible to automate networking devices.
    :ref:`connection_plugins`
        Connection plugins
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible-network IRC chat channel
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/plugins/test.rst
+++ b/docs/docsite/rst/plugins/test.rst
@@ -94,7 +94,5 @@ You can use ``ansible-doc -t test -l`` to see the list of available plugins. Use
        Using tests
    :ref:`lookup_plugins`
        Lookup plugins
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/plugins/vars.rst
+++ b/docs/docsite/rst/plugins/vars.rst
@@ -61,7 +61,5 @@ You can use ``ansible-doc -t vars -l`` to see the list of available vars plugins
        Cache plugins
    :ref:`lookup_plugins`
        Lookup plugins
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/reference_appendices/YAMLSyntax.rst
+++ b/docs/docsite/rst/reference_appendices/YAMLSyntax.rst
@@ -272,12 +272,10 @@ value:
        YAML Lint (online) helps you debug YAML syntax if you are having problems
    `Wikipedia YAML syntax reference <https://en.wikipedia.org/wiki/YAML>`_
        A good guide to YAML syntax
-   `Mailing List <https://groups.google.com/group/ansible-project>`_
-       Questions? Help? Ideas?  Stop by the list on Google Groups
-   :ref:`communication_irc`
-       How to join Ansible chat channels (join #yaml for yaml-specific questions)
    `YAML 1.1 Specification <https://yaml.org/spec/1.1/>`_
        The Specification for YAML 1.1, which PyYAML and libyaml are currently
        implementing
    `YAML 1.2 Specification <https://yaml.org/spec/1.2/spec.html>`_
        For completeness, YAML 1.2 is the successor of 1.1
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/reference_appendices/common_return_values.rst
+++ b/docs/docsite/rst/reference_appendices/common_return_values.rst
@@ -245,7 +245,5 @@ This key contains a list of dictionaries that will be presented to the user. Key
        Browse existing collections, modules, and plugins
    `GitHub modules directory <https://github.com/ansible/ansible/tree/devel/lib/ansible/modules>`_
        Browse source of core and extras modules
-   `Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Development mailing list
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -943,7 +943,7 @@ Though, if you do not override the ``shell`` module, you can also just write it 
 I don't see my question here
 ++++++++++++++++++++++++++++
 
-If you have not found an answer to your questions, you can ask on one of our mailing lists or chat channels. For instructions on subscribing to a list or joining a chat channel, see :ref:`communication`.
+If you have not found an answer to your questions, ask the community! Visit the :ref:`Ansible communication guide<communication>` for details.
 
 .. seealso::
 
@@ -951,5 +951,5 @@ If you have not found an answer to your questions, you can ask on one of our mai
        An introduction to playbooks
    :ref:`playbooks_best_practices`
        Tips and tricks for playbooks
-   `User Mailing List <https://groups.google.com/group/ansible-project>`_
-       Have a question?  Stop by the Google group!
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/reference_appendices/glossary.rst
+++ b/docs/docsite/rst/reference_appendices/glossary.rst
@@ -5,7 +5,7 @@ The following is a list (and re-explanation) of term definitions used elsewhere 
 
 Consult the documentation home page for the full documentation and to see the terms in context, but this should be a good resource
 to check your knowledge of Ansible's components and understand how they fit together.  It is something you might wish to read for review or
-when a term comes up on the mailing list.
+when a term comes up on the :ref:`Ansible Forum<ansible_forum>`.
 
 .. glossary::
 
@@ -534,7 +534,5 @@ when a term comes up on the mailing list.
        An introduction to playbooks
    :ref:`playbooks_best_practices`
        Tips and tricks for playbooks
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -430,7 +430,5 @@ The deprecation cycle in ``ansible-core`` is normally across 4 feature releases 
        Testing strategies
    :ref:`ansible_community_guide`
        Community information and contributing
-   `Development Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Mailing list for development topics
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/reference_appendices/test_strategies.rst
+++ b/docs/docsite/rst/reference_appendices/test_strategies.rst
@@ -297,7 +297,5 @@ system.
        An introduction to playbooks
    :ref:`playbooks_delegation`
        Delegation, useful for working with load balancers, clouds, and locally executed steps.
-   `User Mailing List <https://groups.google.com/group/ansible-project>`_
-       Have a question?  Stop by the Google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/roadmap/COLLECTIONS_11.rst
+++ b/docs/docsite/rst/roadmap/COLLECTIONS_11.rst
@@ -84,5 +84,9 @@ Ansible 11.x minor releases may contain new features (including new collections)
     We will not provide bugfixes or security fixes for collections that do not
     provide updates for their major release cycle included in Ansible 11.
 
+Communication
+=============
 
-For more information, reach out on a mailing list or a chat channel - see :ref:`communication` for more details.
+You can submit feedback on the current roadmap by creating a :ref:`community topic<creating_community_topic>`.
+
+Visit the :ref:`Ansible communication guide<communication>` for details on how to join and use Ansible communication platforms.

--- a/docs/docsite/rst/roadmap/ansible_core_roadmap_index.rst
+++ b/docs/docsite/rst/roadmap/ansible_core_roadmap_index.rst
@@ -12,12 +12,7 @@ Each roadmap offers a *best guess*, based on the ``ansible-core`` team's experie
 
 Each roadmap is published both as an idea of what is upcoming in ``ansible-core``, and as a medium for seeking further feedback from the community.
 
-You can submit feedback on the current roadmap in multiple ways:
-
-- Post on the ``#ansible-devel`` chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_)
-- Email the ansible-devel list
-
-See :ref:`Ansible communication channels <communication>` for details on how to join and use the email lists and chat channels.
+You can submit feedback on the current roadmap by creating a topic on the :ref:`Ansible Forum<ansible_forum>` tagged with ``ansible-core``.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/docsite/rst/roadmap/ansible_roadmap_index.rst
+++ b/docs/docsite/rst/roadmap/ansible_roadmap_index.rst
@@ -12,12 +12,9 @@ Each roadmap offers a *best guess*, based on the Ansible team's experience and o
 
 Each roadmap is published both as an idea of what is upcoming in Ansible, and as a medium for seeking further feedback from the community.
 
-You can submit feedback on the current roadmap in multiple ways:
+You can submit feedback on the current roadmap by creating a :ref:`community topic<creating_community_topic>`.
 
-- Edit the agenda of an `Ansible Community Meeting <https://github.com/ansible/community/issues/539>`_ (preferred)
-- Post on the ``#ansible-community`` chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_)
-
-See :ref:`Ansible communication channels <communication>` for details on how to join and use our chat channels.
+Visit the :ref:`Ansible communication guide<communication>` for details on how to join and use Ansible communication platforms.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
+++ b/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
@@ -206,5 +206,5 @@ This pulls in variables from the `group_vars/os_CentOS.yml` file.
        Learn how to extend Ansible by writing your own modules
    :ref:`intro_patterns`
        Learn about how to select hosts
-   `Mailing List <https://groups.google.com/group/ansible-project>`_
-       Questions? Help? Ideas?  Stop by the list on Google Groups
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide

--- a/docs/docsite/rst/tips_tricks/sample_setup.rst
+++ b/docs/docsite/rst/tips_tricks/sample_setup.rst
@@ -289,5 +289,5 @@ If a playbook has a :file:`./library` directory relative to its YAML file, you c
        Learn how to extend Ansible by writing your own modules
    :ref:`intro_patterns`
        Learn about how to select hosts
-   `Mailing List <https://groups.google.com/group/ansible-project>`_
-       Questions? Help? Ideas?  Stop by the list on Google Groups
+   :ref:`Communication<communication>`
+       Got questions? Need help? Want to share your ideas? Visit the Ansible communication guide


### PR DESCRIPTION
Replace old communication refs with Communication guide ref or forum, part 2