### PR TITLE
Nightly builds for package docs publishing workflow

### DIFF
--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -2,6 +2,8 @@
 
 name: Ansible package docs build
 on:
+  schedule:
+    - cron: '17 5 * * *'
   workflow_dispatch:
     inputs:
       repository-owner:

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -3,7 +3,7 @@
 name: Ansible package docs build
 on:
   schedule:
-    - cron: '17 5 * * *'
+    - cron: '17 5 * * *' # Run at 05:17 am
   workflow_dispatch:
     inputs:
       repository-owner:


### PR DESCRIPTION
Related to https://github.com/ansible/ansible-documentation/pull/1663 and https://github.com/ansible/ansible-documentation/pull/1683

Also follows up on https://github.com/ansible/ansible-documentation/pull/1814

Thanks to @x1101 for helping fix things by adding default values for inputs. And thanks to @gotmax23 for suggestions to improve the check-deploy job that avoids failures on scheduled runs.