### PR TITLE
remove old ad

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -217,7 +217,6 @@ html_show_sphinx = False
 
 html_theme_options = {
     'canonical_url': "https://docs.ansible.com/ansible/latest/",
- #   'hubspot_id': '330046',
     'satellite_tracking': True,
     'show_extranav': True,
     'swift_id': 'yABGvz2N8PwcwBxyfzUc',

--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -217,7 +217,7 @@ html_show_sphinx = False
 
 html_theme_options = {
     'canonical_url': "https://docs.ansible.com/ansible/latest/",
-    'hubspot_id': '330046',
+ #   'hubspot_id': '330046',
     'satellite_tracking': True,
     'show_extranav': True,
     'swift_id': 'yABGvz2N8PwcwBxyfzUc',


### PR DESCRIPTION
The Ad at the bottom left of docs pages stopped working when ansible.com was revamped, so ...time to remove it!