### PR TITLE
clone-core: update clone core script to remove old files

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -136,7 +136,7 @@ def clone_core(session: nox.Session):
     Clone relevant portions of ansible-core from ansible/ansible into the current
     source tree to facilitate building docs.
     """
-    session.run_always("python", "docs/bin/clone-core.py")
+    session.run_always("python", "docs/bin/clone-core.py", *session.posargs)
 
 
 checker_tests = [


### PR DESCRIPTION
See the linked issue. The lingering setup.py and setup.cfg files from
older versions of ansible-core were breaking a local user's doc build.
The clone-core script should automatically remove these.

Relates: https://github.com/ansible/ansible/issues/83937