### PR TITLE
adds detail for running an ad hoc command to gather facts

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_vars_facts.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_vars_facts.rst
@@ -20,7 +20,7 @@ Ansible facts are data related to your remote systems, including operating syste
       ansible.builtin.debug:
         var: ansible_facts
 
-To see the 'raw' information as gathered, run this command at the command line:
+If you have already created an :ref:`inventory<get_started_inventory>` and configured working SSH credentials, you can see the 'raw' information for any host in your inventory by running this :ref:`ad-hoc ansible command<intro_adhoc>` at the command line:
 
 .. code-block:: shell
 


### PR DESCRIPTION
Closes #1850.

First draft. I hope this PR will help people who are frustrated that `ansible <hostname> -m ansible.builtin.setup` doesn't "just work" out of the box.

- Adds links to the inventory getting started page and the ad-hoc commands intro.
- Mentions creating an inventory and configuring SSH connections as pre-requisites for running the `setup` module to gather facts.