### PR TITLE
[stable-2.14] ci: avoid interpolating inputs into run: scripts (#740)

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -53,12 +53,14 @@ jobs:
         env:
           event_json: "${{ toJSON(github.event) }}"
           GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}
-        run:
-          ./venv/bin/python hacking/pr_labeler/label.py issue ${{ github.event.issue.number || inputs.number }}
+          number: "${{ github.event.issue.number || inputs.number }}"
+        run: |
+          ./venv/bin/python hacking/pr_labeler/label.py issue "${number}"
       - name: "Run the PR labeler"
         if: "github.event.pull_request || inputs.type == 'pr'"
         env:
           event_json: "${{ toJSON(github.event) }}"
           GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}
-        run:
-          ./venv/bin/python hacking/pr_labeler/label.py pr ${{ github.event.number || inputs.number }}
+          number: "${{ github.event.number || inputs.number }}"
+        run: |
+          ./venv/bin/python hacking/pr_labeler/label.py pr "${number}"


### PR DESCRIPTION
Github Actions makes it easy to inject arbitrary shell code into Github Actions scripts thanks to the way its templating language works. This change mediates that issue by passing action inputs to the `run:` scripts as env vars instead of using `${{ }}` expansions directly in the script bodies.

The pr_labeler job is the only one that both runs on pull requests and has access to secrets, but we don't interpolate anything other than `github.event.number`, so that wouldn't allow any malicious person to steal credentials.
reusable-pip-compile has access to secrets and accepts user input, but only from trusted sources (i.e., developers who already have write access to this repository) and can manually trigger workflows. Still, it's a good to tighten this up.

(cherry picked from commit 5ebf9f1686650f90caf2e7b775ed3ad2d876ee9f) (cherry picked from commit 7d810c6c3304618762c238421a0cea593dd74a3a)