### PR TITLE
[DO NOT MERGE] Test antsibull-docs/pull/333 in CI

### DIFF
--- a/tests/constraints.in
+++ b/tests/constraints.in
@@ -2,4 +2,4 @@
 # and antsibull-docs that production builds rely upon.
 
 sphinx == 7.2.5
-antsibull-docs == 2.14.0  # currently approved version
+antsibull-docs @ https://github.com/felixfontein/antsibull-docs/archive/refs/heads/pydantic-2.tar.gz

--- a/tests/constraints.in
+++ b/tests/constraints.in
@@ -3,3 +3,4 @@
 
 sphinx == 7.2.5
 antsibull-docs @ https://github.com/felixfontein/antsibull-docs/archive/refs/heads/pydantic-2.tar.gz
+antsibull-core @ https://github.com/ansible-community/antsibull-core/archive/refs/heads/main.tar.gz

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -26,8 +26,10 @@ ansible-pygments==0.1.1
     #   sphinx-ansible-theme
 antsibull-changelog==0.30.0
     # via antsibull-docs
-antsibull-core==3.1.0
-    # via antsibull-docs
+antsibull-core @ https://github.com/ansible-community/antsibull-core/archive/refs/heads/main.tar.gz
+    # via
+    #   -c tests/constraints.in
+    #   antsibull-docs
 antsibull-docs @ https://github.com/felixfontein/antsibull-docs/archive/refs/heads/pydantic-2.tar.gz
     # via
     #   -c tests/constraints.in

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -28,7 +28,7 @@ antsibull-changelog==0.30.0
     # via antsibull-docs
 antsibull-core==3.1.0
     # via antsibull-docs
-antsibull-docs==2.14.0
+antsibull-docs @ https://github.com/felixfontein/antsibull-docs/archive/refs/heads/pydantic-2.tar.gz
     # via
     #   -c tests/constraints.in
     #   -r tests/requirements-relaxed.in


### PR DESCRIPTION
This is to test a build against https://github.com/ansible-community/antsibull-docs/pull/333. We are working on updating the version of pydantic, the library used to validate ansible-doc module/plugin doc schemas, that antsibull-documentation uses.