### PR TITLE
getting_started_ee/build_execution_environment.rst: temporary sample fix

### DIFF
--- a/docs/docsite/rst/getting_started_ee/build_execution_environment.rst
+++ b/docs/docsite/rst/getting_started_ee/build_execution_environment.rst
@@ -16,12 +16,31 @@ To build your first EE:
 
 #. Create a ``execution-environment.yml`` file that specifies dependencies to include in the image.
 
-   .. literalinclude:: yaml/execution-environment.yml
-      :language: yaml
+   .. code-block:: yaml
 
-    > The `psycopg2-binary` Python package is included in the `requirements.txt` file for the collection.
-    > For collections that do not include `requirements.txt` files, you need to specify Python dependencies explicitly.
-    > See the `Ansible Builder documentation <https://ansible-builder.readthedocs.io/en/stable/definition/>`_ for details.
+      version: 3
+
+      images:
+        base_image:
+          name: quay.io/fedora/fedora:latest
+
+      dependencies:
+        ansible_core:
+          package_pip: ansible-core
+        ansible_runner:
+          package_pip: ansible-runner
+        system:
+        - openssh-clients
+        - sshpass
+        galaxy:
+          collections:
+          - name: community.postgresql
+
+   .. note::
+
+     The `psycopg2-binary` Python package is included in the `requirements.txt` file for the collection.
+     For collections that do not include `requirements.txt` files, you need to specify Python dependencies explicitly.
+     See the `Ansible Builder documentation <https://ansible-builder.readthedocs.io/en/stable/definition/>`_ for details.
 
 #. Build a EE container image called ``postgresql_ee``.
 


### PR DESCRIPTION
in docs/docsite/rst/getting_started_ee/build_execution_environment.rst (see [the PR](https://github.com/ansible/ansible-documentation/pull/1852/files))
the part doesn't work: the file content isn't shown as was reported in https://forum.ansible.com/t/building-custom-ee-from-the-doco/8679/3
```
#. Create a ``execution-environment.yml`` file that specifies dependencies to include in the image.

   .. literalinclude:: yaml/execution-environment.yml
      :language: yaml

    > The `psycopg2-binary` Python package is included in the `requirements.txt` file for the collection.
    > For collections that do not include `requirements.txt` files, you need to specify Python dependencies explicitly.
    > See the `Ansible Builder documentation <https://ansible-builder.readthedocs.io/en/stable/definition/>`_ for details.
```
This is a temporary fix.