### PR TITLE
playbooks_filters: Mention the usage of the ansible.builtin.split filter

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_filters.rst
@@ -116,9 +116,6 @@ If you are unsure of the underlying Python type of a variable, you can use the :
 
 You should note that, while this may seem like a useful filter for checking that you have the right type of data in a variable, you should often prefer :ref:`type tests <type_tests>`, which will allow you to test for specific data types.
 
-.. _dict_filter:
-
-
 Transforming strings into lists
 -------------------------------
 
@@ -141,6 +138,8 @@ List data (after applying the :ansplugin:`ansible.builtin.split#filter` filter):
     - apple
     - banana
     - orange
+
+.. _dict_filter:
 
 Transforming dictionaries into lists
 ------------------------------------

--- a/docs/docsite/rst/playbook_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_filters.rst
@@ -123,7 +123,7 @@ Use the :ansplugin:`ansible.builtin.split#filter` filter to transform a characte
 
 .. code-block:: yaml+jinja
 
-    {{ string | split(string) }}
+    {{ string | split(',') }}
 
 String data (before applying the :ansplugin:`ansible.builtin.split#filter` filter):
 

--- a/docs/docsite/rst/playbook_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_filters.rst
@@ -119,7 +119,7 @@ You should note that, while this may seem like a useful filter for checking that
 Transforming strings into lists
 -------------------------------
 
-Use the :ansplugin:`ansible.builtin.split#filter` filter to transform a character/string delimited string into a list of items suitable for :ref:`looping <playbooks_loops>`:
+Use the :ansplugin:`ansible.builtin.split#filter` filter to transform a character/string delimited string into a list of items suitable for :ref:`looping <playbooks_loops>`. For example, if you want to split a string variable `fruits` by commas, you can use:
 
 .. code-block:: yaml+jinja
 

--- a/docs/docsite/rst/playbook_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_filters.rst
@@ -123,13 +123,13 @@ Use the :ansplugin:`ansible.builtin.split#filter` filter to transform a characte
 
 .. code-block:: yaml+jinja
 
-    {{ string | split(',') }}
+    {{ fruits | split(',') }}
 
 String data (before applying the :ansplugin:`ansible.builtin.split#filter` filter):
 
 .. code-block:: yaml
 
-    apple,banana,orange
+    fruits: apple,banana,orange
 
 List data (after applying the :ansplugin:`ansible.builtin.split#filter` filter):
 

--- a/docs/docsite/rst/playbook_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_filters.rst
@@ -120,7 +120,7 @@ You should note that, while this may seem like a useful filter for checking that
 
 
 Transforming strings into lists
-------------------------------------
+-------------------------------
 
 Use the :ansplugin:`ansible.builtin.split#filter` filter to transform a character/string delimited string into a list of items suitable for :ref:`looping <playbooks_loops>`:
 

--- a/docs/docsite/rst/playbook_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_filters.rst
@@ -118,6 +118,30 @@ You should note that, while this may seem like a useful filter for checking that
 
 .. _dict_filter:
 
+
+Transforming strings into lists
+------------------------------------
+
+Use the :ansplugin:`ansible.builtin.split#filter` filter to transform a character/string delimited string into a list of items suitable for :ref:`looping <playbooks_loops>`:
+
+.. code-block:: yaml+jinja
+
+    {{ string | split(string) }}
+
+String data (before applying the :ansplugin:`ansible.builtin.split#filter` filter):
+
+.. code-block:: yaml
+
+    apple,banana,orange
+
+List data (after applying the :ansplugin:`ansible.builtin.split#filter` filter):
+
+.. code-block:: yaml
+
+    - apple
+    - banana
+    - orange
+
 Transforming dictionaries into lists
 ------------------------------------
 


### PR DESCRIPTION
This is a filter I frequently used in my project, it should mentioned in the documentation so that it can be easily recognized by users.

Fixes #1928.