### PR TITLE
fix 2.18 python requirement version

### DIFF
--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -169,7 +169,7 @@ Dates listed indicate the start date of the maintenance cycle.
        | Critical: 19 May 2025
        | Security: 03 Nov 2025
      - May 2026
-     - | Python 3.10 - 3.13
+     - | Python 3.11 - 3.13
      - | Python 3.8 - 3.13
        | PowerShell 5.1
    * - `2.17`_


### PR DESCRIPTION
According to https://github.com/ansible/ansible/pull/83221, the minimum version of Python on the control node of ansible-core 2.18 is now 3.11.
