### PR TITLE
[stable-2.15] nox pip-compile: support check mode

### DIFF
--- a/.github/workflows/reusable-nox.yml
+++ b/.github/workflows/reusable-nox.yml
@@ -11,6 +11,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Inputs:
+          #   session: name of session
+          #   python-versions: comma-separated list of Python versions to install
+          #   extra-args (optional): extra arguments to pass to nox session.
           - session: static
             python-versions: "3.11"
           - session: formatters_check
@@ -23,6 +27,9 @@ jobs:
             python-versions: "3.11"
           - session: "checkers(docs-build)"
             python-versions: "3.11"
+          - session: "pip-compile"
+            extra-args: "--check"
+            python-versions: "3.10"
     name: "Run nox ${{ matrix.session }} session"
     steps:
       - name: Check out repo
@@ -36,4 +43,6 @@ jobs:
           nox -e clone-core
       - name: "Run nox -e ${{ matrix.session }}"
         run: |
-          nox -e "${{ matrix.session }}"
+          # Using GHA expression interpolation is fine here,
+          # as we control all the inputs.
+          nox -e "${{ matrix.session }}" -- ${{ matrix.extra-args }}


### PR DESCRIPTION
Support a custom --check flag to fail if pip-compile made any changes so we can check that that lockfiles are in sync with the input (.in) files.

(cherry picked from commit cb295b1f782bbb0b02af2801b3d0c2337b9a7912)