### PR TITLE
Pip compile check mode

### DIFF
--- a/.github/workflows/pip-compile-dev.yml
+++ b/.github/workflows/pip-compile-dev.yml
@@ -12,13 +12,6 @@ name: "Refresh dev dependencies"
       labels:
         required: false
         type: string
-  push:
-    branches:
-      - devel
-    paths:
-      - .github/workflows/reusable-pip-compile.yml
-      - ".github/workflows/pip-compile-dev.yml"
-      - "tests/*.in"
 
 jobs:
   refresh:

--- a/.github/workflows/pip-compile-docs.yml
+++ b/.github/workflows/pip-compile-docs.yml
@@ -18,13 +18,6 @@ name: "Refresh docs build dependencies"
       labels:
         required: false
         type: string
-  push:
-    branches:
-      - devel
-    paths:
-      - .github/workflows/reusable-pip-compile.yml
-      - ".github/workflows/pip-compile-docs.yml"
-      - "tests/*.in"
 
 jobs:
   refresh:

--- a/.github/workflows/reusable-nox.yml
+++ b/.github/workflows/reusable-nox.yml
@@ -11,6 +11,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Inputs:
+          #   session: name of session
+          #   python-versions: comma-separated list of Python versions to install
+          #   extra-args (optional): extra arguments to pass to nox session.
           - session: static
             python-versions: "3.11"
           - session: formatters_check
@@ -25,6 +29,9 @@ jobs:
             python-versions: "3.11"
           - session: "actionlint"
             python-versions: "3.11"
+          - session: "pip-compile"
+            extra-args: "--check"
+            python-versions: "3.11"
     name: "Run nox ${{ matrix.session }} session"
     steps:
       - name: Check out repo
@@ -38,4 +45,6 @@ jobs:
           nox -e clone-core
       - name: "Run nox -e ${{ matrix.session }}"
         run: |
-          nox -e "${{ matrix.session }}"
+          # Using GHA expression interpolation is fine here,
+          # as we control all the inputs.
+          nox -e "${{ matrix.session }}" -- ${{ matrix.extra-args }}

--- a/noxfile.py
+++ b/noxfile.py
@@ -162,7 +162,14 @@ def pip_compile(session: nox.Session, req: str):
 
     # Use --upgrade by default unless a user passes -P.
     args = list(session.posargs)
-    if not any(
+
+    # Support a custom --check flag to fail if pip-compile made any changes
+    # so we can check that that lockfiles are in sync with the input (.in) files.
+    check_mode = "--check" in args
+    if check_mode:
+        # Remove from args, as pip-compile doesn't actually support --check.
+        args.remove("--check")
+    elif not any(
         arg.startswith(("-P", "--upgrade-package", "--no-upgrade")) for arg in args
     ):
         args.append("--upgrade")
@@ -175,6 +182,9 @@ def pip_compile(session: nox.Session, req: str):
         f"tests/{req}.in",
     )
     # fmt: on
+
+    if check_mode and session.run("git", "diff", "tests", silent=True, external=True):
+        session.error("Check mode: files were changed")
 
 
 @nox.session(name="clone-core")


### PR DESCRIPTION
Support a custom --check flag to fail if pip-compile made any changes so
we can check that that lockfiles are in sync with the input (.in) files on all pushes and PRs.

Then, we can also remove the push trigger from the pip-compile workflows as discussed in https://github.com/ansible/ansible-documentation/pull/1920.