### PR TITLE
Update playbooks_error_handling.rst

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_error_handling.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_error_handling.rst
@@ -116,13 +116,13 @@ You can also combine multiple conditions for failure. This task will fail if bot
       register: result
       failed_when:
         - result.rc == 0
-        - '"No such" not in result.stdout'
+        - '"No such" not in result.stderr'
 
 If you want the task to fail when only one condition is satisfied, change the ``failed_when`` definition to
 
 .. code-block:: yaml
 
-      failed_when: result.rc == 0 or "No such" not in result.stdout
+      failed_when: result.rc == 0 or "No such" not in result.stderr
 
 If you have too many conditions to fit neatly into one line, you can split it into a multi-line YAML value with ``>``.
 


### PR DESCRIPTION
Closes #1895.

Correct example so it behaves as described in the docs. The message "No such file or directory" is sent to stderr, not to stdout.