### PR TITLE
[stable-2.17] Upgrade antsibull-docs to 2.15.0 and antsibull-core to 3.3.0

### DIFF
--- a/tests/constraints.in
+++ b/tests/constraints.in
@@ -2,4 +2,4 @@
 # and antsibull-docs that production builds rely upon.
 
 sphinx == 7.2.5
-antsibull-docs == 2.14.0  # currently approved version
+antsibull-docs == 2.15.0  # currently approved version

--- a/tests/requirements-relaxed.txt
+++ b/tests/requirements-relaxed.txt
@@ -26,9 +26,9 @@ ansible-pygments==0.1.1
     #   sphinx-ansible-theme
 antsibull-changelog==0.30.0
     # via antsibull-docs
-antsibull-core==3.0.2
+antsibull-core==3.3.0
     # via antsibull-docs
-antsibull-docs==2.14.0
+antsibull-docs==2.15.0
     # via -r tests/requirements-relaxed.in
 antsibull-docs-parser==1.1.0
     # via antsibull-docs

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -26,9 +26,9 @@ ansible-pygments==0.1.1
     #   sphinx-ansible-theme
 antsibull-changelog==0.30.0
     # via antsibull-docs
-antsibull-core==3.0.2
+antsibull-core==3.3.0
     # via antsibull-docs
-antsibull-docs==2.14.0
+antsibull-docs==2.15.0
     # via
     #   -c tests/constraints.in
     #   -r tests/requirements-relaxed.in


### PR DESCRIPTION
Manual backport of #1994 to stable-2.17.