### PR TITLE
Add ecosystem_project_resources.rst document

### DIFF
--- a/docs/docsite/rst/community/advanced_index.rst
+++ b/docs/docsite/rst/community/advanced_index.rst
@@ -4,7 +4,7 @@
 Advanced Contributor Guide
 **********************************************
 
-This guide focuses on contributors who are committers, GitHub admins, or release managers.
+This guide focuses on contributors who are committers, GitHub admins, release managers, or Ansible ecosystem project developers.
 
 .. toctree::
    :maxdepth: 1
@@ -12,3 +12,4 @@ This guide focuses on contributors who are committers, GitHub admins, or release
    committer_guidelines
    release_managers
    github_admins
+   ecosystem_project_resources

--- a/docs/docsite/rst/community/ecosystem_project_resources.rst
+++ b/docs/docsite/rst/community/ecosystem_project_resources.rst
@@ -31,7 +31,7 @@ Please take a look at the `docsite <https://ansible.readthedocs.io/projects/ansi
 
 You are welcome to take the template, fill in your project-specific information, build it using `Sphinx <https://www.sphinx-doc.org/en/master/>`_, and then publish it.
 
-Even if your project is not new and already has documentation, we recommend you take a look at the template and check if there is nothing missed in documentation for your project users, contributors and maintainers.
+Even if your project is not new and already has documentation, we recommend you take a look at the template and check if there is nothing missed in documentation for your project users, contributors, and maintainers.
 
 List of community-curated projects
 ==================================

--- a/docs/docsite/rst/community/ecosystem_project_resources.rst
+++ b/docs/docsite/rst/community/ecosystem_project_resources.rst
@@ -22,7 +22,7 @@ Despite being originally developed for Ansible ecosystem projects under the ``an
 Project template
 ================
 
-The `Ansible project-template <https://github.com/ansible-community/project-template>`_ is a GitHub repository template for Ansible ecosystem projects. It contains:
+The `Ansible project-template <https://github.com/ansible-community/project-template>`_ is a GitHub repository template for Ansible ecosystem projects that contains:
 
 * files normally present in every repository like README, license- and code-of-conduct-related ones, and others
 * a docsite template for your project you are encouraged to use to provide a consistent experience to users and contributors across Ansible ecosystem projects.

--- a/docs/docsite/rst/community/ecosystem_project_resources.rst
+++ b/docs/docsite/rst/community/ecosystem_project_resources.rst
@@ -36,6 +36,6 @@ Even if your project is not new and already has documentation, we recommend you 
 List of community-curated projects
 ==================================
 
-Whether your project repository is under the ansible-community GitHub organization or under your own one, you are welcome to include your project in the `Awesome Ansible list <https://github.com/ansible-community/awesome-ansible/blob/main/README.md>`_.
+Whether your project repository is under the ``ansible-community`` GitHub organization or under your own one, you are welcome to include your project in the `Awesome Ansible list <https://github.com/ansible-community/awesome-ansible/blob/main/README.md>`_.
 
 Before letting the community know about your shiny project by adding it to the list, make sure it satisfies the standards explained in the :ref:`onboarding_toolkit` to provide the best user and contributor experience.

--- a/docs/docsite/rst/community/ecosystem_project_resources.rst
+++ b/docs/docsite/rst/community/ecosystem_project_resources.rst
@@ -22,7 +22,7 @@ Despite being originally developed for Ansible ecosystem projects under the ansi
 Project template
 ================
 
-The `Ansible project-template<https://github.com/ansible-community/project-template>`_ is a GitHub repository template for Ansible ecosystem projects. It contains:
+The `Ansible project-template <https://github.com/ansible-community/project-template>`_ is a GitHub repository template for Ansible ecosystem projects. It contains:
 
 * files normally present in every repository like README, license- and code-of-conduct-related ones, and others
 * a docsite template for your project you are encouraged to use to provide a consistent experience to users and contributors across Ansible ecosystem projects.

--- a/docs/docsite/rst/community/ecosystem_project_resources.rst
+++ b/docs/docsite/rst/community/ecosystem_project_resources.rst
@@ -4,7 +4,7 @@
 Ansible Ecosystem Project Development Resources
 ***********************************************
 
-This document lists resources that aim to help contributors interested in developing a community project of the `Ansible ecosystem <https://docs.ansible.com/ecosystem.html>`_.
+This document lists resources to help contributors interested in developing a community project in the `Ansible ecosystem <https://docs.ansible.com/ecosystem.html>`_.
 
 .. note::
 

--- a/docs/docsite/rst/community/ecosystem_project_resources.rst
+++ b/docs/docsite/rst/community/ecosystem_project_resources.rst
@@ -29,7 +29,7 @@ The `Ansible project-template <https://github.com/ansible-community/project-temp
 
 Please take a look at the `docsite <https://ansible.readthedocs.io/projects/ansible-project-template/en/latest/>`_ built from the project-template to see it in action.
 
-You are welcome to take the template, fill it up with your project-specific information, build it using `Sphinx <https://www.sphinx-doc.org/en/master/>`_ and publish it.
+You are welcome to take the template, fill in your project-specific information, build it using `Sphinx <https://www.sphinx-doc.org/en/master/>`_, and then publish it.
 
 Even if your project is not new and already has documentation, we recommend you take a look at the template and check if there is nothing missed in documentation for your project users, contributors and maintainers.
 

--- a/docs/docsite/rst/community/ecosystem_project_resources.rst
+++ b/docs/docsite/rst/community/ecosystem_project_resources.rst
@@ -25,7 +25,7 @@ Project template
 The `Ansible project-template <https://github.com/ansible-community/project-template>`_ is a GitHub repository template for Ansible ecosystem projects that contains:
 
 * Files normally present in every repository like README, license, code of conduct, and so on.
-* a docsite template for your project you are encouraged to use to provide a consistent experience to users and contributors across Ansible ecosystem projects.
+* A docsite template that you are encouraged to use with your project to provide a consistent experience across the Ansible project ecosystem.
 
 Please take a look at the `docsite <https://ansible.readthedocs.io/projects/ansible-project-template/en/latest/>`_ built from the project-template to see it in action.
 

--- a/docs/docsite/rst/community/ecosystem_project_resources.rst
+++ b/docs/docsite/rst/community/ecosystem_project_resources.rst
@@ -24,7 +24,7 @@ Project template
 
 The `Ansible project-template <https://github.com/ansible-community/project-template>`_ is a GitHub repository template for Ansible ecosystem projects that contains:
 
-* files normally present in every repository like README, license- and code-of-conduct-related ones, and others
+* Files normally present in every repository like README, license, code of conduct, and so on.
 * a docsite template for your project you are encouraged to use to provide a consistent experience to users and contributors across Ansible ecosystem projects.
 
 Please take a look at the `docsite <https://ansible.readthedocs.io/projects/ansible-project-template/en/latest/>`_ built from the project-template to see it in action.

--- a/docs/docsite/rst/community/ecosystem_project_resources.rst
+++ b/docs/docsite/rst/community/ecosystem_project_resources.rst
@@ -31,7 +31,7 @@ Please take a look at the `docsite <https://ansible.readthedocs.io/projects/ansi
 
 You are welcome to take the template, fill in your project-specific information, build it using `Sphinx <https://www.sphinx-doc.org/en/master/>`_, and then publish it.
 
-Even if your project is not new and already has documentation, we recommend you take a look at the template and check if there is nothing missed in documentation for your project users, contributors, and maintainers.
+Even if your project is not new and already has documentation, we recommend you take a look at the template and check if there is anything missed in documentation for your project users, contributors, and maintainers.
 
 List of community-curated projects
 ==================================

--- a/docs/docsite/rst/community/ecosystem_project_resources.rst
+++ b/docs/docsite/rst/community/ecosystem_project_resources.rst
@@ -15,7 +15,7 @@ This document lists resources that aim to help contributors interested in develo
 Onboarding toolkit
 ==================
 
-The `Ansible Onboarding toolkit <https://ansible.readthedocs.io/projects/project-onboarding/en/latest/>`_ provides guidelines on the project GitHub repository setup as well as the type of documentation your project should include.
+The `Ansible Onboarding toolkit <https://ansible.readthedocs.io/projects/project-onboarding/en/latest/>`_ provides guidelines on setting up GitHub repositories for new projects as well as the type of documentation your project should include.
 
 Despite being originally developed for Ansible ecosystem projects under the ansible-community GitHub organization, everyone is welcome to use it.
 

--- a/docs/docsite/rst/community/ecosystem_project_resources.rst
+++ b/docs/docsite/rst/community/ecosystem_project_resources.rst
@@ -1,0 +1,41 @@
+.. _ecosystem_project_dev_resources:
+
+***********************************************
+Ansible Ecosystem Project Development Resources
+***********************************************
+
+This document lists resources that aim to help contributors interested in developing a community project of the `Ansible ecosystem <https://docs.ansible.com/ecosystem.html>`_.
+
+.. note::
+
+   Any improvements to the resources listed in this document or to the document itself are very welcome! Please submit a issue or pull request in a corresponding GitHub repository.
+
+.. _onboarding_toolkit:
+
+Onboarding toolkit
+==================
+
+The `Ansible Onboarding toolkit <https://ansible.readthedocs.io/projects/project-onboarding/en/latest/>`_ provides guidelines on the project GitHub repository setup as well as the type of documentation your project should include.
+
+Despite being originally developed for Ansible ecosystem projects under the ansible-community GitHub organization, everyone is welcome to use it.
+
+Project template
+================
+
+The `Ansible project-template<https://github.com/ansible-community/project-template>`_ is a GitHub repository template for Ansible ecosystem projects. It contains:
+
+* files normally present in every repository like README, license- and code-of-conduct-related ones, and others
+* a docsite template for your project you are encouraged to use to provide a consistent experience to users and contributors across Ansible ecosystem projects.
+
+Please take a look at the `docsite <https://ansible.readthedocs.io/projects/ansible-project-template/en/latest/>`_ built from the project-template to see it in action.
+
+You are welcome to take the template, fill it up with your project-specific information, build it using `Sphinx <https://www.sphinx-doc.org/en/master/>`_ and publish it.
+
+Even if your project is not new and already has documentation, we recommend you take a look at the template and check if there is nothing missed in documentation for your project users, contributors and maintainers.
+
+List of community-curated projects
+==================================
+
+Whether your project repository is under the ansible-community GitHub organization or under your own one, you are welcome to include your project in the `Awesome Ansible list <https://github.com/ansible-community/awesome-ansible/blob/main/README.md>`_.
+
+Before letting the community know about your shiny project by adding it to the list, make sure it satisfies the standards explained in the :ref:`onboarding_toolkit` to provide the best user and contributor experience.

--- a/docs/docsite/rst/community/ecosystem_project_resources.rst
+++ b/docs/docsite/rst/community/ecosystem_project_resources.rst
@@ -17,7 +17,7 @@ Onboarding toolkit
 
 The `Ansible Onboarding toolkit <https://ansible.readthedocs.io/projects/project-onboarding/en/latest/>`_ provides guidelines on setting up GitHub repositories for new projects as well as the type of documentation your project should include.
 
-Despite being originally developed for Ansible ecosystem projects under the ansible-community GitHub organization, everyone is welcome to use it.
+Despite being originally developed for Ansible ecosystem projects under the ``ansible-community`` GitHub organization, everyone is welcome to use the onboarding toolkit.
 
 Project template
 ================

--- a/docs/docsite/rst/community/ecosystem_project_resources.rst
+++ b/docs/docsite/rst/community/ecosystem_project_resources.rst
@@ -8,7 +8,7 @@ This document lists resources that aim to help contributors interested in develo
 
 .. note::
 
-   Any improvements to the resources listed in this document or to the document itself are very welcome! Please submit a issue or pull request in a corresponding GitHub repository.
+   Any improvements to the resources listed in this document or to the document itself are very welcome! Please submit an issue or pull request in the corresponding GitHub repository.
 
 .. _onboarding_toolkit:
 

--- a/docs/docsite/rst/community/ecosystem_project_resources.rst
+++ b/docs/docsite/rst/community/ecosystem_project_resources.rst
@@ -24,7 +24,7 @@ Project template
 
 The `Ansible project-template <https://github.com/ansible-community/project-template>`_ is a GitHub repository template for Ansible ecosystem projects that contains:
 
-* Files normally present in every repository like README, license, code of conduct, and so on.
+* Files normally present in every repository such as README, license, code of conduct, and so on.
 * A docsite template that you are encouraged to use with your project to provide a consistent experience across the Ansible project ecosystem.
 
 Please take a look at the `docsite <https://ansible.readthedocs.io/projects/ansible-project-template/en/latest/>`_ built from the project-template to see it in action.


### PR DESCRIPTION
Add ecosystem_project_resources.rst document that will refer to the following resources we don't currently refer to
- https://ansible.readthedocs.io/projects/project-onboarding/en/latest/onboarding_toolkit/
- https://github.com/ansible-community/project-template
- https://ansible.readthedocs.io/projects/ansible-project-template/en/latest/