### PR TITLE
keep lockfiles in sync for stable-2.16

### DIFF
--- a/tests/requirements-relaxed.txt
+++ b/tests/requirements-relaxed.txt
@@ -37,6 +37,7 @@ antsibull-docutils==1.0.0
 antsibull-fileutils==1.0.0
     # via
     #   antsibull-changelog
+    #   antsibull-core
     #   antsibull-docs
 async-timeout==4.0.3
     # via aiohttp
@@ -109,7 +110,6 @@ pyproject-hooks==1.1.0
 pyyaml==6.0.2
     # via
     #   -r tests/requirements-relaxed.in
-    #   antsibull-core
     #   antsibull-docs
     #   antsibull-fileutils
 requests==2.32.3

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -39,6 +39,7 @@ antsibull-docutils==1.0.0
 antsibull-fileutils==1.0.0
     # via
     #   antsibull-changelog
+    #   antsibull-core
     #   antsibull-docs
 async-timeout==4.0.3
     # via aiohttp
@@ -111,7 +112,6 @@ pyproject-hooks==1.1.0
 pyyaml==6.0.2
     # via
     #   -r tests/requirements-relaxed.in
-    #   antsibull-core
     #   antsibull-docs
     #   antsibull-fileutils
 requests==2.32.3


### PR DESCRIPTION
This change updates lockfiles with "nox -s pip-compile -- --no-upgrade"

Follows up on https://github.com/ansible/ansible-documentation/commit/1e296b77c15332c31bdea3d5411db56ea275ece1 which failed the pip-compile check mode test. I merged that too quickly in a late night flurry of PRs and didn't spot the broken check.