### PR TITLE
update maintainers guide to git rm build workflow

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -49,7 +49,7 @@ After creating a new stable branch, remove the appropriate files and references.
 
 ```bash
 # Remove the following workflow files, the tagger script, and tagger requirements.
-git rm -r .github/workflows/pip-compile-dev.yml .github/workflows/pip-compile-docs.yml .github/workflows/reusable-pip-compile.yml .github/workflows/tag.yml hacking/tagger tests/tag.*
+git rm -r .github/workflows/pip-compile-dev.yml .github/workflows/pip-compile-docs.yml .github/workflows/reusable-pip-compile.yml .github/workflows/tag.yml .github/workflows/build-package-docs.yaml hacking/tagger tests/tag.*
 ```
 
 Next, remove references to the tagger dependencies as follows:


### PR DESCRIPTION
This change updates the maintainers guide to include the build package docs workflow in the list of devel only tooling to remove when creating new stable branches.