### PR TITLE
add example of extending ansible_facts

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -64,6 +64,13 @@ Info and facts modules, are just like any other Ansible Module, with a few minor
 5. They MUST NOT make any changes to the system.
 6. They MUST document the :ref:`return fields<return_block>` and :ref:`examples<examples_block>`.
 
+You can add your ``*_facts`` into ``ansible_facts`` field of the result as follows:
+
+.. code-block:: python
+
+    module.exit_json(changed=False, ansible_facts=dict(new_facts))
+    
+
 The rest is just like creating a normal module.
 
 Verifying your module code

--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -64,11 +64,11 @@ Info and facts modules, are just like any other Ansible Module, with a few minor
 5. They MUST NOT make any changes to the system.
 6. They MUST document the :ref:`return fields<return_block>` and :ref:`examples<examples_block>`.
 
-You can add your ``*_facts`` into ``ansible_facts`` field of the result as follows:
+You can add your facts into ``ansible_facts`` field of the result as follows:
 
 .. code-block:: python
 
-    module.exit_json(changed=False, ansible_facts=dict(new_facts))
+    module.exit_json(changed=False, ansible_facts=dict(my_new_fact=value_of_fact))
     
 
 The rest is just like creating a normal module.


### PR DESCRIPTION
Couldn't really find this anywhere, so added it in the general module dev page where we talk about facts vs info modules.