### PR TITLE
Change 2.18 to correct version

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -44,7 +44,7 @@ assert applied_tags_count == 1, (
 
 VERSION = (
      # Controls branch version for core releases
-    'devel' if tags.has('core_lang') or tags.has('core') else
+    '2.18' if tags.has('core_lang') or tags.has('core') else
     # Controls branch version for Ansible package releases
     'devel' if tags.has('ansible') or tags.has('all')
     else '<UNKNOWN>'


### PR DESCRIPTION
Part of https://github.com/ansible/ansible-documentation/issues/2012

Sets the correct text for the core version in the top-left navigation.

Can be merged before release day.