### PR TITLE
update version switcher for 2.18

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -240,7 +240,7 @@ html_context = {
     'current_version': version,
     'latest_version': (
         'devel' if tags.has('all') else
-        '2.17' if tags.has('core_lang') or tags.has('core') else
+        '2.18' if tags.has('core_lang') or tags.has('core') else
         '10' if tags.has('ansible')
         else '<UNKNOWN>'
     ),
@@ -248,7 +248,7 @@ html_context = {
     'available_versions': (
         ('devel',) if tags.has('all') else
         ('2.15_ja', '2.14_ja', '2.13_ja',) if tags.has('core_lang') else
-        ('2.17', '2.16', '2.15', 'devel',) if tags.has('core') else
+        ('2.18', '2.17', '2.16', 'devel',) if tags.has('core') else
         ('latest', '9', '2.9', 'devel') if tags.has('ansible')
         else '<UNKNOWN>'
     ),


### PR DESCRIPTION
Part of https://github.com/ansible/ansible-documentation/issues/2012

Updates the version switcher for 2.18

DO NOT MERGE TIL RELEASE DAY