### PR TITLE
Update playbooks_error_handling.rst

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_error_handling.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_error_handling.rst
@@ -172,9 +172,30 @@ You can also combine multiple conditions to override "changed" result.
         - '"ERROR" in result.stderr'
         - result.rc == 2
 
-.. note::
+If you want to introduce your own variables, to avoid repeating a certain term, you can simply reference them in your conditionals
 
-    Just like ``when`` these two conditionals do not require templating delimiters (``{{ }}``) as they are implied.
+.. code-block:: yaml
+
+  - name: Example playbook
+    hosts: myHosts
+    vars:
+       log_path: /home/ansible/logfolder/
+       log_file: log.log
+
+   tasks:
+      - name: Create empty log file
+       ansible.builtin.shell: mkdir {{ log_path }} || touch {{log_path }}{{ log_file }}
+       register: tmp
+       changed_when:
+         - tmp.rc == 0
+         - 'tmp.stderr != "mkdir: cannot create directory ‘" ~ log_path ~ "’: File exists"'
+
+.. note::
+   Notice the missing ``{{ }}`` around log_path. 
+   
+   Just like ``when`` these two conditionals do not require templating delimiters (``{{ }}``) as they are implied.
+
+   If you still use them, ansible will raise a warning ``[WARNING]: conditional statements should not include jinja2 templating delimiters such as {{ }} or {% %}.``   
 
 See :ref:`controlling_what_defines_failure` for more conditional syntax examples.
 

--- a/docs/docsite/rst/playbook_guide/playbooks_error_handling.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_error_handling.rst
@@ -172,7 +172,7 @@ You can also combine multiple conditions to override "changed" result.
         - '"ERROR" in result.stderr'
         - result.rc == 2
 
-If you want to introduce your own variables, to avoid repeating a certain term, you can simply reference them in your conditionals
+You can reference simple variables in conditionals to avoid repeating certain terms, as in the following example:
 
 .. code-block:: yaml
 
@@ -191,11 +191,11 @@ If you want to introduce your own variables, to avoid repeating a certain term, 
          - 'tmp.stderr != "mkdir: cannot create directory ‘" ~ log_path ~ "’: File exists"'
 
 .. note::
-   Notice the missing ``{{ }}`` around log_path. 
+   Notice the missing double curly braces ``{{ }}`` around the ``log_path`` variable in the ``changed_when`` statement. 
    
-   Just like ``when`` these two conditionals do not require templating delimiters (``{{ }}``) as they are implied.
+   Just like ``when`` these two conditionals do not require templating delimiters (``{{ }}``) because they are raw Jinja2 expressions.
 
-   If you still use them, ansible will raise a warning ``[WARNING]: conditional statements should not include jinja2 templating delimiters such as {{ }} or {% %}.``   
+   If you still use them, ansible will raise a warning  that conditional statements should not include jinja2 templating delimiters.   
 
 See :ref:`controlling_what_defines_failure` for more conditional syntax examples.
 


### PR DESCRIPTION
Add example for using own variables in conditions

Related: https://forum.ansible.com/t/using-variables-in-changed-when-failed-when-directives/10652/3

From my point of view this information was not clear yet, that 
a) custom variables can be used in conditionals as well
b) the ``{{ }}`` annotation has to be avoided