### PR TITLE
Update ansible-core 2.18 and Ansible 11 porting guides

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_11.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_11.rst
@@ -637,11 +637,6 @@ Ansible-core
 - play_context - remove deprecated PlayContext.verbosity property (https://github.com/ansible/ansible/issues/82945).
 - utils/listify - remove deprecated 'loader' argument from listify_lookup_plugin_terms API (https://github.com/ansible/ansible/issues/82949).
 
-ansible.posix
-~~~~~~~~~~~~~
-
-- skippy - Remove skippy pluglin as it is no longer supported(https://github.com/ansible-collections/ansible.posix/issues/350).
-
 community.grafana
 ~~~~~~~~~~~~~~~~~
 

--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.18.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.18.rst
@@ -19,7 +19,7 @@ This document is part of a collection on porting. The complete list of porting g
 Playbook
 ========
 
-No notable changed
+No notable changes
 
 
 Command Line


### PR DESCRIPTION
Follow-up to #2101.