### PR TITLE
Rewrite precedence rules for more clarify

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_variables.rst
@@ -427,13 +427,13 @@ Ansible does apply variable precedence, and you might have a use for it. Here is
   #. role defaults (as defined in :ref:`Role directory structure <role_directory_structure>`) [1]_
   #. variables for group "all" defined inside of an inventory file or script [2]_
   #. other group vars defined inside of an inventory file or script [2]_
-  #. inventory group_vars/all (a file in the directory group_vars/ adjacent to the inventory) [3]_
-  #. playbook group_vars/all (a file in the directory group_vars/ adjacent to the playbook) [3]_
-  #. inventory group_vars/* (a file in the directory group_vars/ adjacent to the inventory) [3]_
-  #. playbook group_vars/* (a file in the directory group_vars/ adjacent to the playbook) [3]_
+  #. inventory ``group_vars/all`` (a file in the ``group_vars/`` directory that is adjacent to the inventory) [3]_
+  #. playbook ``group_vars/all`` (a file in the ``group_vars/`` directory that is adjacent to the playbook) [3]_
+  #. inventory ``group_vars/*`` (a file in the ``group_vars/`` directory that is adjacent to the inventory) [3]_
+  #. playbook ``group_vars/*`` (a file in the ``group_vars/`` directory that is adjacent to the playbook) [3]_
   #. host vars defined in an inventory file or script [2]_
-  #. inventory host_vars/* (a file in the directory host_vars/ adjacent to the inventory) [3]_
-  #. playbook host_vars/* (a file in the directory host_vars/ adjacent to the inventory) [3]_
+  #. inventory ``host_vars/*`` (a file in the ``host_vars/`` directory that is adjacent to the inventory) [3]_
+  #. playbook ``host_vars/*`` (a file in the ``host_vars/`` directory that is adjacent to the inventory) [3]_
   #. host facts / cached set_facts [4]_
   #. play vars (defined in the section vars for the play)
   #. play vars_prompt

--- a/docs/docsite/rst/playbook_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_variables.rst
@@ -199,7 +199,7 @@ You can use the `set_fact` module to combine lists into a new `merged_list` vari
       - peach
       - plum
       - pear
-    
+
     tasks:
     - name: Combine list1 and list2 into a merged_list var
       ansible.builtin.set_fact:
@@ -425,16 +425,17 @@ Ansible does apply variable precedence, and you might have a use for it. Here is
 
   #. command line values (for example, ``-u my_user``, these are not variables)
   #. role defaults (as defined in :ref:`Role directory structure <role_directory_structure>`) [1]_
-  #. inventory file or script group vars [2]_
-  #. inventory group_vars/all [3]_
-  #. playbook group_vars/all [3]_
-  #. inventory group_vars/* [3]_
-  #. playbook group_vars/* [3]_
-  #. inventory file or script host vars [2]_
-  #. inventory host_vars/* [3]_
-  #. playbook host_vars/* [3]_
+  #. variables for group "all" defined inside of an inventory file or script [2]_
+  #. other group vars defined inside of an inventory file or script [2]_
+  #. inventory group_vars/all (a file in the directory group_vars/ adjacent to the inventory) [3]_
+  #. playbook group_vars/all (a file in the directory group_vars/ adjacent to the playbook) [3]_
+  #. inventory group_vars/* (a file in the directory group_vars/ adjacent to the inventory) [3]_
+  #. playbook group_vars/* (a file in the directory group_vars/ adjacent to the playbook) [3]_
+  #. host vars defined in an inventory file or script [2]_
+  #. inventory host_vars/* (a file in the directory host_vars/ adjacent to the inventory) [3]_
+  #. playbook host_vars/* (a file in the directory host_vars/ adjacent to the inventory) [3]_
   #. host facts / cached set_facts [4]_
-  #. play vars
+  #. play vars (defined in the section vars for the play)
   #. play vars_prompt
   #. play vars_files
   #. role vars (as defined in :ref:`Role directory structure <role_directory_structure>`)
@@ -445,6 +446,8 @@ Ansible does apply variable precedence, and you might have a use for it. Here is
   #. role (and include_role) params
   #. include params
   #. extra vars (for example, ``-e "user=my_user"``)(always win precedence)
+
+If inventory file is located in the same directory as a playbook, adjacent group_vars/ are interpreted twice both as inventory group_vars/ and playbook group_vars/, therefore, getting precedence of the playbook group_vars.
 
 In general, Ansible gives precedence to variables that were defined more recently, more actively, and with more explicit scope. Variables in the defaults folder inside a role are easily overridden. Anything in the vars directory of the role overrides previous versions of that variable in the namespace. Host and/or inventory variables override role defaults, but explicit includes such as the vars directory or an ``include_vars`` task override inventory variables.
 


### PR DESCRIPTION
I found existing explanation of precedence rules a bit confusing and not giving enough information.

1. I added one more layer of precedence, 'all' vars looses to 'group-specific' variables within inventory file or script.

```
- #. inventory file or script group vars [2]_
+ #. variables for group "all" defined inside of an inventory file or script [2]_
+ #. other group vars defined inside of an inventory file or script [2]_
```

This is true and it wasn't reflected in the documentation.

Proof: For an inventory `inv.yaml`:

```
---
testgroup:
  hosts:
    test:
  vars:
    foo: testgroup

all:
  vars:
    foo: allgroup
```

Result is:
```
ansible -i inv.yaml -c local -m debug -a var=foo all
test | SUCCESS => {
    "foo": "testgroup"
}
```

2. Clarify that inventory group_vars/all is about files (notation `group_vars/all` is ambiguous and can be interpreted as group_vars.all within file, also). It also allow to understand better difference between playbook and inventory group vars.

```
-  #. inventory group_vars/all [3]_
-  #. playbook group_vars/all [3]_
-  #. inventory group_vars/* [3]_
-  #. playbook group_vars/* [3]_
+  #. inventory group_vars/all (a file in the directory group_vars/ adjacent to the inventory) [3]_
+  #. playbook group_vars/all (a file in the directory group_vars/ adjacent to the playbook) [3]_
+  #. inventory group_vars/* (a file in the directory group_vars/ adjacent to the inventory) [3]_
+  #. playbook group_vars/* (a file in the directory group_vars/ adjacent to the playbook) [3]_
```

3. Clarification for hostvars inside an inventory file.

```
-  #. inventory file or script host vars [2]_
+  #. host vars defined in an inventory file or script [2]_
```

4. Clarification for host_vars (same as for 2)

```
-  #. inventory host_vars/* [3]_
-  #. playbook host_vars/* [3]_
+  #. inventory host_vars/* (a file in the directory host_vars/ adjacent to the inventory) [3]_
+  #. playbook host_vars/* (a file in the directory host_vars/ adjacent to the inventory) [3]_
```

5. Explain 'play vars'

```
-  #. play vars
+  #. play vars (defined in the section vars for the play)
```

6. An additional clarification for the special (but very popular) case, when host_group_vars plugin scan the same `group_vars/` twice, this happens when an inventory and a playbook are in the same directory, and there is `group_vars/` directory there.

```
+If inventory file is located in the same directory as a playbook, adjacent group_vars/ are interpreted twice both as inventory group_vars/ and playbook group_vars/, therefore, getting precedence of the playbook group_vars.
+
```


There is also change for example yaml, removing trailing white spaces, done by my editor, but I think, it's correct:

```

    vars:
      list1:
      - apple
      - banana
      - fig
      list2:
      - peach
      - plum
      - pear
-
+    
    tasks:
    - name: Combine list1 and list2 into a merged_list var
      ansible.builtin.set_fact:
```

