### PR TITLE
Remove string conversion action documentation reference

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
@@ -469,11 +469,6 @@ Type: ``str``
 This argument passes the information to modules about their name. For more details see, the configuration option :ref:`DEFAULT_MODULE_NAME`.
 
 
-_ansible_string_conversion_action
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-This argument provides instructions about what modules should do after the values of the user-specified module parameters are converted to strings. For more details, see the :ref:`STRING_CONVERSION_ACTION` configuration option.
-
-
 _ansible_keep_remote_files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
`STRING_CONVERSION_ACTION` was removed in [this PR](https://github.com/ansible/ansible/pull/84245). 

Removing this reference from developing_program_flow_modules.rst