### PR TITLE
update pip compile dev workflow for 2.18

### DIFF
--- a/.github/workflows/pip-compile-dev.yml
+++ b/.github/workflows/pip-compile-dev.yml
@@ -27,6 +27,13 @@ jobs:
               'pip-compile-3.11(static)'
               'pip-compile-3.11(spelling)'
               'pip-compile-3.11(tag)'
+          - base-branch: stable-2.18
+            pr-branch: pip-compile/stable-2.18/dev
+            nox-args: >-
+              -e 'pip-compile-3.11(formatters)'
+              'pip-compile-3.11(typing)'
+              'pip-compile-3.11(static)'
+              'pip-compile-3.11(spelling)'
           - base-branch: stable-2.17
             pr-branch: pip-compile/stable-2.17/dev
             nox-args: >-
@@ -43,13 +50,6 @@ jobs:
               'pip-compile-3.10(spelling)'
           - base-branch: stable-2.15
             pr-branch: pip-compile/stable-2.15/dev
-            nox-args: >-
-              -e 'pip-compile-3.10(formatters)'
-              'pip-compile-3.10(typing)'
-              'pip-compile-3.10(static)'
-              'pip-compile-3.10(spelling)'
-          - base-branch: stable-2.14
-            pr-branch: pip-compile/stable-2.14/dev
             nox-args: >-
               -e 'pip-compile-3.10(formatters)'
               'pip-compile-3.10(typing)'

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -68,6 +68,10 @@ Next, remove references to the tagger dependencies as follows:
 
 3. Open `noxfile.py` and remove `"hacking/tagger/tag.py",` from the `LINT_FILES` tuple.
 
+### Updating the pip compile dev workflow
+
+Update the `.github/workflows/pip-compile-dev.yml` workflow so that it includes the new stable branch and drops the oldest branch.
+
 ### Update Python versions in the support matrix
 
 The minimum supported Python version changes with each Ansible core version.


### PR DESCRIPTION
Looking at the last batch of dev dependency refreshes and we're missing the stable-2.18 branch. This change fixes that.

Should we also bump the python version for the devel branch to 3.12?