### PR TITLE
Add porting guide for Ansible 11.0.0rc1

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_11.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_11.rst
@@ -169,7 +169,7 @@ community.docker
 community.general
 ~~~~~~~~~~~~~~~~~
 
-- The collection no longer supports ansible-core 2.13 and ansible-core 2.14. While most (or even all) modules and plugins might still work with these versions, they are no longer tested in CI and breakages regarding them will not be fixed (https://github.com/ansible-collections/community.general/pull/8921)."
+- The collection no longer supports ansible-core 2.13 and ansible-core 2.14. While most (or even all) modules and plugins might still work with these versions, they are no longer tested in CI and breakages regarding them will not be fixed (https://github.com/ansible-collections/community.general/pull/8921).
 - cmd_runner module utils - CLI arguments created directly from module parameters are no longer assigned a default formatter (https://github.com/ansible-collections/community.general/pull/8928).
 - irc - the defaults of ``use_tls`` and ``validate_certs`` changed from ``false`` to ``true`` (https://github.com/ansible-collections/community.general/pull/8918).
 - rhsm_repository - the states ``present`` and ``absent`` have been removed. Use ``enabled`` and ``disabled`` instead (https://github.com/ansible-collections/community.general/pull/8918).


### PR DESCRIPTION
Add porting guide for Ansible 11.0.0rc1: ansible-community/ansible-build-data#499