### PR TITLE
remove swiftype search engine

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -220,7 +220,6 @@ html_theme_options = {
     'hubspot_id': '330046',
     'satellite_tracking': True,
     'show_extranav': True,
-    'swift_id': 'yABGvz2N8PwcwBxyfzUc',
     'tag_manager_id': 'GTM-PSB293',
     'vcs_pageview_mode': 'edit'
 }


### PR DESCRIPTION
Fixes https://github.com/ansible/ansible-documentation/issues/544

(once backported :-)

Swiftype search costs us $$ and causes problems like in that issue. Let's just go back to the opensearch option that is part of the standard sphinx theme.

(trying a few extra backports on some EOL docs so we're consistent in the search experience)