### PR TITLE
fix: Remove stray reference to group_by_module

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_conditionals.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_conditionals.rst
@@ -20,7 +20,7 @@ Ansible uses Jinja2 :ref:`tests <playbooks_tests>` and :ref:`filters <playbooks_
 Basic conditionals with ``when``
 ================================
 
-The simplest conditional statement applies to a single task. Create the task, then add a ``when`` statement that applies a test. The ``when`` clause is a raw Jinja2 expression without double curly braces (see :ref:`group_by_module`). When you run the task or playbook, Ansible evaluates the test for all hosts. On any host where the test passes (returns a value of True), Ansible runs that task. For example, if you are installing mysql on multiple machines, some of which have SELinux enabled, you might have a task to configure SELinux to allow mysql to run. You would only want that task to run on machines that have SELinux enabled:
+The simplest conditional statement applies to a single task. Create the task, then add a ``when`` statement that applies a test. The ``when`` clause is a raw Jinja2 expression without double curly braces (see :ref:`jinja2_simple`). When you run the task or playbook, Ansible evaluates the test for all hosts. On any host where the test passes (returns a value of True), Ansible runs that task. For example, if you are installing mysql on multiple machines, some of which have SELinux enabled, you might have a task to configure SELinux to allow mysql to run. You would only want that task to run on machines that have SELinux enabled:
 
 .. code-block:: yaml
 

--- a/docs/docsite/rst/playbook_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_variables.rst
@@ -55,6 +55,8 @@ You can define a simple variable using standard YAML syntax. For example:
 
   remote_install_path: /opt/my_app_config
 
+.. _jinja2_simple:
+
 Referencing simple variables
 ----------------------------
 


### PR DESCRIPTION
Reference to group_by_module was substituted in where it did not make sense:  https://github.com/ansible/ansible/pull/43856

This reference is not essential.  It is already referenced indirectly, via :ref:`os_variance`.

Revert back to referencing the variables page.

Credit for fix and diagnosis: @samccann.  See issue #2077.