### PR TITLE
[stable-2.16] Update docs build dependencies, use antsibull-docs 2.16.0

### DIFF
--- a/tests/constraints.in
+++ b/tests/constraints.in
@@ -2,4 +2,4 @@
 # and antsibull-docs that production builds rely upon.
 
 sphinx == 7.1.2
-antsibull-docs == 2.15.0  # currently approved version
+antsibull-docs == 2.16.0  # currently approved version

--- a/tests/requirements-relaxed.txt
+++ b/tests/requirements-relaxed.txt
@@ -8,9 +8,9 @@ aiofiles==24.1.0
     # via
     #   antsibull-core
     #   antsibull-fileutils
-aiohappyeyeballs==2.4.0
+aiohappyeyeballs==2.4.3
     # via aiohttp
-aiohttp==3.10.5
+aiohttp==3.11.2
     # via
     #   antsibull-core
     #   antsibull-docs
@@ -24,22 +24,22 @@ ansible-pygments==0.1.1
     # via
     #   antsibull-docs
     #   sphinx-ansible-theme
-antsibull-changelog==0.30.0
+antsibull-changelog==0.31.1
     # via antsibull-docs
-antsibull-core==3.3.0
+antsibull-core==3.4.0
     # via antsibull-docs
-antsibull-docs==2.15.0
+antsibull-docs==2.16.0
     # via -r tests/requirements-relaxed.in
 antsibull-docs-parser==1.1.0
     # via antsibull-docs
 antsibull-docutils==1.0.0
     # via antsibull-changelog
-antsibull-fileutils==1.0.0
+antsibull-fileutils==1.1.0
     # via
     #   antsibull-changelog
     #   antsibull-core
     #   antsibull-docs
-async-timeout==4.0.3
+async-timeout==5.0.1
     # via aiohttp
 asyncio-pool==0.6.0
     # via antsibull-docs
@@ -49,11 +49,11 @@ babel==2.16.0
     # via
     #   sphinx
     #   sphinx-intl
-build==1.2.1
+build==1.2.2.post1
     # via antsibull-core
-certifi==2024.7.4
+certifi==2024.8.30
     # via requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
 click==8.1.7
     # via sphinx-intl
@@ -65,11 +65,11 @@ docutils==0.18.1
     #   rstcheck
     #   sphinx
     #   sphinx-rtd-theme
-frozenlist==1.4.1
+frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-idna==3.8
+idna==3.10
     # via
     #   requests
     #   yarl
@@ -80,32 +80,36 @@ jinja2==3.1.4
     #   -r tests/requirements-relaxed.in
     #   antsibull-docs
     #   sphinx
-markupsafe==2.1.5
+markupsafe==3.0.2
     # via jinja2
-multidict==6.0.5
+multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-packaging==24.1
+packaging==24.2
     # via
     #   antsibull-changelog
     #   antsibull-core
     #   antsibull-docs
     #   build
     #   sphinx
-perky==0.9.2
+perky==0.9.3
     # via antsibull-core
-pydantic==2.8.2
+propcache==0.2.0
+    # via
+    #   aiohttp
+    #   yarl
+pydantic==2.9.2
     # via
     #   antsibull-core
     #   antsibull-docs
-pydantic-core==2.20.1
+pydantic-core==2.23.4
     # via pydantic
 pygments==2.18.0
     # via
     #   ansible-pygments
     #   sphinx
-pyproject-hooks==1.1.0
+pyproject-hooks==1.2.0
     # via build
 pyyaml==6.0.2
     # via
@@ -146,11 +150,11 @@ sphinx-ansible-theme==0.10.3
     # via -r tests/requirements-relaxed.in
 sphinx-copybutton==0.5.2
     # via -r tests/requirements-relaxed.in
-sphinx-intl==2.2.0
+sphinx-intl==2.3.0
     # via -r tests/requirements-relaxed.in
 sphinx-notfound-page==1.0.4
     # via -r tests/requirements-relaxed.in
-sphinx-rtd-theme==2.0.0
+sphinx-rtd-theme==3.0.2
     # via sphinx-ansible-theme
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
@@ -166,7 +170,7 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-tomli==2.0.1
+tomli==2.1.0
     # via build
 twiggy==0.5.1
     # via
@@ -176,14 +180,15 @@ types-docutils==0.18.3
     # via rstcheck
 typing-extensions==4.12.2
     # via
+    #   multidict
     #   pydantic
     #   pydantic-core
     #   rstcheck
-urllib3==2.2.2
+urllib3==2.2.3
     # via requests
-yarl==1.9.4
+yarl==1.17.1
     # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==73.0.1
+setuptools==75.5.0
     # via sphinx-intl

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,9 +8,9 @@ aiofiles==24.1.0
     # via
     #   antsibull-core
     #   antsibull-fileutils
-aiohappyeyeballs==2.4.0
+aiohappyeyeballs==2.4.3
     # via aiohttp
-aiohttp==3.10.5
+aiohttp==3.11.2
     # via
     #   antsibull-core
     #   antsibull-docs
@@ -24,11 +24,11 @@ ansible-pygments==0.1.1
     # via
     #   antsibull-docs
     #   sphinx-ansible-theme
-antsibull-changelog==0.30.0
+antsibull-changelog==0.31.1
     # via antsibull-docs
-antsibull-core==3.3.0
+antsibull-core==3.4.0
     # via antsibull-docs
-antsibull-docs==2.15.0
+antsibull-docs==2.16.0
     # via
     #   -c tests/constraints.in
     #   -r tests/requirements-relaxed.in
@@ -36,12 +36,12 @@ antsibull-docs-parser==1.1.0
     # via antsibull-docs
 antsibull-docutils==1.0.0
     # via antsibull-changelog
-antsibull-fileutils==1.0.0
+antsibull-fileutils==1.1.0
     # via
     #   antsibull-changelog
     #   antsibull-core
     #   antsibull-docs
-async-timeout==4.0.3
+async-timeout==5.0.1
     # via aiohttp
 asyncio-pool==0.6.0
     # via antsibull-docs
@@ -51,11 +51,11 @@ babel==2.16.0
     # via
     #   sphinx
     #   sphinx-intl
-build==1.2.1
+build==1.2.2.post1
     # via antsibull-core
-certifi==2024.7.4
+certifi==2024.8.30
     # via requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
 click==8.1.7
     # via sphinx-intl
@@ -67,11 +67,11 @@ docutils==0.18.1
     #   rstcheck
     #   sphinx
     #   sphinx-rtd-theme
-frozenlist==1.4.1
+frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-idna==3.8
+idna==3.10
     # via
     #   requests
     #   yarl
@@ -82,32 +82,36 @@ jinja2==3.1.4
     #   -r tests/requirements-relaxed.in
     #   antsibull-docs
     #   sphinx
-markupsafe==2.1.5
+markupsafe==3.0.2
     # via jinja2
-multidict==6.0.5
+multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-packaging==24.1
+packaging==24.2
     # via
     #   antsibull-changelog
     #   antsibull-core
     #   antsibull-docs
     #   build
     #   sphinx
-perky==0.9.2
+perky==0.9.3
     # via antsibull-core
-pydantic==2.8.2
+propcache==0.2.0
+    # via
+    #   aiohttp
+    #   yarl
+pydantic==2.9.2
     # via
     #   antsibull-core
     #   antsibull-docs
-pydantic-core==2.20.1
+pydantic-core==2.23.4
     # via pydantic
 pygments==2.18.0
     # via
     #   ansible-pygments
     #   sphinx
-pyproject-hooks==1.1.0
+pyproject-hooks==1.2.0
     # via build
 pyyaml==6.0.2
     # via
@@ -149,11 +153,11 @@ sphinx-ansible-theme==0.10.3
     # via -r tests/requirements-relaxed.in
 sphinx-copybutton==0.5.2
     # via -r tests/requirements-relaxed.in
-sphinx-intl==2.2.0
+sphinx-intl==2.3.0
     # via -r tests/requirements-relaxed.in
 sphinx-notfound-page==1.0.4
     # via -r tests/requirements-relaxed.in
-sphinx-rtd-theme==2.0.0
+sphinx-rtd-theme==3.0.2
     # via sphinx-ansible-theme
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
@@ -169,7 +173,7 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-tomli==2.0.1
+tomli==2.1.0
     # via build
 twiggy==0.5.1
     # via
@@ -179,14 +183,15 @@ types-docutils==0.18.3
     # via rstcheck
 typing-extensions==4.12.2
     # via
+    #   multidict
     #   pydantic
     #   pydantic-core
     #   rstcheck
-urllib3==2.2.2
+urllib3==2.2.3
     # via requests
-yarl==1.9.4
+yarl==1.17.1
     # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==73.0.1
+setuptools==75.5.0
     # via sphinx-intl


### PR DESCRIPTION
See #2167.