### PR TITLE
LICENSE and DCO in CODEOWNERS for doc maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
 /docs/docsite/rst/community/collection_contributors/collection_requirements.rst @ansible/steering-committee
 /docs/docsite/rst/community/steering/* @ansible/steering-committee
 /docs/docsite/rst/roadmap/COLLECTIONS_*.rst @ansible/steering-committee
+/DCO @ansible/community-docs-maintainers
+/COPYING @ansible/community-docs-maintainers
+/MAINTAINERS.md @ansible/community-docs-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,8 @@
 /docs/docsite/rst/community/collection_contributors/collection_requirements.rst @ansible/steering-committee
 /docs/docsite/rst/community/steering/* @ansible/steering-committee
 /docs/docsite/rst/roadmap/COLLECTIONS_*.rst @ansible/steering-committee
+/MAINTAINERS.md @ansible/community-docs-maintainers
+# DCO and COPYING need approval from the Red Hat open-source legal team
+# See the maintainers guide for details
 /DCO @ansible/community-docs-maintainers
 /COPYING @ansible/community-docs-maintainers
-/MAINTAINERS.md @ansible/community-docs-maintainers

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,6 +6,11 @@ If you're interested in becoming a maintainer, or want to get in touch with us, 
 We have weekly meetings on Matrix every Tuesday.
 See [the Ansible calendar](https://forum.ansible.com/upcoming-events) for meeting details.
 
+## Requesting review from legal
+
+Any modifications to the `DCO` or `COPYING` file must be reviewed and approved by the Red Hat open-source legal team.
+Send an email with the request to `opensource-legal@redhat.com` with `ansible-community-team@redhat.com` on copy.
+
 ## Branching for new stable versions
 
 The branching strategy for this repository mirrors the [`ansible/ansible`](https://github.com/ansible/ansible) repository.


### PR DESCRIPTION
This change adds the LICENSE, DCO, and MAINTAINERS.md files to CODEOWNERS and specifies the community docs maintainers team as owners. The purpose of this change is to prevent any unintentional or unauthorized modifications to these files. Resolves #2178