### PR TITLE
[stable-2.17] LICENSE and DCO in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
 /docs/docsite/rst/community/collection_contributors/collection_requirements.rst @ansible/steering-committee
 /docs/docsite/rst/community/steering/* @ansible/steering-committee
 /docs/docsite/rst/roadmap/COLLECTIONS_*.rst @ansible/steering-committee
+# DCO and COPYING need approval from the Red Hat open-source legal team
+/DCO @ansible/community-docs-maintainers
+/COPYING @ansible/community-docs-maintainers


### PR DESCRIPTION
This change adds the LICENSE and DCO files to CODEOWNERS and specifies the community docs maintainers team as owners. The purpose of this change is to prevent any unintentional or unauthorized modifications to these files. Resolves #2178

Manual backport of https://github.com/ansible/ansible-documentation/pull/2193