### PR TITLE
Update faq.rst

### DIFF
--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -866,12 +866,12 @@ and backups, which most file based modules also support:
           copy:
              remote_src: true
              dest: /x/y/z
-             src: "{{ updated['backup_file'] }}"
+             src: "{{ updated['backup'] }}"
           when: updated is changed
      always:
         - name: We choose to always delete backup, but could copy or move, or only delete in rescue.
           file:
-             path: "{{ updated['backup_file'] }}"
+             path: "{{ updated['backup'] }}"
              state: absent
           when: updated is changed
 


### PR DESCRIPTION
Using `backup_file` gives error as the name is now changed to `backup` in newer Ansible versions.

Please update.