### PR TITLE
use name instead of source for installing collection dir requirements

### DIFF
--- a/docs/docsite/rst/shared_snippets/installing_collections_file.rst
+++ b/docs/docsite/rst/shared_snippets/installing_collections_file.rst
@@ -4,11 +4,11 @@ Ansible can also install from a source directory in several ways:
 
     collections:
       # directory containing the collection
-      - source: ./my_namespace/my_collection/
+      - name: ./my_namespace/my_collection/
         type: dir
 
       # directory containing a namespace, with collections as subdirectories
-      - source: ./my_namespace/
+      - name: ./my_namespace/
         type: subdirs
 
 Ansible can also install a collection collected with ``ansible-galaxy collection build`` or downloaded from Galaxy for offline use by specifying the output file directly:


### PR DESCRIPTION
I should have caught this before approving the PR that added these examples.

When the dependency resolver was added to ansible-galaxy in 2.12, it inadvertently overloaded the `source` collection requirement field, which was previously only able to be a URL to a galaxy server. Now it is sort of an alias to `name` in some situations, and it's a bug because we had specifically discussed not unifying role `src` vs collection `source` for requirements, because although it's unfortunate that they're similarly named but completely different features (one is a URL to a role, the other is a URL galaxy server), it was outside of the scope of that PR (and at the time of discussion, I was under the impression we would want to make the role syntax more like collections though - not the other way around).