### PR TITLE
Update noxfile and pip-compile sessions to fix failing workflows

### DIFF
--- a/.github/workflows/pip-compile-dev.yml
+++ b/.github/workflows/pip-compile-dev.yml
@@ -22,39 +22,32 @@ jobs:
           - base-branch: devel
             pr-branch: pip-compile/devel/dev
             nox-args: >-
-              -e 'pip-compile-3.11(formatters)'
-              'pip-compile-3.11(typing)'
-              'pip-compile-3.11(static)'
-              'pip-compile-3.11(spelling)'
-              'pip-compile-3.11(tag)'
+              -e 'pip-compile(formatters)'
+              'pip-compile(typing)'
+              'pip-compile(static)'
+              'pip-compile(spelling)'
+              'pip-compile(tag)'
           - base-branch: stable-2.18
             pr-branch: pip-compile/stable-2.18/dev
             nox-args: >-
-              -e 'pip-compile-3.11(formatters)'
-              'pip-compile-3.11(typing)'
-              'pip-compile-3.11(static)'
-              'pip-compile-3.11(spelling)'
+              -e 'pip-compile(formatters)'
+              'pip-compile(typing)'
+              'pip-compile(static)'
+              'pip-compile(spelling)'
           - base-branch: stable-2.17
             pr-branch: pip-compile/stable-2.17/dev
             nox-args: >-
-              -e 'pip-compile-3.10(formatters)'
-              'pip-compile-3.10(typing)'
-              'pip-compile-3.10(static)'
-              'pip-compile-3.10(spelling)'
+              -e 'pip-compile(formatters)'
+              'pip-compile(typing)'
+              'pip-compile(static)'
+              'pip-compile(spelling)'
           - base-branch: stable-2.16
             pr-branch: pip-compile/stable-2.16/dev
             nox-args: >-
-              -e 'pip-compile-3.10(formatters)'
-              'pip-compile-3.10(typing)'
-              'pip-compile-3.10(static)'
-              'pip-compile-3.10(spelling)'
-          - base-branch: stable-2.15
-            pr-branch: pip-compile/stable-2.15/dev
-            nox-args: >-
-              -e 'pip-compile-3.10(formatters)'
-              'pip-compile-3.10(typing)'
-              'pip-compile-3.10(static)'
-              'pip-compile-3.10(spelling)'
+              -e 'pip-compile(formatters)'
+              'pip-compile(typing)'
+              'pip-compile(static)'
+              'pip-compile(spelling)'
     name: "Refresh dev dependencies"
     uses: ./.github/workflows/reusable-pip-compile.yml
     with:

--- a/.github/workflows/pip-compile-docs.yml
+++ b/.github/workflows/pip-compile-docs.yml
@@ -29,8 +29,8 @@ jobs:
       pr-branch: "${{ inputs.pr-branch || 'pip-compile/devel/docs' }}"
       nox-args: >-
         -e
-        'pip-compile-3.11(requirements)'
-        'pip-compile-3.11(requirements-relaxed)'
+        'pip-compile(requirements)'
+        'pip-compile(requirements-relaxed)'
       reset-branch: "${{ inputs.reset-branch || false }}"
       labels: "${{ inputs.labels || 'doc builds,no_backport' }}"
     secrets: inherit

--- a/noxfile.py
+++ b/noxfile.py
@@ -155,7 +155,7 @@ requirements_files = list(
 )
 
 
-@nox.session(name="pip-compile", python=["3.11"])
+@nox.session(name="pip-compile", python="3.11")
 @nox.parametrize(["req"], requirements_files, requirements_files)
 def pip_compile(session: nox.Session, req: str):
     """


### PR DESCRIPTION
Fixes #2177

I'll handle the backports separately because they require different versions and don't contain the workflows. Also worth noting that I dropped stable-2.15 from the workflows because we're no longer maintaining that version.