### PR TITLE
[stable-2.16] Update noxfile to fix failing workflows

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -106,7 +106,7 @@ requirements_files = list(
 )
 
 
-@nox.session(name="pip-compile", python=["3.10"])
+@nox.session(name="pip-compile", python="3.10")
 @nox.parametrize(["req"], requirements_files, requirements_files)
 def pip_compile(session: nox.Session, req: str):
     # .pip-tools.toml was introduced in v7


### PR DESCRIPTION
fixes #2177 for stable-2.16 and follows up on https://github.com/ansible/ansible-documentation/pull/2260