### PR TITLE
Package docs build workflow: use relaxed or tested requirements

### DIFF
--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -80,8 +80,8 @@ jobs:
     - name: Install project requirements
       run: >-
         python -m pip install
-        -r tests/requirements-relaxed.in
-        -c tests/requirements-relaxed.txt
+        -r tests/requirements${{ github.event.inputs.requirements == 'relaxed' && '-relaxed' || '' }}.in
+        -c tests/requirements${{ github.event.inputs.requirements == 'relaxed' && '-relaxed' || '' }}.txt
       working-directory: build-directory
 
     - name: Set the COLLECTION_LIST variable

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -130,6 +130,7 @@ jobs:
           echo "Package version: ${{ github.event.inputs.ansible-package-version }}";
           echo "Owner: ${{ github.event.inputs.repository-owner }}";
           echo "Branch: ${{ github.event.inputs.repository-branch }}";
+          echo "Requirements: ${{ github.event.inputs.requirements }}";
         } >> "${GITHUB_STEP_SUMMARY}"
 
   notify-build-failures:

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -28,6 +28,13 @@ on:
         - '11'
         - '10'
         - '9'
+      requirements:
+        type: choice
+        description: Use relax or tested requirements
+        default: tested
+        options:
+        - relaxed
+        - tested
       deploy:
         type: boolean
         description: Deploy the build
@@ -73,8 +80,8 @@ jobs:
     - name: Install project requirements
       run: >-
         python -m pip install
-        -r tests/requirements.in
-        -c tests/requirements.txt
+        -r tests/requirements-relaxed.in
+        -c tests/requirements-relaxed.txt
       working-directory: build-directory
 
     - name: Set the COLLECTION_LIST variable


### PR DESCRIPTION
Fixes #2270 

This change updates the build package docs workflow to use either relaxed or tested requirements files.

I've pushed an additional commit to consolidate the two steps but I'm not sure if it's a good idea. On the one hand, it's tidier in the workflow file but maybe less obvious which set of requirements get installed when looking at the run.