### PR TITLE
ci pip-compile: specify the correct Python version for each branch

### DIFF
--- a/.github/workflows/pip-compile-dev.yml
+++ b/.github/workflows/pip-compile-dev.yml
@@ -27,6 +27,7 @@ jobs:
               'pip-compile(static)'
               'pip-compile(spelling)'
               'pip-compile(tag)'
+            python-versions: "3.11"
           - base-branch: stable-2.18
             pr-branch: pip-compile/stable-2.18/dev
             nox-args: >-
@@ -34,6 +35,7 @@ jobs:
               'pip-compile(typing)'
               'pip-compile(static)'
               'pip-compile(spelling)'
+            python-versions: "3.11"
           - base-branch: stable-2.17
             pr-branch: pip-compile/stable-2.17/dev
             nox-args: >-
@@ -41,6 +43,7 @@ jobs:
               'pip-compile(typing)'
               'pip-compile(static)'
               'pip-compile(spelling)'
+            python-versions: "3.10"
           - base-branch: stable-2.16
             pr-branch: pip-compile/stable-2.16/dev
             nox-args: >-
@@ -48,6 +51,7 @@ jobs:
               'pip-compile(typing)'
               'pip-compile(static)'
               'pip-compile(spelling)'
+            python-versions: "3.10"
     name: "Refresh dev dependencies"
     uses: ./.github/workflows/reusable-pip-compile.yml
     with:
@@ -55,6 +59,7 @@ jobs:
       base-branch: "${{ matrix.base-branch }}"
       pr-branch: "${{ matrix.pr-branch }}"
       nox-args: "${{ matrix.nox-args }}"
+      python-versions: "${{ matrix.python-versions }}"
       reset-branch: "${{ inputs.reset-branch || false }}"
       labels: "${{ inputs.labels || 'no_backport,tooling' }}"
     secrets: inherit

--- a/.github/workflows/pip-compile-docs.yml
+++ b/.github/workflows/pip-compile-docs.yml
@@ -33,4 +33,5 @@ jobs:
         'pip-compile(requirements-relaxed)'
       reset-branch: "${{ inputs.reset-branch || false }}"
       labels: "${{ inputs.labels || 'doc builds,no_backport' }}"
+      python-versions: "3.11"
     secrets: inherit

--- a/.github/workflows/reusable-pip-compile.yml
+++ b/.github/workflows/reusable-pip-compile.yml
@@ -32,6 +32,9 @@ name: "Refresh pinned dependencies"
       labels:
         type: string
         default: ""
+      python-versions:
+        type: string
+        required: true
 jobs:
   refresh:
     runs-on: ubuntu-latest
@@ -55,7 +58,7 @@ jobs:
       - name: Set up nox
         uses: wntrblm/nox@2024.10.09
         with:
-          python-versions: "3.9"
+          python-versions: "${{ inputs.python-versions }}"
       - name: Set up git committer
         run: |
           hacking/get_bot_user.sh "ansible-documentation-bot" "Ansible Documentation Bot"


### PR DESCRIPTION
CI jobs for stable-2.18 and stable-2.17 were failing before this; they use a different Python version for lockfile generation that was not incidentally installed like Python 3.11.