### PR TITLE
[stable-2.16] Bump antsibull-docs to 2.16.2. (#2317)

### DIFF
--- a/tests/constraints.in
+++ b/tests/constraints.in
@@ -2,4 +2,4 @@
 # and antsibull-docs that production builds rely upon.
 
 sphinx == 7.1.2
-antsibull-docs == 2.16.1  # currently approved version
+antsibull-docs == 2.16.2  # currently approved version

--- a/tests/requirements-relaxed.txt
+++ b/tests/requirements-relaxed.txt
@@ -28,7 +28,7 @@ antsibull-changelog==0.31.1
     # via antsibull-docs
 antsibull-core==3.4.0
     # via antsibull-docs
-antsibull-docs==2.16.1
+antsibull-docs==2.16.2
     # via -r tests/requirements-relaxed.in
 antsibull-docs-parser==1.1.0
     # via antsibull-docs

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -28,7 +28,7 @@ antsibull-changelog==0.31.1
     # via antsibull-docs
 antsibull-core==3.4.0
     # via antsibull-docs
-antsibull-docs==2.16.1
+antsibull-docs==2.16.2
     # via
     #   -c tests/constraints.in
     #   -r tests/requirements-relaxed.in


### PR DESCRIPTION
(cherry picked from commit 359c1984c192c62dfcdf0d1c1e71741f1831bc71)

Manual backport for https://github.com/ansible/ansible-documentation/pull/2317