### PR TITLE
Fix(style-guide): Add definition for "ID" abbreviation in spelling and word choice guide

### DIFF
--- a/docs/docsite/rst/dev_guide/style_guide/spelling_word_choice.rst
+++ b/docs/docsite/rst/dev_guide/style_guide/spelling_word_choice.rst
@@ -145,6 +145,16 @@ Hostname
 ^^^^^^^^
 Correct. Do not use host name.
 
+ID
+^^
+Use **ID** (all uppercase) when referring to "Identification" or "Identifier."
+
+- Do not use "Id," "id," or other variations.
+- Examples:
+    - "User ID"
+    - "Resource ID"
+- **Reason**: "ID" is a standard abbreviation for "Identification" or "Identifier" and is more readable when capitalized consistently.
+
 i.e.
 ^^^^
 Spell it out: "That is."


### PR DESCRIPTION

- Added entry for "ID" (Identification/Identifier) to the spelling and word choice guide.
- Clarified correct usage as "ID" (all uppercase) and specified avoiding variations like "Id" or "id".
- Provided examples and reasoning for consistent capitalization.

Resolves: ansible/ansible-documentation#2326