### PR TITLE
[stable-2.18] remove tag session from noxfile

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -249,18 +249,3 @@ def make(session: nox.Session):
         *make_args,
         external=True,
     )
-
-
-@nox.session
-def tag(session: nox.Session):
-    """
-    Check the core repo for new releases and create tags in ansible-documentation
-    """
-    install(session, req="tag")
-    args = list(session.posargs)
-
-    # If run without any arguments, default to "tag"
-    if not any(arg.startswith(("hash", "mantag", "new-tags", "tag")) for arg in args):
-        args.append("tag")
-
-    session.run("python", "hacking/tagger/tag.py", *args)


### PR DESCRIPTION
Follows on from 932e5d67e39460ff0b2033be366e1e2390533dc6 to drop the tag session from the noxfile.