### PR TITLE
Skip auto-generated porting guides for rstcheck

### DIFF
--- a/tests/checkers/rstcheck.json
+++ b/tests/checkers/rstcheck.json
@@ -1,5 +1,8 @@
 {
     "extensions": [
         ".rst"
+    ],
+    "ignore_regexs": [
+        "^docs/docsite/rst/porting_guides/porting_guide_[0-9]+\\.rst$"
     ]
 }


### PR DESCRIPTION
This caused problems with the latest Ansible 11 porting guide: https://github.com/ansible/ansible-documentation/pull/2375 - https://github.com/ansible/ansible-documentation/actions/runs/13014407433/job/36299852606:
```
/home/runner/work/ansible-documentation/ansible-documentation/docs/docsite/rst/porting_guides/porting_guide_11.rst:144:0: Inline emphasis start-string without end-string.
```
This PR makes the rstcheck checker skip all Ansible community package porting guides.