### PR TITLE
Also check .txt files with rstcheck

### DIFF
--- a/tests/checkers/rstcheck.json
+++ b/tests/checkers/rstcheck.json
@@ -1,6 +1,7 @@
 {
     "extensions": [
-        ".rst"
+        ".rst",
+        ".txt"
     ],
     "ignore_regexs": [
         "^docs/docsite/rst/porting_guides/porting_guide_[0-9]+\\.rst$"

--- a/tests/checkers/rstcheck.json
+++ b/tests/checkers/rstcheck.json
@@ -4,6 +4,7 @@
         ".txt"
     ],
     "ignore_regexs": [
-        "^docs/docsite/rst/porting_guides/porting_guide_[0-9]+\\.rst$"
+        "^docs/docsite/rst/porting_guides/porting_guide_[0-9]+\\.rst$",
+        "^docs/docsite/rst/getting_started/ansible_output/.*\\.txt$"
     ]
 }


### PR DESCRIPTION
Some (included) RST files have the `.txt` ending:
```
docs/docsite/rst/dev_guide/shared_snippets/licensing.txt
docs/docsite/rst/getting_started/ansible_output/first_playbook_output.txt
docs/docsite/rst/getting_started/ansible_output/ping_inventory_output.txt
docs/docsite/rst/getting_started/ansible_output/ping_output.txt
docs/docsite/rst/inventory_guide/shared_snippets/SSH_password_prompt.txt
docs/docsite/rst/network/user_guide/shared_snippets/SSH_warning.txt
docs/docsite/rst/playbook_guide/shared_snippets/role_directory.txt
docs/docsite/rst/playbook_guide/shared_snippets/with2loop.txt
docs/docsite/rst/shared_snippets/basic_concepts.txt
docs/docsite/rst/shared_snippets/download_tarball_collections.txt
docs/docsite/rst/shared_snippets/galaxy_server_list.txt
docs/docsite/rst/shared_snippets/installing_collections_git_repo.txt
docs/docsite/rst/shared_snippets/installing_multiple_collections.txt
docs/docsite/rst/shared_snippets/installing_older_collection.txt
docs/docsite/rst/tips_tricks/shared_snippets/role_directory.txt
```
Make sure these are also checked.