### PR TITLE
Remove incorrect parts from docs

### DIFF
--- a/docs/docsite/rst/network/user_guide/cli_parsing.rst
+++ b/docs/docsite/rst/network/user_guide/cli_parsing.rst
@@ -56,8 +56,6 @@ The ``cli_parse`` module includes the following cli_parsing plugins:
   A library for semi-structured text parsing using templates, with added capabilities to simplify the process
 ``pyats``
   Uses the parsers included with the Cisco Test Automation & Validation Solution
-``jc``
-  A python module that converts the output of dozens of popular Linux/UNIX/macOS/Windows commands and file types to python dictionaries or lists of dictionaries. Note: this filter plugin can be found in the ``community.general`` collection.
 ``json``
   Converts JSON output at the CLI to an Ansible native data structure
 


### PR DESCRIPTION
The community.general.jc filter never was a sub-plugin for cli_parse. Having it listed as one is wrong and confuses users. It was originally added there in https://github.com/ansible/ansible/pull/74563 for unknown reasons.

Ref: https://forum.ansible.com/t/39999