### PR TITLE
Involuntarily leaving SC: Allow PM on forum

### DIFF
--- a/docs/docsite/rst/community/steering/steering_committee_membership.rst
+++ b/docs/docsite/rst/community/steering/steering_committee_membership.rst
@@ -107,7 +107,7 @@ In case of absence or irregular participation, the removal process consists of t
 
   * If the answer is negative, the initiator asks the person to :ref:`step down voluntarily<Voluntarily leaving process>`.
 
-#. In case there is no response from the person within a week or if the person agreed to step down but has no time to do it themselves, the initiator:
+#. In case there is no response from the person within a week after the message was sent or if the person agreed to step down but has no time to do it themselves, the initiator:
 
   * Sends a private message to the ``SteeringCommittee`` group on the forum.
 

--- a/docs/docsite/rst/community/steering/steering_committee_membership.rst
+++ b/docs/docsite/rst/community/steering/steering_committee_membership.rst
@@ -103,11 +103,11 @@ Absence or irregular participation in discussing topics and votes
 
 In case of absence or irregular participation, the removal process consists of the following steps:
 
-#. Another Committee member (hereinafter the initiator) contacts the person by email asking if they are still interested in fulfilling their Committee member's duties.
+#. Another Committee member (hereinafter the initiator) contacts the person by email or PM on the forum asking if they are still interested in fulfilling their Committee member's duties.
 
   * If the answer is negative, the initiator asks the person to :ref:`step down voluntarily<Voluntarily leaving process>`.
 
-#. In case there is no response from the person within a week after the email was sent or if the person agreed to step down but has no time to do it themselves, the initiator:
+#. In case there is no response from the person within a week or if the person agreed to step down but has no time to do it themselves, the initiator:
 
   * Sends a private message to the ``SteeringCommittee`` group on the forum.
 

--- a/docs/docsite/rst/community/steering/steering_committee_membership.rst
+++ b/docs/docsite/rst/community/steering/steering_committee_membership.rst
@@ -127,7 +127,7 @@ Ansible Community Code of Conduct violations
 
 In case of the `Ansible Community Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_ violations, the process is the same as above except steps 1-2. Instead:
 
-#. The initiator reports the case to the Committee by email or PM.
+#. The initiator reports the case to the Committee by email.
 
 #. The Committee discusses the case internally, evaluates its severity, and possible solutions.
 

--- a/docs/docsite/rst/community/steering/steering_committee_membership.rst
+++ b/docs/docsite/rst/community/steering/steering_committee_membership.rst
@@ -127,7 +127,7 @@ Ansible Community Code of Conduct violations
 
 In case of the `Ansible Community Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_ violations, the process is the same as above except steps 1-2. Instead:
 
-#. The initiator reports the case to the Committee by email.
+#. The initiator reports the case to the Committee by email or PM.
 
 #. The Committee discusses the case internally, evaluates its severity, and possible solutions.
 

--- a/docs/docsite/rst/community/steering/steering_committee_membership.rst
+++ b/docs/docsite/rst/community/steering/steering_committee_membership.rst
@@ -103,7 +103,11 @@ Absence or irregular participation in discussing topics and votes
 
 In case of absence or irregular participation, the removal process consists of the following steps:
 
-#. Another Committee member (hereinafter the initiator) contacts the person by email or PM on the forum asking if they are still interested in fulfilling their Committee member's duties.
+#. Another Committee member (hereinafter the initiator) contacts the person by PM on the forum asking if they are still interested in fulfilling their Committee member's duties.
+
+  * If the answer is negative, the initiator asks the person to :ref:`step down voluntarily<Voluntarily leaving process>`.
+
+#. If there is no response from the person within a week after the message was sent, the initiator contacts the person by email asking if they are still interested in fulfilling their Committee member's duties.
 
   * If the answer is negative, the initiator asks the person to :ref:`step down voluntarily<Voluntarily leaving process>`.
 


### PR DESCRIPTION
I think we should change the process and allow to contact possibly inactive SC members via a private message on the forum.

After all, we've moved most (all?) discussions and votes to the forum. So we can assume that SC members are active there, can't we?

edit: [discussion on forum](https://forum.ansible.com/t/40058)