### PR TITLE
fix: clarify documentation on role name restrictions

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_collections_structure.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_structure.rst
@@ -181,10 +181,13 @@ roles directory
 
 Collection roles are mostly the same as existing roles, but with a couple of limitations:
 
- - Role names are now limited to contain only lowercase alphanumeric characters, plus ``_`` and start with an alpha character.
- - Roles in a collection cannot contain plugins any more. Plugins must live in the collection ``plugins`` directory tree. Each plugin is accessible to all roles in the collection.
+ - Role names:
 
-The directory name of the role is used as the role name. Therefore, the directory name must comply with the above role name rules. The collection import into Galaxy will fail if a role name does not comply with these rules.
+   - The role name is derived from the role directory name and may contain only alphanumeric characters and underscores (``_``). This corresponds to Python regex ``\w``, which includes all Unicode alphanumeric characters and the underscore.
+   - As a best practice, and for maximum compatibility with Galaxy publishing and external tooling, role names should start with a lowercase letter and contain only lowercase alphanumeric characters and underscores (``[a-z][a-zA-Z0-9_]*``).
+   - By convention, roles prefixed with an underscore (``_``) are considered internal roles used within the collection and are not intended to be invoked directly by users.
+
+ - Plugins are no longer allowed inside roles within a collection. Plugins must live in the collection ``plugins`` directory tree. Each plugin is accessible to all roles in the collection.
 
 You can migrate 'traditional roles' into a collection but they must follow the rules above. You may need to rename roles if they don't conform. You will have to move or link any role-based plugins to the collection specific directories.
 


### PR DESCRIPTION
corrects the documentation to reflect that role names can begin with an underscore (_). It also recommends reserving such names for internal roles within a collection, not for direct user invocation.

fixes: #2035