### PR TITLE
Recommend madbg instead of epdb

### DIFF
--- a/docs/docsite/rst/dev_guide/debugging.rst
+++ b/docs/docsite/rst/dev_guide/debugging.rst
@@ -102,7 +102,7 @@ The following steps use ``localhost`` as the target host, but you can use the sa
 Simple debugging
 ================
 
-The easiest way to run a debugger in a module, either local or remote, is to use `epdb <https://pypi.org/project/epdb/>`_. Add ``import epdb; epdb.serve()`` in the module code on the control node at the desired break point. To connect to the debugger, run ``epdb.connect()``. See the `epdb documentation <https://pypi.org/project/epdb/>`_ for how to specify the ``host`` and ``port``. If connecting to a remote node, make sure to use a port that is allowed by any firewall between the control node and the remote node.
+The easiest way to run a debugger in a module, either local or remote, is to use `madbg <https://github.com/kmaork/madbg/blob/master/README.md>`_. Add ``import madbg; madbg.set_trace()`` in the module code on the control node at the desired break point. To connect to the debugger, run ``madbg connect``. See the `madbg documentation <https://pypi.org/project/madbg/>`_ for how to specify the ``host`` and ``port``. If connecting to a remote node, make sure to use a port that is allowed by any firewall between the control node and the remote node.
 
 This technique should work with any remote debugger, but we do not guarantee any particular remote debugging tool will work.
 


### PR DESCRIPTION
epdb doesn't work anymore in Python 3.13 because it requires telnetlib which was removed from Python's stdlib in 3.13

It's a nice upgrade too, as we get a fully-featured ipdb in the client debugger!