### PR TITLE
pr_labeler: fix error in pyproject.toml

### DIFF
--- a/hacking/pr_labeler/pyproject.toml
+++ b/hacking/pr_labeler/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools"]
-backend = "setuptools.build_meta"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "ad-internal-pr-labeler"


### PR DESCRIPTION
The correct key-name is `build-backend`, not `backend`.