### PR TITLE
Update interpreter_discovery for changes made in ansible-core 2.17

### DIFF
--- a/docs/docsite/rst/reference_appendices/interpreter_discovery.rst
+++ b/docs/docsite/rst/reference_appendices/interpreter_discovery.rst
@@ -3,9 +3,6 @@
 Interpreter Discovery
 =====================
 
-Note: the behavior of this option changed in ansible-core 2.17. Consult the
-previous documentation if you are using ansible-core < 2.17.
-
 Most Ansible modules that execute under a POSIX environment require a Python
 interpreter on the target host. Unless configured otherwise, Ansible will
 attempt to discover a suitable Python interpreter on each target host the first

--- a/docs/docsite/rst/reference_appendices/interpreter_discovery.rst
+++ b/docs/docsite/rst/reference_appendices/interpreter_discovery.rst
@@ -20,7 +20,7 @@ auto (default) :
   interpreter paths and uses the first one found. Also issues a warning that
   future installation of another Python interpreter could alter the one chosen.
 
-auto_legacy : 
+auto_legacy :
   Deprecated alias for ``auto``.
 
 auto_silent :

--- a/docs/docsite/rst/reference_appendices/interpreter_discovery.rst
+++ b/docs/docsite/rst/reference_appendices/interpreter_discovery.rst
@@ -19,7 +19,7 @@ To control the discovery behavior:
 Use one of the following values:
 
 auto (default) :
-  Searches a list (i.e. ``interpreter_python_fallback``) of common Python
+  Searches the list (i.e. ``interpreter_python_fallback``) of common Python
   interpreter paths and uses the first one found. Also issues a warning that
   future installation of another Python interpreter could alter the one chosen.
 

--- a/docs/docsite/rst/reference_appendices/interpreter_discovery.rst
+++ b/docs/docsite/rst/reference_appendices/interpreter_discovery.rst
@@ -3,10 +3,13 @@
 Interpreter Discovery
 =====================
 
+Note: the behavior of this option changed in ansible-core 2.17. Consult the
+previous documentation if you are using ansible-core < 2.17.
+
 Most Ansible modules that execute under a POSIX environment require a Python
 interpreter on the target host. Unless configured otherwise, Ansible will
-attempt to discover a suitable Python interpreter on each target host
-the first time a Python module is executed for that host.
+attempt to discover a suitable Python interpreter on each target host the first
+time a Python module is executed for that host.
 
 To control the discovery behavior:
 
@@ -15,37 +18,19 @@ To control the discovery behavior:
 
 Use one of the following values:
 
-auto_legacy :
-  Detects the target OS platform, distribution, and version, then consults a
-  table listing the correct Python interpreter and path for each
-  platform/distribution/version. If an entry is found, and ``/usr/bin/python`` is absent, uses the discovered interpreter (and path). If an entry
-  is found, and ``/usr/bin/python`` is present, uses ``/usr/bin/python``
-  and issues a warning.
-  This exception provides temporary compatibility with previous versions of
-  Ansible that always defaulted to ``/usr/bin/python``, so if you have
-  installed Python and other dependencies at ``/usr/bin/python`` on some hosts,
-  Ansible will find and use them with this setting.
-  If no entry is found, or the listed Python is not present on the
-  target host, searches a list of common Python interpreter
-  paths and uses the first one found; also issues a warning that future
-  installation of another Python interpreter could alter the one chosen.
+auto (default) :
+  Searches a list of common Python interpreter paths and uses the first one
+  found. Also issues a warning that future installation of another Python
+  interpreter could alter the one chosen.
 
-auto : (default in 2.12)
-  Detects the target OS platform, distribution, and version, then consults a
-  table listing the correct Python interpreter and path for each
-  platform/distribution/version. If an entry is found, uses the discovered
-  interpreter.
-  If no entry is found, or the listed Python is not present on the
-  target host, searches a list of common Python interpreter
-  paths and uses the first one found; also issues a warning that future
-  installation of another Python interpreter could alter the one chosen.
+auto_legacy : 
+  Deprecated alias for ``auto``.
 
-auto_legacy_silent
-  Same as ``auto_legacy``, but does not issue warnings.
-
-auto_silent
+auto_silent :
   Same as ``auto``, but does not issue warnings.
 
-You can still set ``ansible_python_interpreter`` to a specific path at any
-variable level (for example, in host_vars, in vars files, in playbooks, and so on).
-Setting a specific path completely disables automatic interpreter discovery; Ansible always uses the path specified.
+auto_legacy_silent :
+  Deprecated alias for ``auto_silent``.
+
+``/path/to/python`` :
+  Use the specified path to Python.

--- a/docs/docsite/rst/reference_appendices/interpreter_discovery.rst
+++ b/docs/docsite/rst/reference_appendices/interpreter_discovery.rst
@@ -5,8 +5,8 @@ Interpreter Discovery
 
 Most Ansible modules that execute under a POSIX environment require a Python
 interpreter on the target host. Unless configured otherwise, Ansible will
-attempt to discover a suitable Python interpreter on each target host the first
-time a Python module is executed for that host.
+attempt to discover a suitable Python interpreter on each target host
+the first time a Python module is executed for that host.
 
 To control the discovery behavior:
 

--- a/docs/docsite/rst/reference_appendices/interpreter_discovery.rst
+++ b/docs/docsite/rst/reference_appendices/interpreter_discovery.rst
@@ -19,9 +19,9 @@ To control the discovery behavior:
 Use one of the following values:
 
 auto (default) :
-  Searches a list of common Python interpreter paths and uses the first one
-  found. Also issues a warning that future installation of another Python
-  interpreter could alter the one chosen.
+  Searches a list (i.e. ``interpreter_python_fallback``) of common Python
+  interpreter paths and uses the first one found. Also issues a warning that
+  future installation of another Python interpreter could alter the one chosen.
 
 auto_legacy : 
   Deprecated alias for ``auto``.

--- a/docs/docsite/rst/reference_appendices/interpreter_discovery.rst
+++ b/docs/docsite/rst/reference_appendices/interpreter_discovery.rst
@@ -13,11 +13,11 @@ To control the discovery behavior:
 * for individual hosts and groups, use the ``ansible_python_interpreter`` inventory variable
 * globally, use the ``interpreter_python`` key in the ``[defaults]`` section of ``ansible.cfg``
 
-Use one of the following values:
+Configure a path to a specific Python interpreter, or one of the following values:
 
 auto (default) :
-  Searches the list (i.e. ``interpreter_python_fallback``) of common Python
-  interpreter paths and uses the first one found. Also issues a warning that
+  Searches the configurable list of common Python interpreter paths
+  (see :ref:`INTERPRETER_PYTHON_FALLBACK`) and issues a warning that
   future installation of another Python interpreter could alter the one chosen.
 
 auto_legacy :
@@ -29,5 +29,3 @@ auto_silent :
 auto_legacy_silent :
   Deprecated alias for ``auto_silent``.
 
-``/path/to/python`` :
-  Use the specified path to Python.


### PR DESCRIPTION
I've updated ansible-core to 2.18, and suddenly got a warning regarding interpreter discovery, which pointed me to [this](https://docs.ansible.com/ansible-core/2.18/reference_appendices/interpreter_discovery.html) page.

I've read the page and stayed confused why it suddenly happened.

Then I've read the source, and mainly [this](https://github.com/ansible/ansible/pull/82420/files) PR merged in 2.17 changed a lot regarding interpreter discovery.

- There is no "target OS platform, distribution, and version" list anymore (well, it's empty), so you're always using the fallback list if you don't manually specify an interpreter, and so you'll always get a warning.
- Therefore [this exception](https://github.com/sivel/ansible/blob/release-2.18.2-159ff813/lib/ansible/executor/interpreter_discovery.py#L116) is always raised, and [the check for legacy](https://github.com/sivel/ansible/blob/release-2.18.2-159ff813/lib/ansible/executor/interpreter_discovery.py#L121) never happens, making `auto_legacy` effectively an alias for `auto`.
- Not really important anymore, since the code is never reached, but `auto_legacy` now uses [python3](https://github.com/sivel/ansible/blob/release-2.18.2-159ff813/lib/ansible/executor/interpreter_discovery.py#L130), so seems the legacy option isn't really legacy anymore.

So I've updated the documentation page to reflect these changes.