### PR TITLE
ci pip-compile: always create PR when one doesn't exist

### DIFF
--- a/.github/workflows/reusable-pip-compile.yml
+++ b/.github/workflows/reusable-pip-compile.yml
@@ -94,6 +94,7 @@ jobs:
           pr_title: "[${{ inputs.base-branch }}] ${{ inputs.message }}"
           changed_files: "${{ inputs.changed-files }}"
           labels: "${{ inputs.labels }}"
+          branch_exists: "${{ steps.branch.outputs.branch-exists }}"
         run: |
           set -x
           git diff || :
@@ -107,20 +108,31 @@ jobs:
 
           git commit -m "${message}"
           git push --force origin "${pr_branch}"
-          if [ "${{ steps.branch.outputs.branch-exists }}" = "false" ]
-          then
-            command=(gh pr create
-              --base "${base_branch}"
-              --title "${pr_title}"
-              --body ""
-              --label dependency_update
-            )
-            # Add custom labels to the command.
-            old_ifs="$IFS"
-            IFS=","
-            for label in ${labels}; do
-              command+=("--label" "${label}")
-            done
-            IFS="${old_ifs}"
+
+          if [ "${branch_exists}" = "true" ]; then
+            # https://github.com/cli/cli/discussions/5792#discussioncomment-10410197
+            current_pr="$(gh pr list \
+              --head "${pr_branch}"\
+              --app ansible-documentation-bot \
+              --state open \
+              --json url --jq .[].url \
+            )"
+            if [ -n "${current_pr}" ]; then
+              echo "PR already exists: ${current_pr}"
+              exit
+            fi
           fi
+          command=(gh pr create
+            --base "${base_branch}"
+            --title "${pr_title}"
+            --body ""
+            --label dependency_update
+          )
+          # Add custom labels to the command.
+          old_ifs="$IFS"
+          IFS=","
+          for label in ${labels}; do
+            command+=("--label" "${label}")
+          done
+          IFS="${old_ifs}"
           "${command[@]}"


### PR DESCRIPTION
Previously, this only would create a PR when the branch was newly created earlier in the workflow (assuming that branches would be deleted once the previous dependency update PR was merged), but it was possible for the branch to already exist but not have a PR open against it. This uses the Github API to properly check whether a PR already exists.