### PR TITLE
Announce Ansible 11 lifetime extension

### DIFF
--- a/docs/docsite/rst/roadmap/COLLECTIONS_11.rst
+++ b/docs/docsite/rst/roadmap/COLLECTIONS_11.rst
@@ -79,7 +79,7 @@ Ansible 11.x minor releases may contain new features (including new collections)
 
     Minor and patch releases will stop when Ansible-13 is released.
     This will likely be in November 2025, at the end of the Ansible Core 2.18 critical bugfix support lifecycle.
-    This is roughly half a year longer than regular Ansible releases.
+    This is approximately six months longer than regular Ansible releases.
     See the :ref:`Release and Maintenance Page <release_and_maintenance>` for more information.
 
 .. note::

--- a/docs/docsite/rst/roadmap/COLLECTIONS_11.rst
+++ b/docs/docsite/rst/roadmap/COLLECTIONS_11.rst
@@ -77,7 +77,10 @@ Ansible 11.x minor releases may contain new features (including new collections)
 
 .. note::
 
-    Minor and patch releases will stop when Ansible-12 is released. See the :ref:`Release and Maintenance Page <release_and_maintenance>` for more information.
+    Minor and patch releases will stop when Ansible-13 is released.
+    This will likely be in November 2025, at the end of the Ansible Core 2.18 critical bugfix support lifecycle.
+    This is roughly half a year longer than regular Ansible releases.
+    See the :ref:`Release and Maintenance Page <release_and_maintenance>` for more information.
 
 .. note::
 


### PR DESCRIPTION
Depends on the result of the vote in https://forum.ansible.com/t/40851/11, and on whether Data Tagging makes it into ansible-core 2.19.

So this should only be merged once:
- [x] the [vote](https://forum.ansible.com/t/40851/11) has been accepted **and**
- [x] ansible-core 2.19.0 rc1 is out.
