### PR TITLE
2.19 roadmap updates

### DIFF
--- a/docs/docsite/rst/roadmap/ROADMAP_2_19.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_19.rst
@@ -30,7 +30,7 @@ The ``milestone`` branch will be advanced at the start date of each development 
 Release Phase
 ^^^^^^^^^^^^^
 
-- 2025-03-14 Feature Freeze (and ``stable-2.19`` branching from ``devel``)
+- 2025-04-14 Feature Freeze (and ``stable-2.19`` branching from ``devel``)
   No new functionality (including modules/plugins) to any code
 
 - 2025-04-14 Beta 1

--- a/docs/docsite/rst/roadmap/ROADMAP_2_19.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_19.rst
@@ -25,21 +25,21 @@ The ``milestone`` branch will be advanced at the start date of each development 
 - 2024-10-14 Development Phase 1
 - 2024-12-16 Development Phase 2
 - 2025-02-17 Development Phase 3
-- 2025-04-07 Beta 1
+- 2025-04-14 Beta 1
 
 Release Phase
 ^^^^^^^^^^^^^
 
-- 2025-03-31 Feature Freeze (and ``stable-2.19`` branching from ``devel``)
+- 2025-03-14 Feature Freeze (and ``stable-2.19`` branching from ``devel``)
   No new functionality (including modules/plugins) to any code
 
-- 2025-04-07 Beta 1
+- 2025-04-14 Beta 1
 
-- 2025-04-28 Release Candidate 1
+- 2025-05-26 Release Candidate 1
 
-- 2025-05-19 Release
+- 2025-06-16 Release
 
-.. note:: The beta and release candidate schedules allow for up to 3 releases on a weekly schedule depending on the necessity of creating a release.
+.. note:: The beta schedule allows for up to 6 releases and release candidate schedules allow for up to 3 releases on a weekly schedule depending on the necessity of creating a release.
 
 Release Manager
 ===============
@@ -50,16 +50,10 @@ Planned work
 ============
 
 * Data Tagging
-* Register Projections
 * No longer allow forks to inherit stdio
 * ``ansible-galaxy`` CLI improvements
-   * Denote preferred collection
-   * Add ``uninstall`` command
-   * Support rollback on upgrade failures
-   * Utilize ``requires_ansible`` during installs/upgrades
    * Support relative ``download_url`` in galaxy API responses
    * Add support to ansible-galaxy for new console.redhat.com service account auth
-* Move environment variable handling for modules out of shell plugins, to support private environment variables
 * Evaluate pre-fork loop processing in strategy plugins
 * Add alternative to ``sshpass`` to the ``ssh`` connection plugin
 * Evaluate inclusion of ``ssh-agent`` handling
@@ -71,10 +65,15 @@ Planned work
 * Update ansible-test container images and VMs
 * Update ansible-test dependencies
 
-
 Delayed work
 ============
 
 The following work has been delayed and retargeted for a future release:
 
-* TBD
+* Register Projections
+* ``ansible-galaxy`` CLI improvements
+   * Denote preferred collection
+   * Add ``uninstall`` command
+   * Support rollback on upgrade failures
+   * Utilize ``requires_ansible`` during installs/upgrades
+* Move environment variable handling for modules out of shell plugins, to support private environment variables


### PR DESCRIPTION
This PR is updating the 2.19 roadmap to reflect updated release dates, and delayed work.

Until this PR is actually merged, the dates within are just conjecture. I'll move this out of draft once we are confirmed and ready to merge.