### PR TITLE
ci pip-compile-dev: remove invalid sessions

### DIFF
--- a/.github/workflows/pip-compile-dev.yml
+++ b/.github/workflows/pip-compile-dev.yml
@@ -36,7 +36,6 @@ jobs:
               'pip-compile(typing)'
               'pip-compile(static)'
               'pip-compile(spelling)'
-              'pip-compile(pip-compile)'
             python-versions: "3.11"
           - base-branch: stable-2.17
             pr-branch: pip-compile/stable-2.17/dev
@@ -45,7 +44,6 @@ jobs:
               'pip-compile(typing)'
               'pip-compile(static)'
               'pip-compile(spelling)'
-              'pip-compile(pip-compile)'
             python-versions: "3.10"
           - base-branch: stable-2.16
             pr-branch: pip-compile/stable-2.16/dev
@@ -54,7 +52,6 @@ jobs:
               'pip-compile(typing)'
               'pip-compile(static)'
               'pip-compile(spelling)'
-              'pip-compile(pip-compile)'
             python-versions: "3.10"
     name: "Refresh dev dependencies"
     uses: ./.github/workflows/reusable-pip-compile.yml


### PR DESCRIPTION
This pip-compile lockfile only exists on the devel branch. Oops.

Fixes: 040fcce431056cd4185b851338604e27431d25bb

---

Test workflow run: https://github.com/ansible/ansible-documentation/actions/runs/14450575450