### PR TITLE
Update example image from `fedora:39` to `fedora:42`

### DIFF
--- a/docs/docsite/rst/getting_started_ee/yaml/execution-environment.yml
+++ b/docs/docsite/rst/getting_started_ee/yaml/execution-environment.yml
@@ -6,7 +6,7 @@ images:
 
 dependencies:
   python_interpreter:
-    package_system: "python3"
+    package_system: python3
   ansible_core:
     package_pip: ansible-core
   ansible_runner:

--- a/docs/docsite/rst/getting_started_ee/yaml/execution-environment.yml
+++ b/docs/docsite/rst/getting_started_ee/yaml/execution-environment.yml
@@ -2,9 +2,11 @@ version: 3
 
 images:
   base_image:
-    name: quay.io/fedora/fedora:40
+    name: registry.fedoraproject.org/fedora:42
 
 dependencies:
+  python_interpreter: 
+    package_system: "python3"
   ansible_core:
     package_pip: ansible-core
   ansible_runner:

--- a/docs/docsite/rst/getting_started_ee/yaml/execution-environment.yml
+++ b/docs/docsite/rst/getting_started_ee/yaml/execution-environment.yml
@@ -5,7 +5,7 @@ images:
     name: registry.fedoraproject.org/fedora:42
 
 dependencies:
-  python_interpreter: 
+  python_interpreter:
     package_system: "python3"
   ansible_core:
     package_pip: ansible-core

--- a/docs/docsite/rst/getting_started_ee/yaml/execution-environment.yml
+++ b/docs/docsite/rst/getting_started_ee/yaml/execution-environment.yml
@@ -2,7 +2,7 @@ version: 3
 
 images:
   base_image:
-    name: quay.io/fedora/fedora:39
+    name: quay.io/fedora/fedora:40
 
 dependencies:
   ansible_core:


### PR DESCRIPTION
Image builds otherwise unmondifed with this. Trying to bump to 41 or 42 has unrelated failure that would require additional changes/investigation.

Fixes #2534 