### PR TITLE
Update developing_modules_documenting.rst

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -11,7 +11,7 @@ Before you open a pull request, in addition to following these guidelines, pleas
 
 * :ref:`submission checklist <developing_modules_checklist>`
 * :ref:`programming tips <developing_modules_best_practices>`
-* :ref:`testing <developing_testing>` before you open a pull request.
+* :ref:`testing <developing_testing>` before you open a pull request
 
 Every Ansible module written in Python must begin with seven standard sections in a particular order, followed by the code. The sections in order are:
 


### PR DESCRIPTION
For consistency

Now it looks like:

![Screenshot from 2025-04-23 09-41-44](https://github.com/user-attachments/assets/f045ec28-51f3-42e6-8c11-978ae94c6c0f)

We could also put commas after the first two items and keep the period. Not sure