### PR TITLE
Only run pr_labeler on devel or stable-* branches

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,9 @@
 
 "on":
   pull_request_target:
+    branches:
+      - devel
+      - "stable-*"
   issues:
     types:
       - opened


### PR DESCRIPTION
Adds branch requirements to the labeler workflow. Will only run on devel or stable-* branch pulls. 
Fixes #2509