### PR TITLE
First pass at adding notes requested in #1638

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_vars_facts.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_vars_facts.rst
@@ -499,6 +499,8 @@ To reference the system hostname:
 
     {{ ansible_facts['nodename'] }}
 
+Note that `ansible_` prefix shown in the setup module output is not used when addressing these variables. 
+
 You can use facts in conditionals (see :ref:`playbooks_conditionals`) and also in templates. You can also use facts to create dynamic groups of hosts that match particular criteria, see the :ref:`group_by module <group_by_module>` documentation for details.
 
 .. note:: Because ``ansible_date_time`` is created and cached when Ansible gathers facts before each playbook run, it can get stale with long-running playbooks. If your playbook takes a long time to run, use the ``pipe`` filter (for example, ``lookup('pipe', 'date +%Y-%m-%d.%H:%M:%S')``) or :ref:`now() <templating_now>` with a Jinja 2 template instead of ``ansible_date_time``.


### PR DESCRIPTION
#1638 requests clarity on the `ansbile_` prefix present in setup/facts output, but not used when addressing variables. This is a first pass at addressing that. 

Fixes #1638 