### PR TITLE
collection_requirements: add requirements version specification recommendation to avoid conflicts when building EEs

### DIFF
--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -204,7 +204,7 @@ If a collection has controller-side Python package and/or system package require
 * They SHOULD be listed in corresponding files under the ``meta`` directory, specified in ``meta/execution-environment.yml``, and `verified <https://ansible.readthedocs.io/projects/builder/en/latest/collection_metadata/#when-installing-collections-using-ansible-galaxy>`_.
 * The entries in the file SHOULD NOT have a version cap or be fixed. Entries like ``<=x.x.x`` or ``==x.x.x`` are not allowed. Only ``>=x.x.x`` entries (with or without ``,!=x.x.x``), or no specified version at all are allowed.
 
-  * It helps prevent issues during the creation of execution environments, particularly when bundling collections that have conflicting versions of the same dependencies. For instance, if one collection requires a fixed version of a dependency while another requires a higher version of the same dependency, the build process will fail.
+  * This rule helps prevent issues during the creation of execution environments, particularly when bundling collections that have conflicting versions of the same dependencies. For instance, if one collection requires a fixed version of a dependency while another requires a higher version of the same dependency, the build process will fail.
 
 See the `Collection-level dependencies guide <https://ansible.readthedocs.io/projects/builder/en/latest/collection_metadata/#collection-level-dependencies>`_ for more information and `collection_template/meta <https://github.com/ansible-collections/collection_template/tree/main/meta>`_ directory content as an example.
 

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -202,7 +202,7 @@ meta/execution-environment.yml
 If a collection has controller-side Python package and/or system package requirements, to allow easy :ref:`execution environment<getting_started_ee_index>` building:
 
 * They SHOULD be listed in corresponding files under the ``meta`` directory, specified in ``meta/execution-environment.yml``, and `verified <https://ansible.readthedocs.io/projects/builder/en/latest/collection_metadata/#when-installing-collections-using-ansible-galaxy>`_.
-* The entries in the file SHOULD NOT have a version cap or be fixed. This means no ``<=x.x.x`` or ``==x.x.x`` entries, only ``>=x.x.x`` entries. No specified version at all is also allowed.
+* The entries in the file SHOULD NOT have a version cap or be fixed. This means no ``<=x.x.x`` or ``==x.x.x`` entries, only ``>=x.x.x`` entries, potentially combined with ``,!=x.x.x``. No specified version at all is also allowed.
 
   * It helps prevent issues during the creation of execution environments, particularly when bundling collections that have conflicting versions of the same dependencies. For instance, if one collection requires a fixed version of a dependency while another requires a higher version of the same dependency, the build process will fail.
 

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -202,7 +202,7 @@ meta/execution-environment.yml
 If a collection has controller-side Python package and/or system package requirements, to allow easy :ref:`execution environment<getting_started_ee_index>` building:
 
 * They SHOULD be listed in corresponding files under the ``meta`` directory, specified in ``meta/execution-environment.yml``, and `verified <https://ansible.readthedocs.io/projects/builder/en/latest/collection_metadata/#when-installing-collections-using-ansible-galaxy>`_.
-* The entries in the file SHOULD NOT have a version cap or be fixed. This means no ``<=x.x.x`` or ``==x.x.x`` entries, only ``>=x.x.x`` entries, potentially combined with ``,!=x.x.x``. No specified version at all is also allowed.
+* The entries in the file SHOULD NOT have a version cap or be fixed. Entries like ``<=x.x.x`` or ``==x.x.x`` are not allowed. Only ``>=x.x.x`` entries (with or without ``,!=x.x.x``), or no specified version at all are allowed.
 
   * It helps prevent issues during the creation of execution environments, particularly when bundling collections that have conflicting versions of the same dependencies. For instance, if one collection requires a fixed version of a dependency while another requires a higher version of the same dependency, the build process will fail.
 

--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -199,7 +199,12 @@ Example: `meta/runtime.yml <https://github.com/ansible-collections/collection_te
 meta/execution-environment.yml
 ------------------------------
 
-If a collection has controller-side Python package and/or system package requirements, to allow easy :ref:`execution environment<getting_started_ee_index>` building, they SHOULD be listed in corresponding files under the ``meta`` directory, specified in ``meta/execution-environment.yml``, and `verified <https://ansible.readthedocs.io/projects/builder/en/latest/collection_metadata/#when-installing-collections-using-ansible-galaxy>`_.
+If a collection has controller-side Python package and/or system package requirements, to allow easy :ref:`execution environment<getting_started_ee_index>` building:
+
+* They SHOULD be listed in corresponding files under the ``meta`` directory, specified in ``meta/execution-environment.yml``, and `verified <https://ansible.readthedocs.io/projects/builder/en/latest/collection_metadata/#when-installing-collections-using-ansible-galaxy>`_.
+* The entries in the file SHOULD NOT have a version cap or be fixed. This means no ``<=x.x.x`` or ``==x.x.x`` entries, only ``>=x.x.x`` entries. No specified version at all is also allowed.
+
+  * It helps prevent issues during the creation of execution environments, particularly when bundling collections that have conflicting versions of the same dependencies. For instance, if one collection requires a fixed version of a dependency while another requires a higher version of the same dependency, the build process will fail.
 
 See the `Collection-level dependencies guide <https://ansible.readthedocs.io/projects/builder/en/latest/collection_metadata/#collection-level-dependencies>`_ for more information and `collection_template/meta <https://github.com/ansible-collections/collection_template/tree/main/meta>`_ directory content as an example.
 


### PR DESCRIPTION
collection_requirements: add requirements version specification recommendation to avoid conflicts when building EEs

There's also a question if we should make the whole requirements thing a MUST.
Let's discuss it in the [forum topic first](https://forum.ansible.com/t/collection-requirements-dependencies-related-changes/42281).