### PR TITLE
Update networking jumphost examples

### DIFF
--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -658,19 +658,19 @@ file to specify the proxy host.
     nxos02
 
     [nxos:vars]
-    ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+    ansible_paramiko_proxy_command='-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 With the configuration above, simply build and run the playbook as normal with
 no additional changes necessary.  The network module will now connect to the
 network device by first connecting to the host specified in
-``ansible_ssh_common_args``, which is ``bastion01`` in the above example.
+``ansible_paramiko_proxy_command``, which is ``bastion01`` in the above example.
 
 You can also set the proxy target for all hosts by using environment variables.
 
 .. code-block:: shell
 
-    export ANSIBLE_SSH_ARGS='-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+    export ANSIBLE_PARAMIKO_PROXY_COMMAND='-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 Using bastion/jump host with netconf connection
 -----------------------------------------------

--- a/docs/docsite/rst/network/user_guide/platform_ce.rst
+++ b/docs/docsite/rst/network/user_guide/platform_ce.rst
@@ -53,11 +53,11 @@ Example CLI inventory ``[ce:vars]``
    ansible_network_os=community.network.ce
    ansible_user=myuser
    ansible_password=!vault...
-   ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_paramiko_proxy_command='-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
-- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_ssh_common_args`` configuration.
+- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords with environment variables.
 
 Example CLI task
@@ -105,7 +105,7 @@ Example NETCONF inventory ``[ce:vars]``
    ansible_network_os=community.network.ce
    ansible_user=myuser
    ansible_password=!vault |
-   ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_paramiko_proxy_command='-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 Example NETCONF task

--- a/docs/docsite/rst/network/user_guide/platform_cnos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_cnos.rst
@@ -54,11 +54,11 @@ Example CLI ``group_vars/cnos.yml``
    ansible_become: true
    ansible_become_method: enable
    ansible_become_password: !vault...
-   ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_paramiko_proxy_command: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
-- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_ssh_common_args`` configuration.
+- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.
 
 Example CLI task

--- a/docs/docsite/rst/network/user_guide/platform_dellos10.rst
+++ b/docs/docsite/rst/network/user_guide/platform_dellos10.rst
@@ -55,11 +55,11 @@ Example CLI ``group_vars/dellos10.yml``
    ansible_become: true
    ansible_become_method: enable
    ansible_become_password: !vault...
-   ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_paramiko_proxy_command: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
-- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_ssh_common_args`` configuration.
+- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.
 
 Example CLI task

--- a/docs/docsite/rst/network/user_guide/platform_dellos6.rst
+++ b/docs/docsite/rst/network/user_guide/platform_dellos6.rst
@@ -54,11 +54,11 @@ Example CLI ``group_vars/dellos6.yml``
    ansible_become: true
    ansible_become_method: enable
    ansible_become_password: !vault...
-   ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_paramiko_proxy_command: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
-- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_ssh_common_args`` configuration.
+- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.
 
 Example CLI task

--- a/docs/docsite/rst/network/user_guide/platform_dellos9.rst
+++ b/docs/docsite/rst/network/user_guide/platform_dellos9.rst
@@ -54,11 +54,11 @@ Example CLI ``group_vars/dellos9.yml``
    ansible_become: true
    ansible_become_method: enable
    ansible_become_password: !vault...
-   ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_paramiko_proxy_command: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
-- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_ssh_common_args`` configuration.
+- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.
 
 Example CLI task

--- a/docs/docsite/rst/network/user_guide/platform_enos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_enos.rst
@@ -56,11 +56,11 @@ Example CLI ``group_vars/enos.yml``
    ansible_become: true
    ansible_become_method: enable
    ansible_become_password: !vault...
-   ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_paramiko_proxy_command: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
-- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_ssh_common_args`` configuration.
+- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.
 
 Example CLI task

--- a/docs/docsite/rst/network/user_guide/platform_eos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_eos.rst
@@ -59,11 +59,11 @@ Example CLI ``group_vars/eos.yml``
    ansible_become: true
    ansible_become_method: enable
    ansible_become_password: !vault...
-   ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_paramiko_proxy_command: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
-- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_ssh_common_args`` configuration.
+- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.
 
 Example CLI task

--- a/docs/docsite/rst/network/user_guide/platform_eric_eccli.rst
+++ b/docs/docsite/rst/network/user_guide/platform_eric_eccli.rst
@@ -49,11 +49,11 @@ Example CLI ``group_vars/eric_eccli.yml``
    ansible_network_os: community.network.eric_eccli
    ansible_user: myuser
    ansible_password: !vault...
-   ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_paramiko_proxy_command: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
-- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_ssh_common_args`` configuration.
+- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.
 
 Example CLI task

--- a/docs/docsite/rst/network/user_guide/platform_exos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_exos.rst
@@ -51,11 +51,11 @@ Example CLI ``group_vars/exos.yml``
    ansible_network_os: community.network.exos
    ansible_user: myuser
    ansible_password: !vault...
-   ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_paramiko_proxy_command: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
-- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_ssh_common_args`` configuration.
+- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.
 
 Example CLI task

--- a/docs/docsite/rst/network/user_guide/platform_frr.rst
+++ b/docs/docsite/rst/network/user_guide/platform_frr.rst
@@ -48,11 +48,11 @@ Example CLI ``group_vars/frr.yml``
    ansible_network_os: frr.frr.frr
    ansible_user: frruser
    ansible_password: !vault...
-   ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_paramiko_proxy_command: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 - The ``ansible_user`` should be a part of the ``frrvty`` group and should have the default shell set to ``/bin/vtysh``.
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
-- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_ssh_common_args`` configuration.
+- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.
 
 Example CLI task

--- a/docs/docsite/rst/network/user_guide/platform_icx.rst
+++ b/docs/docsite/rst/network/user_guide/platform_icx.rst
@@ -52,11 +52,11 @@ Example CLI ``group_vars/icx.yml``
    ansible_become: true
    ansible_become_method: enable
    ansible_become_password: !vault...
-   ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_paramiko_proxy_command: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
-- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_ssh_common_args`` configuration.
+- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.
 
 Example CLI task

--- a/docs/docsite/rst/network/user_guide/platform_ios.rst
+++ b/docs/docsite/rst/network/user_guide/platform_ios.rst
@@ -54,11 +54,11 @@ Example CLI ``group_vars/ios.yml``
    ansible_become: true
    ansible_become_method: enable
    ansible_become_password: !vault...
-   ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_paramiko_proxy_command: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
-- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_ssh_common_args`` configuration.
+- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.
 
 Example CLI task

--- a/docs/docsite/rst/network/user_guide/platform_iosxr.rst
+++ b/docs/docsite/rst/network/user_guide/platform_iosxr.rst
@@ -56,11 +56,11 @@ Example CLI inventory ``[iosxr:vars]``
    ansible_network_os=cisco.iosxr.iosxr
    ansible_user=myuser
    ansible_password=!vault...
-   ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_paramiko_proxy_command='-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
-- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_ssh_common_args`` configuration.
+- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.
 
 Example CLI task
@@ -106,7 +106,7 @@ Example NETCONF inventory ``[iosxr:vars]``
    ansible_network_os=cisco.iosxr.iosxr
    ansible_user=myuser
    ansible_password=!vault |
-   ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_paramiko_proxy_command='-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 Example NETCONF task

--- a/docs/docsite/rst/network/user_guide/platform_ironware.rst
+++ b/docs/docsite/rst/network/user_guide/platform_ironware.rst
@@ -55,11 +55,11 @@ Example CLI ``group_vars/mlx.yml``
    ansible_become: true
    ansible_become_method: enable
    ansible_become_password: !vault...
-   ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_paramiko_proxy_command: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
-- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_ssh_common_args`` configuration.
+- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.
 
 Example CLI task

--- a/docs/docsite/rst/network/user_guide/platform_junos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_junos.rst
@@ -57,11 +57,11 @@ Example CLI inventory ``[junos:vars]``
    ansible_network_os=junipernetworks.junos.junos
    ansible_user=myuser
    ansible_password=!vault...
-   ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_paramiko_proxy_command='-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
-- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_ssh_common_args`` configuration.
+- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.
 
 Example CLI task
@@ -107,7 +107,7 @@ Example NETCONF inventory ``[junos:vars]``
    ansible_network_os=junipernetworks.junos.junos
    ansible_user=myuser
    ansible_password=!vault |
-   ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_netconf_proxy_command='-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 Example NETCONF task

--- a/docs/docsite/rst/network/user_guide/platform_netvisor.rst
+++ b/docs/docsite/rst/network/user_guide/platform_netvisor.rst
@@ -50,11 +50,11 @@ Example CLI ``group_vars/netvisor.yml``
    ansible_network_os: community.netcommon.netvisor
    ansible_user: myuser
    ansible_password: !vault...
-   ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_paramiko_proxy_command: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
-- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_ssh_common_args`` configuration.
+- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.
 
 Example CLI task

--- a/docs/docsite/rst/network/user_guide/platform_nos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_nos.rst
@@ -50,11 +50,11 @@ Example CLI ``group_vars/nos.yml``
    ansible_network_os: community.network.nos
    ansible_user: myuser
    ansible_password: !vault...
-   ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_paramiko_proxy_command: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
-- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_ssh_common_args`` configuration.
+- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.
 
 Example CLI task

--- a/docs/docsite/rst/network/user_guide/platform_nxos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_nxos.rst
@@ -56,11 +56,11 @@ Example CLI ``group_vars/nxos.yml``
    ansible_become: true
    ansible_become_method: enable
    ansible_become_password: !vault...
-   ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_paramiko_proxy_command: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
-- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_ssh_common_args`` configuration.
+- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.
 
 Example CLI task

--- a/docs/docsite/rst/network/user_guide/platform_routeros.rst
+++ b/docs/docsite/rst/network/user_guide/platform_routeros.rst
@@ -64,11 +64,11 @@ Example CLI ``group_vars/routeros.yml``
    ansible_become: true
    ansible_become_method: enable
    ansible_become_password: !vault...
-   ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_paramiko_proxy_command: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
-- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_ssh_common_args`` configuration.
+- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.
 - If you are getting timeout errors you may want to add ``+cet1024w`` suffix to your username which will disable console colors, enable "dumb" mode, tell RouterOS not to try detecting terminal capabilities and set terminal width to 1024 columns. See article `Console login process <https://wiki.mikrotik.com/wiki/Manual:Console_login_process>`_ in MikroTik wiki for more information.
 - More notes can be found in the :ref:`the community.routeros collection's SSH guide <ansible_collections.community.routeros.docsite.ssh-guide>`.

--- a/docs/docsite/rst/network/user_guide/platform_slxos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_slxos.rst
@@ -51,11 +51,11 @@ Example CLI ``group_vars/slxos.yml``
    ansible_network_os: community.network.slxos
    ansible_user: myuser
    ansible_password: !vault...
-   ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_paramiko_proxy_command: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
-- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_ssh_common_args`` configuration.
+- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.
 
 Example CLI task

--- a/docs/docsite/rst/network/user_guide/platform_voss.rst
+++ b/docs/docsite/rst/network/user_guide/platform_voss.rst
@@ -54,11 +54,11 @@ Example CLI ``group_vars/voss.yml``
    ansible_become: true
    ansible_become_method: enable
    ansible_password: !vault...
-   ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_paramiko_proxy_command: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
-- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_ssh_common_args`` configuration.
+- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.
 
 Example CLI task

--- a/docs/docsite/rst/network/user_guide/platform_vyos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_vyos.rst
@@ -50,11 +50,11 @@ Example CLI ``group_vars/vyos.yml``
    ansible_network_os: vyos.vyos.vyos
    ansible_user: myuser
    ansible_password: !vault...
-   ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_paramiko_proxy_command: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
-- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_ssh_common_args`` configuration.
+- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.
 
 Example CLI task

--- a/docs/docsite/rst/network/user_guide/platform_weos4.rst
+++ b/docs/docsite/rst/network/user_guide/platform_weos4.rst
@@ -50,11 +50,11 @@ Example CLI ``group_vars/weos4.yml``
    ansible_network_os: community.network.weos4
    ansible_user: myuser
    ansible_password: !vault...
-   ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+   ansible_paramiko_proxy_command: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
-- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_ssh_common_args`` configuration.
+- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.
 
 Example CLI task


### PR DESCRIPTION
The `ansible.netcommon.network_cli` connection plugin uses the `ansible.netcommon.libssh` connection plugin or falls back to `ansible.builtin.paramiko`.

In ansible-core 2.18, the `ansible.builtin.paramiko` connection [no longer](https://github.com/ansible/ansible/commit/92feda2e1354ba419e8e25e11aeedac452c713aa) uses the variable `ansible_ssh_common_args` to configure a jumphost, and instead requires the variable `ansible_paramiko_proxy_command` (which is compatible with `ansible.netcommon.libssh` in [ansible.netcommon >= 2.2.0](https://github.com/ansible-collections/ansible.netcommon/commit/bac22ce78310e2c65b34a11b89036658fc91000f) too).

Using the wrong variable could cause issues like https://forum.ansible.com/t/while-running-playbook-ansible-is-not-using-the-proxy/42323.

I also fixed the example for `ansible.netcommon.netconf`, which never appears to have never supported `ansible_ssh_common_args`, but does support `ansible_paramiko_proxy_command` and `ansible_netconf_proxy_command` to configure a jumphost.