### PR TITLE
add github-environment input for deploy jobs

### DIFF
--- a/.github/workflows/build-devel-docs.yaml
+++ b/.github/workflows/build-devel-docs.yaml
@@ -18,5 +18,6 @@ jobs:
     uses: ./.github/workflows/reusable-deploy-docs.yaml
     with:
       deployment-environment: 'production'
+      github-environment: 'auto-deploy-package-docs'
     secrets:
       DEPLOY_DOC_BUILD: ${{ secrets.DEPLOY_DOC_BUILD }}

--- a/.github/workflows/build-latest-docs.yaml
+++ b/.github/workflows/build-latest-docs.yaml
@@ -22,6 +22,7 @@ jobs:
     with:
       ansible-package-version: '11'
       deployment-environment: 'production'
+      github-environment: 'auto-deploy-package-docs'
       repository-branch: 'stable-2.18'
     secrets:
       DEPLOY_DOC_BUILD: ${{ secrets.DEPLOY_DOC_BUILD }}

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -65,6 +65,7 @@ jobs:
     with:
       ansible-package-version: ${{ github.event.inputs.ansible-package-version }}
       deployment-environment: ${{ github.event.inputs.deployment-environment }}
+      github-environment: 'deploy-package-docs'
       repository-owner: ${{ github.event.inputs.repository-owner }}
       repository-branch:  ${{ github.event.inputs.repository-branch }}
     secrets:

--- a/.github/workflows/reusable-deploy-docs.yaml
+++ b/.github/workflows/reusable-deploy-docs.yaml
@@ -24,6 +24,10 @@ name: Deploy docs
         type: string
         required: false
         default: test
+      github-environment:
+        type: string
+        description: Name of the GitHub environment
+        required: true
     secrets:
       DEPLOY_DOC_BUILD:
         required: true
@@ -45,7 +49,7 @@ jobs:
   deploy-package-docs:
     runs-on: ubuntu-latest
     environment:
-      name: deploy-package-docs
+      name: ${{ inputs.github-environment }}
       url: ${{ env.ENV_URL }}
     env:
       TARGET: ${{ github.event.inputs.deployment-environment }}


### PR DESCRIPTION
This change adds a github-environment input so that scheduled jobs that deploy doc builds use an environment without approval protection while jobs triggered manually require approval.

Reason for this change: scheduled builds for devel and latest result in multiple deployment reviews. We should require approval for manually triggered builds only.

@samccann has suggested simply removing the approval as a deployment protection step from the existing environment.

Alternatively, this change lets us keep the approvals but results in another environment that contains the private part of the deploy key.

We could potentially create a [custom deployment protection rule](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/creating-custom-deployment-protection-rules) but that requires a GitHub App and is a bit more complex.