### PR TITLE
Fix docs build

### DIFF
--- a/docs/docsite/rst/reference_appendices/module_utils.rst
+++ b/docs/docsite/rst/reference_appendices/module_utils.rst
@@ -18,6 +18,14 @@ To use this functionality, include ``from ansible.module_utils.basic import Ansi
    :members:
    :noindex:
 
+PluginInfo
+----------
+
+To use this functionality, include ``from ansible.module_utils.common.messages import PluginInfo`` in your module.
+
+.. autoclass:: ansible.module_utils.common.messages.PluginInfo
+   :members:
+
 Basic
 ------
 

--- a/docs/docsite/rst/reference_appendices/module_utils.rst
+++ b/docs/docsite/rst/reference_appendices/module_utils.rst
@@ -10,7 +10,7 @@ Ansible modules in Python.
 
 
 AnsibleModule
---------------
+=============
 
 To use this functionality, include ``from ansible.module_utils.basic import AnsibleModule`` in your module.
 
@@ -18,16 +18,8 @@ To use this functionality, include ``from ansible.module_utils.basic import Ansi
    :members:
    :noindex:
 
-PluginInfo
-----------
-
-To use this functionality, include ``from ansible.module_utils.common.messages import PluginInfo`` in your module.
-
-.. autoclass:: ansible.module_utils.common.messages.PluginInfo
-   :members:
-
 Basic
-------
+=====
 
 To use this functionality, include ``import ansible.module_utils.basic`` in your module.
 
@@ -35,19 +27,27 @@ To use this functionality, include ``import ansible.module_utils.basic`` in your
    :members:
 
 
+PluginInfo
+==========
+
+To use this functionality, include ``from ansible.module_utils.common.messages import PluginInfo`` in your module.
+
+.. autoclass:: ansible.module_utils.common.messages.PluginInfo
+   :members:
+
 Argument Spec
----------------------
+=============
 
 Classes and functions for validating parameters against an argument spec.
 
 ArgumentSpecValidator
-=====================
+---------------------
 
 .. autoclass:: ansible.module_utils.common.arg_spec.ArgumentSpecValidator
    :members:
 
 ValidationResult
-================
+----------------
 
 .. autoclass:: ansible.module_utils.common.arg_spec.ValidationResult
    :members:
@@ -55,7 +55,7 @@ ValidationResult
    :private-members: _no_log_values  # This only works in sphinx >= 3.2. Otherwise it shows all private members with doc strings.
 
 Parameters
-==========
+----------
 
 .. automodule:: ansible.module_utils.common.parameters
    :members:
@@ -66,7 +66,7 @@ Parameters
      used to check that type, :func:`~ansible.module_utils.common.validation.check_type_str` in this case.
 
 Validation
-==========
+----------
 
 Standalone functions for validating various parameter types.
 
@@ -75,7 +75,7 @@ Standalone functions for validating various parameter types.
 
 
 Errors
-------
+======
 
 .. automodule:: ansible.module_utils.errors
    :members:


### PR DESCRIPTION
https://github.com/ansible/ansible/pull/85095 broke the docs build since `AnsibleModule`'s documentation now references a class `PluginInfo`, which isn't currently documented on the docsite.

The error message is:
```
docs/docsite/rst/index.rst:0:0: unknown: /tmp/docs-build-ndrdw7z9-sanity/lib/ansible/module_utils/basic.py:docstring of ansible.module_utils.basic.AnsibleModule.deprecate:1: WARNING: py:class reference target not found: ansible.module_utils.common.messages.PluginInfo
```