### PR TITLE
Fix inputs in the deploy workflow

### DIFF
--- a/.github/workflows/reusable-deploy-docs.yaml
+++ b/.github/workflows/reusable-deploy-docs.yaml
@@ -48,7 +48,6 @@ jobs:
       name: deploy-package-docs
       url: ${{ env.ENV_URL }}
     env:
-      TARGET: ${{ inputs.deployment-environment }}
       DEST_REPO: ansible-community/package-doc-builds
       USER_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
       USER_NAME: "github-actions[bot]"
@@ -65,7 +64,7 @@ jobs:
         --one-top-level
 
     - name: Set the production branch and url
-      if: env.TARGET == 'production'
+      if: inputs.deployment-environment == 'production'
       env:
         BRANCH_NAME: ${{ inputs.ansible-package-version }}
         PROD_URL: https://ansible.readthedocs.io/projects/ansible
@@ -74,7 +73,7 @@ jobs:
         echo "ENV_URL=${PROD_URL}/${BRANCH_NAME}" >> "${GITHUB_ENV}"
 
     - name: Set the test branch and url
-      if: env.TARGET == 'test'
+      if: inputs.deployment-environment == 'test'
       env:
         TEST_URL: https://ansible-community.github.io/package-doc-builds
       run: |
@@ -98,7 +97,7 @@ jobs:
         deploy-directory/docs
 
     - name: Create a norobots.txt file for the test site
-      if: env.TARGET == 'test'
+      if: inputs.deployment-environment == 'test'
       run: |
         touch norobots.txt
         echo "User-agent: *" > norobots.txt

--- a/.github/workflows/reusable-deploy-docs.yaml
+++ b/.github/workflows/reusable-deploy-docs.yaml
@@ -99,10 +99,8 @@ jobs:
     - name: Create a norobots.txt file for the test site
       if: inputs.deployment-environment == 'test'
       run: |
-        touch norobots.txt
-        echo "User-agent: *" > norobots.txt
-        echo "Disallow: /" >> norobots.txt
-      working-directory: deploy-directory/docs
+        echo "User-agent: *" > deploy-directory/docs/norobots.txt
+        echo "Disallow: /" >> deploy-directory/docs/norobots.txt
 
     - name: Configure the git user
       run: |

--- a/.github/workflows/reusable-deploy-docs.yaml
+++ b/.github/workflows/reusable-deploy-docs.yaml
@@ -48,7 +48,7 @@ jobs:
       name: deploy-package-docs
       url: ${{ env.ENV_URL }}
     env:
-      TARGET: ${{ github.event.inputs.deployment-environment }}
+      TARGET: ${{ inputs.deployment-environment }}
       DEST_REPO: ansible-community/package-doc-builds
       USER_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
       USER_NAME: "github-actions[bot]"
@@ -67,7 +67,7 @@ jobs:
     - name: Set the production branch and url
       if: env.TARGET == 'production'
       env:
-        BRANCH_NAME: ${{ github.event.inputs.ansible-package-version }}
+        BRANCH_NAME: ${{ inputs.ansible-package-version }}
         PROD_URL: https://ansible.readthedocs.io/projects/ansible
       run: |
         echo "BRANCH=${BRANCH_NAME}" >> "${GITHUB_ENV}"


### PR DESCRIPTION
I noticed that the scheduled jobs to deploy the latest build were failing because the branch was not getting set properly. This PR fixes that issue with the following changes:

- Use `inputs` instead of `github.event.inputs`. The reusable workflows with `workflow_call` need to [access inputs through the `inputs` context](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#inputs-context).
- Remove the `TARGET` env and use `inputs.deployment-environment` directly.
- Also simplified the step to create a norobots.txt file when deploying to test.