### PR TITLE
porting guide 2.19 - describe lazy complex var eval impact on builtin filters/tests

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.19.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.19.rst
@@ -766,6 +766,56 @@ Noteworthy plugin changes
   This filter now returns ``False`` instead of ``None`` when the input is ``None``.
   The aforementioned deprecation warning is also issued in this case.
 
+* Passing complex, partially undefined variables to Jinja2 filters such as ``default`` and ``mandatory``,
+  and test plugins ``defined`` and ``undefined`` no longer behaves the same way now that complex variables
+  are evaluated lazily. In earlier versions, an undefined element of a complex variable would result in
+  the whole variable being undefined. In 2.19, this assertion passes:
+
+  .. code-block:: yaml
+
+     - assert:
+         that:
+           - complex_var is defined
+           - (complex_var | default(unused)).nested is undefined
+           - complex_var.nested is undefined
+       vars:
+         complex_var:
+           nested: "{{ undefined_variable }}"
+         unused:
+           nested: default
+
+  To restore the previous behavior and evaluate a complex variable without using it recursively, use a filter
+  which recursively templates the variable (for example, ``string``, ``to_json``, ``to_yaml``) in conjunction with the
+  ``defined``/``undefined`` tests and the ``ternary`` filter:
+
+  .. code-block:: yaml
+
+     - vars:
+         complex_var:
+           nested: "{{ undefined_variable }}"
+         default_complex:
+           nested:
+             argument: fallback
+       block:
+         - name: Variable that relied on templating unused elements of complex variables recursively
+           assert:
+             that: variable == default_complex
+           vars:
+             variable: "{{ complex_var | default(default_complex) }}"
+           ignore_errors: True
+
+         - name: Variable adjusted for 2.19
+           assert:
+             that: variable == default_complex
+           vars:
+             variable: "{{ (complex_var | to_json is defined) | ternary(complex_var, default_complex) }}"
+
+         - name: Variable adjusted for 2.19 and backwards compatibility
+           assert:
+             that: variable == default_complex
+           vars:
+             variable: "{{ (complex_var is undefined or complex_var | to_json is undefined) | ternary(default_complex, complex_var) }}"
+
 
 Porting custom scripts
 ======================

--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.19.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.19.rst
@@ -784,38 +784,6 @@ Noteworthy plugin changes
          unused:
            nested: default
 
-  To restore the previous behavior and evaluate a complex variable without using it recursively, use a filter
-  which recursively templates the variable (for example, ``string``, ``to_json``, ``to_yaml``) in conjunction with the
-  ``defined``/``undefined`` tests and the ``ternary`` filter:
-
-  .. code-block:: yaml
-
-     - vars:
-         complex_var:
-           nested: "{{ undefined_variable }}"
-         default_complex:
-           nested:
-             argument: fallback
-       block:
-         - name: Variable that relied on templating unused elements of complex variables recursively
-           assert:
-             that: variable == default_complex
-           vars:
-             variable: "{{ complex_var | default(default_complex) }}"
-           ignore_errors: True
-
-         - name: Variable adjusted for 2.19
-           assert:
-             that: variable == default_complex
-           vars:
-             variable: "{{ (complex_var | to_json is defined) | ternary(complex_var, default_complex) }}"
-
-         - name: Variable adjusted for 2.19 and backwards compatibility
-           assert:
-             that: variable == default_complex
-           vars:
-             variable: "{{ (complex_var is undefined or complex_var | to_json is undefined) | ternary(default_complex, complex_var) }}"
-
 
 Porting custom scripts
 ======================

--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.19.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.19.rst
@@ -776,7 +776,7 @@ Noteworthy plugin changes
 
      - assert:
          that:
-           # Check that the parent variable exists (same as previous versions).
+           # Unlike earlier versions, complex_var is defined even though complex_var.nested is not.
            - complex_var is defined
            # Apply the default filter to complex_var and then access the nested property.
            # In 2.19, the embedded template "{{ undefined_variable }}" is not evaluated until use.

--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.19.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.19.rst
@@ -793,6 +793,7 @@ Noteworthy plugin changes
            nested: "{{ undefined_variable }}"
          unused:
            # This variable is used only if "complex_var" is undefined.
+           # This only happens in ansible-core before 2.19.
            nested: default
 
 

--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.19.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.19.rst
@@ -780,8 +780,7 @@ Noteworthy plugin changes
            - complex_var is defined
            # Unlike earlier versions, the default value is not applied because complex_var is defined.
            - (complex_var | default(unused)).nested is undefined
-           # Directly access the nested property with an embedded template.
-           # In 2.19, this also asserts as undefined because the template is not yet evaluated.
+           # Like earlier versions, directly accessing complex_var.nested evaluates as undefined.
            - complex_var.nested is undefined
        vars:
          complex_var:

--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.19.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.19.rst
@@ -778,9 +778,7 @@ Noteworthy plugin changes
          that:
            # Unlike earlier versions, complex_var is defined even though complex_var.nested is not.
            - complex_var is defined
-           # Apply the default filter to complex_var and then access the nested property.
-           # In 2.19, the embedded template "{{ undefined_variable }}" is not evaluated until use.
-           # This asserts as undefined.
+           # Unlike earlier versions, the default value is not applied because complex_var is defined.
            - (complex_var | default(unused)).nested is undefined
            # Directly access the nested property with an embedded template.
            # In 2.19, this also asserts as undefined because the template is not yet evaluated.

--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.19.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.19.rst
@@ -784,12 +784,11 @@ Noteworthy plugin changes
            - complex_var.nested is undefined
        vars:
          complex_var:
-           # This nested value contains an embedded template with an undefined variable.
-           # Before 2.19 the embedded template would be evaluated immediately.
-           # In 2.19 the embedded template is evaluated only when it is accessed.
+           # Before 2.19, complex_var.nested is evaluated immediately when complex_var is accessed.
+           # In 2.19, complex_var.nested is evaluated only when it is accessed.
            nested: "{{ undefined_variable }}"
          unused:
-           # This variable is used only if "complex_var" is undefined.
+           # This variable is used only if complex_var is undefined.
            # This only happens in ansible-core before 2.19.
            nested: default
 

--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.19.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.19.rst
@@ -767,21 +767,32 @@ Noteworthy plugin changes
   The aforementioned deprecation warning is also issued in this case.
 
 * Passing nested non-scalars with embedded templates that may resolve to ``Undefined`` to Jinja2
-  filter plugins such as ``default`` and ``mandatory``, and test plugins including ``defined`` and ``undefined``
-  no longer evaluate the same, since nested non-scalars with embedded templates are only templated on use.
+  filter plugins, such as ``default`` and ``mandatory``, and test plugins including ``defined`` and ``undefined``
+  no longer evaluate as they did in previous versions because nested non-scalars with embedded templates are templated
+  on use only.
   In 2.19, this assertion passes:
 
   .. code-block:: yaml
 
      - assert:
          that:
+           # Check that the parent variable exists (same as previous versions).
            - complex_var is defined
+           # Apply the default filter to complex_var and then access the nested property.
+           # In 2.19, the embedded template "{{ undefined_variable }}" is not evaluated until use.
+           # This asserts as undefined.
            - (complex_var | default(unused)).nested is undefined
+           # Directly access the nested property with an embedded template.
+           # In 2.19, this also asserts as undefined because the template is not yet evaluated.
            - complex_var.nested is undefined
        vars:
          complex_var:
+           # This nested value contains an embedded template with an undefined variable.
+           # Before 2.19 the embedded template would be evaluated immediately.
+           # In 2.19 the embedded template is evaluated only when it is accessed.
            nested: "{{ undefined_variable }}"
          unused:
+           # This variable is used only if "complex_var" is undefined.
            nested: default
 
 

--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.19.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.19.rst
@@ -766,10 +766,10 @@ Noteworthy plugin changes
   This filter now returns ``False`` instead of ``None`` when the input is ``None``.
   The aforementioned deprecation warning is also issued in this case.
 
-* Passing complex, partially undefined variables to Jinja2 filters such as ``default`` and ``mandatory``,
-  and test plugins ``defined`` and ``undefined`` no longer behaves the same way now that complex variables
-  are evaluated lazily. In earlier versions, an undefined element of a complex variable would result in
-  the whole variable being undefined. In 2.19, this assertion passes:
+* Passing nested non-scalars with embedded templates that may resolve to ``Undefined`` to Jinja2
+  filter plugins such as ``default`` and ``mandatory``, and test plugins including ``defined`` and ``undefined``
+  no longer evaluate the same, since nested non-scalars with embedded templates are only templated on use.
+  In 2.19, this assertion passes:
 
   .. code-block:: yaml
 


### PR DESCRIPTION
This is generally covered by https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_12.html#lazy-templating, but t I think it would be helpful to give a couple examples as well.