### PR TITLE
add sphinx nitpick_ignore_regex configuration

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -176,7 +176,7 @@ exclude_patterns += [] if tags.has('all') else [
 ] if tags.has('ansible') else '<UNKNOWN>'
 
 nitpick_ignore_regex = [
-    (r"py:.*", r"ansible\.module_utils\._internal\..*"),
+    (r"py:.*", r"ansible\..*_internal\..*"),
 ]
 
 # The reST default role (used for this markup: `text`) to use for all

--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -176,7 +176,7 @@ exclude_patterns += [] if tags.has('all') else [
 ] if tags.has('ansible') else '<UNKNOWN>'
 
 nitpick_ignore_regex = [
-    (r"py:.*", r"ansible\..*_internal\..*"),
+    (r"py:.*", r"ansible\.(?:.*\.)?_internal\..*"),
 ]
 
 # The reST default role (used for this markup: `text`) to use for all

--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -175,6 +175,10 @@ exclude_patterns += [] if tags.has('all') else [
     'porting_guides/core_porting_guides',
 ] if tags.has('ansible') else '<UNKNOWN>'
 
+nitpick_ignore_regex = [
+    (r"py:.*", r"ansible\.module_utils\._internal\..*"),
+]
+
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
 # default_role = None

--- a/docs/docsite/rst/reference_appendices/module_utils.rst
+++ b/docs/docsite/rst/reference_appendices/module_utils.rst
@@ -26,15 +26,6 @@ To use this functionality, include ``import ansible.module_utils.basic`` in your
 .. automodule:: ansible.module_utils.basic
    :members:
 
-
-PluginInfo
-==========
-
-To use this functionality, include ``from ansible.module_utils.common.messages import PluginInfo`` in your module.
-
-.. autoclass:: ansible.module_utils.common.messages.PluginInfo
-   :members:
-
 Argument Spec
 =============
 


### PR DESCRIPTION
Ignore the _internal directories in ansible, including the class `ansible.module_utils._internal._messages.PluginInfo`, which is causing `nox -e checkers` to fail.