### PR TITLE
unreachable hosts do not execute the always section either

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_blocks.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_blocks.rst
@@ -60,7 +60,7 @@ You can control how Ansible responds to task errors using blocks with ``rescue``
 
 .. note::
 
-    Errors caused by bad task definitions and unreachable hosts do not trigger the ``rescue`` or ``always`` sections of a block.
+    Errors caused by invalid task definitions and unreachable hosts do not trigger the ``rescue`` or ``always`` sections of a block.
 
 Rescue blocks specify tasks to run when an earlier task in a block fails. This approach is similar to exception handling in many programming languages. Ansible only runs rescue blocks after a task returns a 'failed' state.
 

--- a/docs/docsite/rst/playbook_guide/playbooks_blocks.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_blocks.rst
@@ -58,7 +58,11 @@ Handling errors with blocks
 
 You can control how Ansible responds to task errors using blocks with ``rescue`` and ``always`` sections.
 
-Rescue blocks specify tasks to run when an earlier task in a block fails. This approach is similar to exception handling in many programming languages. Ansible only runs rescue blocks after a task returns a 'failed' state. Bad task definitions and unreachable hosts will not trigger the rescue block.
+.. note::
+
+    Errors caused by bad task definitions and unreachable hosts do not trigger the ``rescue`` or ``always`` sections of a block.
+
+Rescue blocks specify tasks to run when an earlier task in a block fails. This approach is similar to exception handling in many programming languages. Ansible only runs rescue blocks after a task returns a 'failed' state.
 
 .. _block_rescue:
 .. code-block:: YAML


### PR DESCRIPTION
Unreachable hosts are excluded from the list of active hosts, meaning that the `always` section does not run, as designed.