### PR TITLE
Collection requirements: declare that Galaxy artifacts must not be deleted once they appear in Ansible releases

### DIFF
--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -96,6 +96,9 @@ The following guidelines describe the required infrastructure for your collectio
   * If the collection has its own CoC, it MUST be evaluated by the :ref:`Diversity and Inclusion working group <working_group_list>` and confirmed as compatible with the :ref:`code_of_conduct`.
 
 * MUST be published to `Ansible Galaxy <https://galaxy.ansible.com>`_ with version 1.0.0 or later.
+
+  * Collection artifacts published on Ansible Galaxy MUST NOT be deleted once they appear in any Ansible release, even if it is a pre-release.
+
 * MUST contain only objects that follow the :ref:`Licensing rules <coll_licensing_req>`.
 * SHOULD NOT contain any large objects (binaries) comparatively to the current Galaxy tarball size limit of 20 MB, For example, do not include package installers for testing purposes.
 * SHOULD NOT contain any unnecessary files such as temporary files.


### PR DESCRIPTION
This updates the Ansible community package collections requirements. This change was prompted by the deletion of a collection release already contained in Ansible 12.0.0b4, which broke the build of that release, *and also of all newer and upcoming Ansible 12 releases* (as the changelog can no longer be built).