### PR TITLE
fix option for _ANSIBLE_TEMPLAR_UNTRUSTED_TEMPLATE_BEHAVIOR

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.19.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.19.rst
@@ -239,7 +239,7 @@ The environment variable ``_ANSIBLE_TEMPLAR_UNTRUSTED_TEMPLATE_BEHAVIOR`` can be
 
 Valid options are:
 
-* ``warn`` - A warning will be issued when an untrusted template is encountered.
+* ``warning`` - A warning will be issued when an untrusted template is encountered.
 * ``fail`` - An error will be raised when an untrusted template is encountered.
 * ``ignore`` - Untrusted templates are silently ignored and used as-is. This is the default behavior.
 


### PR DESCRIPTION
Fix option for `_ANSIBLE_TEMPLAR_UNTRUSTED_TEMPLATE_BEHAVIOR` `warn` to `warning`.

related to https://github.com/ansible/ansible/blob/stable-2.19/lib/ansible/config/base.yml#L2090

