### PR TITLE
add details on some plugin options - AI-assisted

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -63,7 +63,7 @@ To define configurable options for your plugin, describe them in the ``DOCUMENTA
         description: describe this config option
         default: default value for this config option
         env:
-          - name: MYCOLLECTION_NAME_OF_ENV_VAR
+          - name: MYCOLLECTION_NAME_ENV_VAR_NAME
         ini:
           - section: mycollection_section_of_ansible.cfg_where_this_config_option_is_defined
             key: key_used_in_ansible.cfg
@@ -115,7 +115,7 @@ General precedence rules
 
 * Keywords
 * CLI settings
-* Environment variables
+* Environment variables (``env``)
 * Values defined in ``ansible.cfg``
 * Default value for the option, if present.
 

--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -63,17 +63,44 @@ To define configurable options for your plugin, describe them in the ``DOCUMENTA
         description: describe this config option
         default: default value for this config option
         env:
-          - name: NAME_OF_ENV_VAR
+          - name: MYCOLLECTION_NAME_OF_ENV_VAR
         ini:
-          - section: section_of_ansible.cfg_where_this_config_option_is_defined
-            key: key_used_in_ansible.cfg
+          - section: mycollection_section_of_ansible.cfg_where_this_config_option_is_defined
+            key: mycollection_key_used_in_ansible.cfg
         vars:
-          - name: name_of_ansible_var
-          - name: name_of_second_var
+          - name: mycollection_name_of_ansible_var
+          - name: mycollection_name_of_second_var
             version_added: X.x
         required: True/False
         type: boolean/float/integer/list/none/path/pathlist/pathspec/string/tmppath
         version_added: X.x
+
+The supported configuration fields are:
+
+**env**
+  List of environment variables that can be used to set this option.
+  Each entry includes a ``name`` field specifying the environment variable name.
+  The name should be in uppercase and should be prefixed with the collection name.
+  Multiple environment variables can be listed for the same option.
+  The first environment variable in the list takes precedence if multiple are set.
+  This is commonly used for plugins (especially inventory plugins) to allow configuration through environment variables.
+  
+
+**ini**
+  List of configuration file settings that can be used to set this option.
+  Each entry includes a ``section`` field for the configuration file section and a ``key`` field for the configuration key. Both should be in lowercase and should be prefixed with the collection name.
+  Multiple configuration settings can be listed for the same option.
+  This allows plugins to be configured via ansible.cfg.
+  
+
+**vars**
+  List of Ansible variables that can be used to set this option.
+  Each entry includes a ``name`` field specifying the variable name.
+  The name should be in lowercase and should be prefixed with the collection name.
+  Multiple variables can be listed for the same option.
+  Variables follow Ansible's variable precedence rules.
+  This allows plugins to be configured via Ansible variables.
+  
 
 To access the configuration settings in your plugin, use ``self.get_option(<option_name>)``. 
 Some plugin types handle this differently:

--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -114,7 +114,7 @@ General precedence rules
 * CLI settings
 * Environment variables
 * Values defined in ``ansible.cfg``
-* Option's default value, if present. ``None`` if there is no default.
+* Option's default value, if present.
 
 .. _accessing_configuration_settings:
 

--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -82,7 +82,7 @@ The supported configuration fields are:
   Each entry includes a ``name`` field specifying the environment variable name.
   The name should be in uppercase and should be prefixed with the collection name.
   Multiple environment variables can be listed for the same option.
-  The first environment variable in the list takes precedence if multiple are set.
+  The last environment variable in the list takes precedence if multiple are set.
   This is commonly used for plugins (especially inventory plugins) to allow configuration through environment variables.
   
 
@@ -90,6 +90,7 @@ The supported configuration fields are:
   List of configuration file settings that can be used to set this option.
   Each entry includes a ``section`` field for the configuration file section and a ``key`` field for the configuration key. Both should be in lowercase and should be prefixed with the collection name.
   Multiple configuration settings can be listed for the same option.
+  The last configuration setting in the list takes precedence if multiple are set.
   This allows plugins to be configured via ansible.cfg.
   
 
@@ -98,9 +99,29 @@ The supported configuration fields are:
   Each entry includes a ``name`` field specifying the variable name.
   The name should be in lowercase and should be prefixed with the collection name.
   Multiple variables can be listed for the same option.
+  The last variable in the list takes precedence if multiple are set.
   Variables follow Ansible's variable precedence rules.
   This allows plugins to be configured via Ansible variables.
-  
+
+.. _general_plugin_precedence_rules:
+
+General precedence rules
+------------------------
+
+ The precedence rules for configuration sources are listed below,starting with the highest precedence values:
+
+* Direct specification 
+* Ansible variables
+* Keywords
+* CLI settings
+* Environment variables
+* Values defined in ``ansible.cfg``
+* Option's default value, if present. None if there is no default.
+
+.. _accessing_configuration_settings:
+
+Accessing configuration settings
+--------------------------------
 
 To access the configuration settings in your plugin, use ``self.get_option(<option_name>)``. 
 Some plugin types handle this differently:

--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -84,6 +84,7 @@ The supported configuration fields are:
   Multiple environment variables can be listed for the same option.
   The last set environment variable in the list takes precedence if multiple are set.
   This is commonly used for plugins (especially inventory plugins) to allow configuration through environment variables.
+  Examples: ``VMWARE_PORT``, ``GRAFANA_PASSWORD``
   
 
 **ini**
@@ -92,6 +93,7 @@ The supported configuration fields are:
   Multiple configuration settings can be listed for the same option.
   The last set configuration setting in the list takes precedence if multiple are set.
   This allows plugins to be configured with ansible.cfg.
+  Example: ``grafana_password``
   
 
 **vars**
@@ -102,6 +104,7 @@ The supported configuration fields are:
   The last set variable in the list takes precedence if multiple are set.
   Variables follow Ansible's variable precedence rules.
   This allows plugins to be configured with Ansible variables.
+  Example: ``ansible_vmware_port``
 
 .. _general_plugin_precedence_rules:
 

--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -66,7 +66,7 @@ To define configurable options for your plugin, describe them in the ``DOCUMENTA
           - name: MYCOLLECTION_NAME_OF_ENV_VAR
         ini:
           - section: mycollection_section_of_ansible.cfg_where_this_config_option_is_defined
-            key: mycollection_key_used_in_ansible.cfg
+            key: key_used_in_ansible.cfg
         vars:
           - name: mycollection_name_of_ansible_var
           - name: mycollection_name_of_second_var

--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -82,7 +82,7 @@ The supported configuration fields are:
   Each entry includes a ``name`` field specifying the environment variable name.
   The name should be in uppercase and should be prefixed with the collection name.
   Multiple environment variables can be listed for the same option.
-  The last environment variable in the list takes precedence if multiple are set.
+  The last set environment variable in the list takes precedence if multiple are set.
   This is commonly used for plugins (especially inventory plugins) to allow configuration through environment variables.
   
 
@@ -90,7 +90,7 @@ The supported configuration fields are:
   List of configuration file settings that can be used to set this option.
   Each entry includes a ``section`` field for the configuration file section and a ``key`` field for the configuration key. Both should be in lowercase and should be prefixed with the collection name.
   Multiple configuration settings can be listed for the same option.
-  The last configuration setting in the list takes precedence if multiple are set.
+  The last set configuration setting in the list takes precedence if multiple are set.
   This allows plugins to be configured via ansible.cfg.
   
 
@@ -99,7 +99,7 @@ The supported configuration fields are:
   Each entry includes a ``name`` field specifying the variable name.
   The name should be in lowercase and should be prefixed with the collection name.
   Multiple variables can be listed for the same option.
-  The last variable in the list takes precedence if multiple are set.
+  The last set variable in the list takes precedence if multiple are set.
   Variables follow Ansible's variable precedence rules.
   This allows plugins to be configured via Ansible variables.
 
@@ -108,15 +108,13 @@ The supported configuration fields are:
 General precedence rules
 ------------------------
 
- The precedence rules for configuration sources are listed below,starting with the highest precedence values:
+ The precedence rules for configuration sources are listed below, starting with the highest precedence values:
 
-* Direct specification 
-* Ansible variables
 * Keywords
 * CLI settings
 * Environment variables
 * Values defined in ``ansible.cfg``
-* Option's default value, if present. None if there is no default.
+* Option's default value, if present. ``None`` if there is no default.
 
 .. _accessing_configuration_settings:
 

--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -91,7 +91,7 @@ The supported configuration fields are:
   Each entry includes a ``section`` field for the configuration file section and a ``key`` field for the configuration key. Both should be in lowercase and should be prefixed with the collection name.
   Multiple configuration settings can be listed for the same option.
   The last set configuration setting in the list takes precedence if multiple are set.
-  This allows plugins to be configured via ansible.cfg.
+  This allows plugins to be configured with ansible.cfg.
   
 
 **vars**
@@ -101,7 +101,7 @@ The supported configuration fields are:
   Multiple variables can be listed for the same option.
   The last set variable in the list takes precedence if multiple are set.
   Variables follow Ansible's variable precedence rules.
-  This allows plugins to be configured via Ansible variables.
+  This allows plugins to be configured with Ansible variables.
 
 .. _general_plugin_precedence_rules:
 
@@ -114,7 +114,7 @@ General precedence rules
 * CLI settings
 * Environment variables
 * Values defined in ``ansible.cfg``
-* Option's default value, if present.
+* Default value for the option, if present.
 
 .. _accessing_configuration_settings:
 


### PR DESCRIPTION
Fixes #2673

Should have done this in 2 commits (AI-generated, then human adapted).  Lines 78-93 are predominantly generated.

To fix this bug, I fed the following into Cursor chat mode:
`Fix the documentation problems from @https://github.com/ansible/ansible-documentation/issues/2673`