### PR TITLE
Fixes #2830 uses actions/create-github-app-token@v2

### DIFF
--- a/.github/workflows/release-porting-guide.yml
+++ b/.github/workflows/release-porting-guide.yml
@@ -24,7 +24,6 @@ jobs:
       CI_COMMIT_MESSAGE: >-
         Add the Ansible community ${{ inputs.ansible-version }} porting guide
 
-
     steps:
       - name: Extract the major version
         run: echo "ANSIBLE_VERSION_MAJOR=${ANSIBLE_VERSION_FULL%%.*}" >> "${GITHUB_ENV}"

--- a/.github/workflows/release-porting-guide.yml
+++ b/.github/workflows/release-porting-guide.yml
@@ -28,8 +28,18 @@ jobs:
         run: echo "ANSIBLE_VERSION_MAJOR=${ANSIBLE_VERSION_FULL%%.*}" >> "${GITHUB_ENV}"
         shell: bash --noprofile --norc -O extglob -eEuo pipefail {0}
 
+      - name: Generate temp GITHUB_TOKEN
+        id: create_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_KEY }}
+
       - name: Check out this repo src
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.create_token.outputs.token }}
+
       - name: Check out ansible-build-data
         uses: actions/checkout@v4
         with:
@@ -59,11 +69,13 @@ jobs:
           git commit -m "${CI_COMMIT_MESSAGE}"
 
       - name: Push to the repo
+        env:
+          GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}
         run: git push origin "${GIT_BRANCH}"
 
       - name: Create the porting guide PR as draft
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}
           PR_BODY_MESSAGE: |-
             ##### SUMMARY
 

--- a/.github/workflows/release-porting-guide.yml
+++ b/.github/workflows/release-porting-guide.yml
@@ -17,11 +17,13 @@ jobs:
   upload-porting-guide:
     name: Extract the porting guide
     runs-on: ubuntu-latest
+    environment: github-bot
     env:
       GIT_BRANCH: "release/porting-guide-${{ inputs.ansible-version }}"
       ANSIBLE_VERSION_FULL: ${{ inputs.ansible-version }}
       CI_COMMIT_MESSAGE: >-
         Add the Ansible community ${{ inputs.ansible-version }} porting guide
+
 
     steps:
       - name: Extract the major version
@@ -32,8 +34,8 @@ jobs:
         id: create_token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
-          private-key: ${{ secrets.BOT_APP_KEY }}
+          app-id: ${{ secrets.BOT_APP_ID }} # From github-bot environment
+          private-key: ${{ secrets.BOT_APP_KEY }} # From github-bot environment
 
       - name: Check out this repo src
         uses: actions/checkout@v4


### PR DESCRIPTION
In this PR I am using [actions/create-github-app-token@v2](https://github.com/actions/create-github-app-token) to get a `GITHUB_TOKEN` which can push in a branch and also create a PR. 

I created a test app  on personal ansible-documentation testing repository and tested the workflow [here](https://github.com/anweshadas/actiontesting/actions/runs/16356953697/job/46217451544). The workflow ran successfully and created draft PR.

The  [actions/create-github-app-token@v2](https://github.com/actions/create-github-app-token)  action is already being used in `.github/workflows/reusable-pip-compile.yml` file. 
  