### PR TITLE
Styleguide update for installation_distros.rst - AI-assisted

### DIFF
--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -16,7 +16,7 @@ This guide shows you how to install Ansible from different distribution package 
 Requirements for adding new distributions
 -----------------------------------------
 
-To add instructions for another distribution to this guide, package maintainers **must** do the following:
+Package maintainers who want to add instructions for another distribution to this guide must meet the following requirements:
 
 * Ensure the distribution provides a reasonably up-to-date version of ``ansible``.
 * Keep ``ansible-core`` and ``ansible`` versions synchronized to the extent that the build system allows.
@@ -27,7 +27,9 @@ To add instructions for another distribution to this guide, package maintainers 
   :local:
 
 Installing Ansible on Fedora Linux
-----------------------------------
+-----------------------------------
+
+Fedora Linux provides both the full Ansible package and the minimal ansible-core package through the standard repositories.
 
 Install the full ``ansible`` package:
 
@@ -49,12 +51,14 @@ For example, install the ``community.general`` collection:
    $ sudo dnf install ansible-collection-community-general
 
 See the `Fedora Packages index <https://packages.fedoraproject.org/search?query=ansible-collection>`_
-for a full list of Ansible collections packaged in Fedora.
+for a complete list of Ansible collections packaged in Fedora.
 
 Contact the package maintainers by `filing a bug <https://bugzilla.redhat.com/enter_bug.cgi>`_ against the ``Fedora`` product in Red Hat Bugzilla.
 
 Installing Ansible from EPEL
-----------------------------
+-----------------------------
+
+The EPEL repository provides Ansible packages for Enterprise Linux distributions.
 
 If you use CentOS Stream, Almalinux, Rocky Linux, or related distributions, you can install ``ansible`` or Ansible collections from the community-maintained `EPEL <https://docs.fedoraproject.org/en-US/epel/>`_ (Extra Packages for Enterprise Linux) repository.
 
@@ -64,7 +68,9 @@ Then use the same ``dnf`` commands as for Fedora Linux.
 Contact the package maintainers by `filing a bug <https://bugzilla.redhat.com/enter_bug.cgi>`_ against the ``Fedora EPEL`` product in Red Hat Bugzilla.
 
 Installing Ansible on OpenSUSE Tumbleweed/Leap
-----------------------------------------------
+-----------------------------------------------
+
+OpenSUSE provides Ansible packages through the standard package manager.
 
 .. code-block:: bash
 
@@ -75,7 +81,9 @@ See the `OpenSUSE Support Portal <https://en.opensuse.org/Portal:Support>`_ for 
 .. _from_apt:
 
 Installing Ansible on Ubuntu
-----------------------------
+-----------------------------
+
+Ubuntu provides Ansible packages through a Personal Package Archive (PPA) that contains more recent versions than the standard repositories.
 
 Ubuntu builds are available `in a PPA here <https://launchpad.net/~ansible/+archive/ubuntu/ansible>`_.
 
@@ -97,9 +105,11 @@ Configure the PPA on your system and install Ansible:
 File any issues in `the PPA's issue tracker <https://github.com/ansible-community/ppa/issues>`_.
 
 Installing Ansible on Debian
-----------------------------
+-----------------------------
 
-While Ansible is available from the `main Debian repository <https://packages.debian.org/stable/ansible>`_, it can be outdated.
+Debian users can choose between the standard repository or the Ubuntu PPA for more recent versions.
+
+While Ansible is available from the `main Debian repository <https://packages.debian.org/stable/ansible>`_, this version can be outdated.
 
 For a more recent version, Debian users can use the Ubuntu PPA according to the following table:
 
@@ -142,12 +152,14 @@ Set ``UBUNTU_CODENAME=...`` based on the table above (we use ``jammy`` in this e
 These commands download the signing key and add an entry to apt's sources pointing to the PPA.
 
 Previously, you may have used ``apt-key add``.
-This approach is now `deprecated <https://manpages.debian.org/testing/apt/apt-key.8.en.html>`_ for security reasons (on Debian, Ubuntu, and elsewhere).
-For more details, see `this AskUbuntu post <https://askubuntu.com/a/1307181>`_.
-For security reasons, we do NOT add the key to ``/etc/apt/trusted.gpg.d/`` or to ``/etc/apt/trusted.gpg`` where it would be allowed to sign releases from ANY repository.
+The ``apt-key add`` approach is now `deprecated <https://askubuntu.com/a/1307181>`_ for security reasons (on Debian, Ubuntu, and elsewhere).
+
+As such, we do NOT add the key to ``/etc/apt/trusted.gpg.d/`` or to ``/etc/apt/trusted.gpg`` where the key would be allowed to sign releases from ANY repository.
 
 Installing Ansible on Arch Linux
---------------------------------
+---------------------------------
+
+Arch Linux provides both the full Ansible package and ansible-core through the standard package repositories.
 
 Install the full ``ansible`` package:
 

--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -3,17 +3,25 @@
 Installing Ansible on specific operating systems
 ================================================
 
-.. note:: These instructions are provided by their respective communities. Any bugs/issues should be filed with that community to update these instructions. Ansible maintains only the ``pip install`` instructions.
+.. note:: 
+   These instructions come from their respective communities. 
+   If you encounter bugs or issues, file them with that community to update these instructions. 
+   Ansible maintains only the ``pip install`` instructions.
 
-The ``ansible`` package can always be :ref:`installed from PyPI using pip <intro_installation_guide>` on most systems but it is also packaged and maintained by the community for a variety of Linux distributions.
+You can always :ref:`install the ansible package from PyPI using pip <intro_installation_guide>` on most systems.
+The community also packages and maintains Ansible for various Linux distributions.
 
-This document guides you through installing Ansible from different distribution's package repositories.
+This guide shows you how to install Ansible from different distribution package repositories.
+
+Requirements for adding new distributions
+-----------------------------------------
 
 To add instructions for another distribution to this guide, package maintainers **must** do the following:
 
-    * Ensure the distribution provides a reasonably up-to-date version of ``ansible``.
-    * Ensure that ``ansible-core`` and ``ansible`` versions are kept in sync to the extent that the build system allows.
-    * Provide a way to contact the distribution maintainers as part of the instructions. Distribution maintainers are also encouraged to join the `Ansible Packaging <https://matrix.to/#/#packaging:ansible.com>`_ Matrix room.
+* Ensure the distribution provides a reasonably up-to-date version of ``ansible``.
+* Keep ``ansible-core`` and ``ansible`` versions synchronized to the extent that the build system allows.
+* Provide a way to contact the distribution maintainers as part of the instructions. 
+  Distribution maintainers are also encouraged to join the `Ansible Packaging <https://matrix.to/#/#packaging:ansible.com>`_ Matrix room.
 
 .. contents::
   :local:
@@ -21,21 +29,20 @@ To add instructions for another distribution to this guide, package maintainers 
 Installing Ansible on Fedora Linux
 ----------------------------------
 
-To install the full ``ansible`` package run:
+Install the full ``ansible`` package:
 
 .. code-block:: bash
 
     $ sudo dnf install ansible
 
-To install the minimal ``ansible-core`` package run:
+Install the minimal ``ansible-core`` package:
 
 .. code-block:: bash
 
     $ sudo dnf install ansible-core
 
-Several Ansible collections are also available from the Fedora repositories as
-standalone packages that users can install alongside ``ansible-core``.
-For example, to install the ``community.general`` collection run:
+Fedora repositories include several Ansible collections as standalone packages that you can install alongside ``ansible-core``.
+For example, install the ``community.general`` collection:
 
 .. code-block:: bash
 
@@ -44,23 +51,17 @@ For example, to install the ``community.general`` collection run:
 See the `Fedora Packages index <https://packages.fedoraproject.org/search?query=ansible-collection>`_
 for a full list of Ansible collections packaged in Fedora.
 
-Please `file a bug <https://bugzilla.redhat.com/enter_bug.cgi>`_ against the
-``Fedora`` product in Red Hat Bugzilla to reach the package maintainers.
+Contact the package maintainers by `filing a bug <https://bugzilla.redhat.com/enter_bug.cgi>`_ against the ``Fedora`` product in Red Hat Bugzilla.
 
 Installing Ansible from EPEL
 ----------------------------
 
-Users of CentOS Stream, Almalinux, Rocky Linux, and related distributions
-can install ``ansible`` or Ansible collections from the community maintained
-`EPEL <https://docs.fedoraproject.org/en-US/epel/>`_
-(Extra Packages for Enterprise Linux) repository.
+If you use CentOS Stream, Almalinux, Rocky Linux, or related distributions, you can install ``ansible`` or Ansible collections from the community-maintained `EPEL <https://docs.fedoraproject.org/en-US/epel/>`_ (Extra Packages for Enterprise Linux) repository.
 
-After `enabling the EPEL repository <https://docs.fedoraproject.org/en-US/epel/#_quickstart>`_,
-users can use the same ``dnf`` commands as for Fedora Linux.
+First, `enable the EPEL repository <https://docs.fedoraproject.org/en-US/epel/#_quickstart>`_.
+Then use the same ``dnf`` commands as for Fedora Linux.
 
-Please `file a bug <https://bugzilla.redhat.com/enter_bug.cgi>`_ against the
-``Fedora EPEL`` product in Red Hat Bugzilla to reach the package maintainers.
-
+Contact the package maintainers by `filing a bug <https://bugzilla.redhat.com/enter_bug.cgi>`_ against the ``Fedora EPEL`` product in Red Hat Bugzilla.
 
 Installing Ansible on OpenSUSE Tumbleweed/Leap
 ----------------------------------------------
@@ -69,7 +70,7 @@ Installing Ansible on OpenSUSE Tumbleweed/Leap
 
     $ sudo zypper install ansible
 
-See `OpenSUSE Support Portal <https://en.opensuse.org/Portal:Support>`_ for additional help with Ansible on OpenSUSE.
+See the `OpenSUSE Support Portal <https://en.opensuse.org/Portal:Support>`_ for additional help with Ansible on OpenSUSE.
 
 .. _from_apt:
 
@@ -78,7 +79,7 @@ Installing Ansible on Ubuntu
 
 Ubuntu builds are available `in a PPA here <https://launchpad.net/~ansible/+archive/ubuntu/ansible>`_.
 
-To configure the PPA on your system and install Ansible run these commands:
+Configure the PPA on your system and install Ansible:
 
 .. code-block:: bash
 
@@ -87,17 +88,20 @@ To configure the PPA on your system and install Ansible run these commands:
     $ sudo add-apt-repository --yes --update ppa:ansible/ansible
     $ sudo apt install ansible
 
-.. note:: On older Ubuntu distributions, "software-properties-common" is called "python-software-properties". You may want to use ``apt-get`` rather than ``apt`` in older versions. Also, be aware that only newer distributions (that is, 18.04, 18.10, and later) have a ``-u`` or ``--update`` flag. Adjust your script as needed.
+.. note:: 
+   On older Ubuntu distributions, "software-properties-common" is called "python-software-properties". 
+   You may want to use ``apt-get`` rather than ``apt`` in older versions. 
+   Also, only newer distributions (18.04, 18.10, and later) have a ``-u`` or ``--update`` flag. 
+   Adjust your script as needed.
 
 File any issues in `the PPA's issue tracker <https://github.com/ansible-community/ppa/issues>`_.
-
 
 Installing Ansible on Debian
 ----------------------------
 
-While Ansible is available from the `main Debian repository <https://packages.debian.org/stable/ansible>`_, it can be out of date.
+While Ansible is available from the `main Debian repository <https://packages.debian.org/stable/ansible>`_, it can be outdated.
 
-To get a more recent version, Debian users can use the Ubuntu PPA according to the following table:
+For a more recent version, Debian users can use the Ubuntu PPA according to the following table:
 
 .. list-table::
   :header-rows: 1
@@ -119,10 +123,10 @@ To get a more recent version, Debian users can use the Ubuntu PPA according to t
     - Ubuntu 18.04 (Bionic)
     - ``bionic``
 
-In the following example, we assume that you have wget and gpg already installed (``sudo apt install wget gpg``).
+The following example assumes that you already have wget and gpg installed (``sudo apt install wget gpg``).
 
-Run the following commands to add the repository and install Ansible.
-Set ``UBUNTU_CODENAME=...`` based on the table above (we use ``jammy`` in this example).
+Add the repository and install Ansible.
+Set ``UBUNTU_CODENAME=...`` based on the table above (we use ``jammy`` in this example):
 
 .. code-block:: bash
 
@@ -131,39 +135,36 @@ Set ``UBUNTU_CODENAME=...`` based on the table above (we use ``jammy`` in this e
     $ echo "deb [signed-by=/usr/share/keyrings/ansible-archive-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu $UBUNTU_CODENAME main" | sudo tee /etc/apt/sources.list.d/ansible.list
     $ sudo apt update && sudo apt install ansible
 
-Note: the " " around the keyserver URL are important.
-Around the "echo deb" it is important to use " " rather than ' '.
+.. note::
+   The quotation marks around the keyserver URL are important.
+   Around the "echo deb" command, use double quotes rather than single quotes.
 
 These commands download the signing key and add an entry to apt's sources pointing to the PPA.
 
 Previously, you may have used ``apt-key add``.
-This is now `deprecated <https://manpages.debian.org/testing/apt/apt-key.8.en.html>`_
-for security reasons (on Debian, Ubuntu, and elsewhere).
+This approach is now `deprecated <https://manpages.debian.org/testing/apt/apt-key.8.en.html>`_ for security reasons (on Debian, Ubuntu, and elsewhere).
 For more details, see `this AskUbuntu post <https://askubuntu.com/a/1307181>`_.
-Also note that, for security reasons, we do NOT add the key to ``/etc/apt/trusted.gpg.d/``
-nor to ``/etc/apt/trusted.gpg`` where it would be allowed to sign releases from ANY repository.
+For security reasons, we do NOT add the key to ``/etc/apt/trusted.gpg.d/`` or to ``/etc/apt/trusted.gpg`` where it would be allowed to sign releases from ANY repository.
 
 Installing Ansible on Arch Linux
 --------------------------------
 
-To install the full ``ansible`` package run:
+Install the full ``ansible`` package:
 
 .. code-block:: bash
 
     $ sudo pacman -S ansible
 
-To install the minimal ``ansible-core`` package run:
+Install the minimal ``ansible-core`` package:
 
 .. code-block:: bash
 
     $ sudo pacman -S ansible-core
 
-Several Ansible ecosystem packages are also available from the Arch Linux repositories as
-standalone packages that users can install alongside ``ansible-core``.
-See the `Arch Linux Packages index <https://archlinux.org/packages/?sort=&q=ansible>`_
-for a full list of Ansible packages in Arch Linux.
+Arch Linux repositories include several Ansible ecosystem packages as standalone packages that you can install alongside ``ansible-core``.
+See the `Arch Linux Packages index <https://archlinux.org/packages/?sort=&q=ansible>`_ for a complete list of Ansible packages in Arch Linux.
 
-Please `open an issue <https://gitlab.archlinux.org/archlinux/packaging/packages>`_ in the related package GitLab repository to reach the package maintainers.
+Contact the package maintainers by `opening an issue <https://gitlab.archlinux.org/archlinux/packaging/packages>`_ in the related package GitLab repository.
 
 .. _from_windows:
 

--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -20,14 +20,14 @@ Package maintainers who want to add instructions for another distribution to thi
 
 * Ensure the distribution provides a reasonably up-to-date version of ``ansible``.
 * Keep ``ansible-core`` and ``ansible`` versions synchronized to the extent that the build system allows.
-* Provide a way to contact the distribution maintainers as part of the instructions. 
-  Distribution maintainers are also encouraged to join the `Ansible Packaging <https://matrix.to/#/#packaging:ansible.com>`_ Matrix room.
+* Provide a way to contact the distribution maintainers as part of the instructions.
+* Distribution maintainers are also encouraged to join and monitor the `Ansible Packaging <https://matrix.to/#/#packaging:ansible.com>`_ Matrix room.
 
 .. contents::
   :local:
 
 Installing Ansible on Fedora Linux
------------------------------------
+----------------------------------
 
 Fedora Linux provides both the full Ansible package and the minimal ansible-core package through the standard repositories.
 
@@ -56,19 +56,18 @@ for a complete list of Ansible collections packaged in Fedora.
 Contact the package maintainers by `filing a bug <https://bugzilla.redhat.com/enter_bug.cgi>`_ against the ``Fedora`` product in Red Hat Bugzilla.
 
 Installing Ansible from EPEL
------------------------------
+----------------------------
 
-The EPEL repository provides Ansible packages for Enterprise Linux distributions.
 
-If you use CentOS Stream, Almalinux, Rocky Linux, or related distributions, you can install ``ansible`` or Ansible collections from the community-maintained `EPEL <https://docs.fedoraproject.org/en-US/epel/>`_ (Extra Packages for Enterprise Linux) repository.
+If you use CentOS Stream, Almalinux, Rocky Linux, or related distributions, you can install ``ansible`` or Ansible collections from the community-maintained `EPEL <https://docs.fedoraproject.org/en-US/epel/>`_ (Extra Packages for Enterprise Linux) repository:
 
-First, `enable the EPEL repository <https://docs.fedoraproject.org/en-US/epel/#_quickstart>`_.
-Then use the same ``dnf`` commands as for Fedora Linux.
+1. `Enable the EPEL repository <https://docs.fedoraproject.org/en-US/epel/#_quickstart>`_.
+2. Use the same ``dnf`` commands as for Fedora Linux.
 
 Contact the package maintainers by `filing a bug <https://bugzilla.redhat.com/enter_bug.cgi>`_ against the ``Fedora EPEL`` product in Red Hat Bugzilla.
 
 Installing Ansible on OpenSUSE Tumbleweed/Leap
------------------------------------------------
+----------------------------------------------
 
 OpenSUSE provides Ansible packages through the standard package manager.
 
@@ -81,7 +80,7 @@ See the `OpenSUSE Support Portal <https://en.opensuse.org/Portal:Support>`_ for 
 .. _from_apt:
 
 Installing Ansible on Ubuntu
------------------------------
+----------------------------
 
 Ubuntu provides Ansible packages through a Personal Package Archive (PPA) that contains more recent versions than the standard repositories.
 
@@ -105,7 +104,7 @@ Configure the PPA on your system and install Ansible:
 File any issues in `the PPA's issue tracker <https://github.com/ansible-community/ppa/issues>`_.
 
 Installing Ansible on Debian
------------------------------
+----------------------------
 
 Debian users can choose between the standard repository or the Ubuntu PPA for more recent versions.
 
@@ -133,7 +132,7 @@ For a more recent version, Debian users can use the Ubuntu PPA according to the 
     - Ubuntu 18.04 (Bionic)
     - ``bionic``
 
-The following example assumes that you already have wget and gpg installed (``sudo apt install wget gpg``).
+The following example assumes that you already have ``wget`` and ``gpg`` installed.
 
 Add the repository and install Ansible.
 Set ``UBUNTU_CODENAME=...`` based on the table above (we use ``jammy`` in this example):
@@ -157,7 +156,7 @@ The ``apt-key add`` approach is now `deprecated <https://askubuntu.com/a/1307181
 As such, we do NOT add the key to ``/etc/apt/trusted.gpg.d/`` or to ``/etc/apt/trusted.gpg`` where the key would be allowed to sign releases from ANY repository.
 
 Installing Ansible on Arch Linux
----------------------------------
+--------------------------------
 
 Arch Linux provides both the full Ansible package and ansible-core through the standard package repositories.
 

--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -145,8 +145,7 @@ Set ``UBUNTU_CODENAME=...`` based on the table above (we use ``jammy`` in this e
     $ sudo apt update && sudo apt install ansible
 
 .. note::
-   The quotation marks around the keyserver URL are important.
-   Around the "echo deb" command, use double quotes rather than single quotes.
+   Use double quotes around the keyserver URL and in the "echo deb" command like in the example above.
 
 These commands download the signing key and add an entry to apt's sources pointing to the PPA.
 


### PR DESCRIPTION
Using Cursor editor, approached in two steps (one commit each):
1. Asked Cursor in chat mode to edit the file using the style guide directory.
2. Asked Curso in chat mode to then use some of the prompts from #2834 that were not already in the style guide:
* Generally, use a sentence to introduce a list that is not a procedure.
* Fix ambiguous pronouns: ensure that the noun to which a pronoun refers is clear. Avoid sentences in which a pronoun can refer to more than one noun or in which a pronoun refers to an unstated noun.
* When you break a long procedure or tutorial into smaller chunks, include a summary at the start of the procedure or tutorial. In the summary, explain the overall goal or list the sets of steps that are required to complete the procedure or tutorial.

Remaining prompts from that PR don't apply as Cursor edits the RST file directly. It also gives you the ability to accept or reject individual changes, so I didn't need an extra commit for my edits.