### PR TITLE
EOL 2.16 docs

### DIFF
--- a/docs/docsite/.templates/banner.html
+++ b/docs/docsite/.templates/banner.html
@@ -1,7 +1,7 @@
 {% if is_eol %}
 {# Creates a banner at the top of the page for EOL versions. #}
 <div id='banner' class='Admonition caution'>
-  <p>You are reading an unmaintained version of the Ansible documentation. Unmaintained Ansible versions can contain unfixed security vulnerabilities (CVE). Please upgrade to a maintained version. See <a href="/ansible/latest/">the latest Ansible documentation</a>.</p>
+  <p>You are reading an unmaintained version of the community Ansible documentation. This does not apply to Red Hat Ansible Automation Platform subscriptions. See the <a href="https://access.redhat.com/support/policy/updates/ansible-automation-platform">Red Hat AAP Life Cycle</a> for product-based details. Unmaintained Ansible versions can contain unfixed security vulnerabilities (CVE). Please upgrade to a maintained version. See <a href="/ansible/latest/">the latest Ansible documentation</a>.</p>
 </div>
 {% else %}
   <script>

--- a/docs/docsite/.templates/banner.html
+++ b/docs/docsite/.templates/banner.html
@@ -1,7 +1,7 @@
 {% if is_eol %}
 {# Creates a banner at the top of the page for EOL versions. #}
 <div id='banner' class='Admonition caution'>
-  <p>You are reading an unmaintained version of the community Ansible documentation. This does not apply to Red Hat Ansible Automation Platform subscriptions. See the <a href="https://access.redhat.com/support/policy/updates/ansible-automation-platform">Red Hat AAP Life Cycle</a> for product-based details. Unmaintained Ansible versions can contain unfixed security vulnerabilities (CVE). Please upgrade to a maintained version. See <a href="/ansible/latest/">the latest Ansible documentation</a>.</p>
+  <p>You are reading an unmaintained version of the Ansible documentation. Unmaintained Ansible versions can contain unfixed security vulnerabilities (CVE). Please upgrade to a maintained version. See <a href="/ansible/latest/">the latest Ansible documentation</a>.</p>
 </div>
 {% else %}
   <script>

--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -227,7 +227,7 @@ html_theme_options = {
 html_context = {
     'display_github': 'True',
     'show_sphinx': False,
-    'is_eol': False,
+    'is_eol': True,
     'github_user': 'ansible',
     'github_repo': 'ansible-documentation',
     'github_version': 'devel',


### PR DESCRIPTION
Fixes #2545

Sets the eol flag so that the documentation build applies the EOL banner to these docs.