### PR TITLE
update for control node min. python 3.12 now

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -48,10 +48,10 @@ jobs:
           private-key: ${{ secrets.BOT_APP_KEY }}
       - name: Checkout parent repository
         uses: actions/checkout@v4
-      - name: Install Python 3.11
+      - name: Install Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Set up UV
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Setup venv

--- a/.github/workflows/pip-compile-dev.yml
+++ b/.github/workflows/pip-compile-dev.yml
@@ -28,7 +28,7 @@ jobs:
               'pip-compile(spelling)'
               'pip-compile(tag)'
               'pip-compile(pip-compile)'
-            python-versions: "3.11"
+            python-versions: "3.12"
           - base-branch: stable-2.19
             pr-branch: pip-compile/stable-2.19/dev
             nox-args: >-

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ build:
   os: ubuntu-22.04
   tools:
     python: >-
-      3.11
+      3.12
   # Build with make coredocs
   commands:
     - python -m venv "${READTHEDOCS_VIRTUALENV_PATH}"

--- a/docs/docsite/rst/dev_guide/testing/sanity/compile.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/compile.rst
@@ -12,9 +12,9 @@ All Python source files must successfully compile using all supported Python ver
 
 Control node code, including plugins in Ansible Collections, must support the following Python versions:
 
-- 3.11
-- 3.10
-- 3.9
+- 3.14
+- 3.13
+- 3.12
 
 Code which runs on targets (``modules`` and ``module_utils``) must support all control node supported Python versions,
 as well as the additional Python versions supported only on targets:

--- a/noxfile.py
+++ b/noxfile.py
@@ -155,7 +155,7 @@ requirements_files = list(
 )
 
 
-@nox.session(name="pip-compile", python="3.11")
+@nox.session(name="pip-compile", python="3.12")
 @nox.parametrize(["req"], requirements_files, requirements_files)
 def pip_compile(session: nox.Session, req: str):
     """


### PR DESCRIPTION
[ansible-core dropped 3.11 on the control node](https://github.com/ansible/ansible/pull/85590). This PR should get the docs builds working again.