### PR TITLE
compile sanity test: update supported Python versions

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/compile.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/compile.rst
@@ -9,6 +9,7 @@ All Python source files must successfully compile using all supported Python ver
 
    The list of supported Python versions is dependent on the version of ``ansible-core`` that you are using.
    Make sure you consult the version of the documentation which matches your ``ansible-core`` version.
+   You can find an overview for this and previous versions in :ref:`ansible_core_support_matrix`.
 
 Control node code, including plugins in Ansible Collections, must support the following Python versions:
 
@@ -19,11 +20,12 @@ Control node code, including plugins in Ansible Collections, must support the fo
 Code which runs on targets (``modules`` and ``module_utils``) must support all control node supported Python versions,
 as well as the additional Python versions supported only on targets:
 
-- 3.8
-- 3.7
-- 3.6
-- 3.5
-- 2.7
+- 3.14
+- 3.13
+- 3.12
+- 3.11
+- 3.10
+- 3.9
 
 .. note::
 


### PR DESCRIPTION
Follow-up to https://github.com/ansible/ansible-documentation/pull/2934#discussion_r2246321509.

I think it would be better to get rid of the explicit lists of Python versions here completely, but as a first step let's fix the lists and add a link to https://docs.ansible.com/ansible-core/devel/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix.
