### PR TITLE
Update EOL banner for clarity

### DIFF
--- a/docs/docsite/.templates/banner.html
+++ b/docs/docsite/.templates/banner.html
@@ -1,7 +1,7 @@
 {% if is_eol %}
 {# Creates a banner at the top of the page for EOL versions. #}
 <div id='banner' class='Admonition caution'>
-  <p>You are reading an unmaintained version of the community Ansible documentation. This does not apply to Red Hat Ansible Automation Platform subscriptions. See the <a href="https://access.redhat.com/support/policy/updates/ansible-automation-platform">Red Hat AAP Life Cycle</a> for product-based details. Unmaintained Ansible versions can contain unfixed security vulnerabilities (CVE). Please upgrade to a maintained version. See <a href="/ansible/latest/">the latest Ansible documentation</a>.</p>
+  <p>You are reading an unmaintained version of the Ansible community documentation. Unmaintained Ansible versions can contain security vulnerabilities (CVEs). Please upgrade to a maintained version. See <a href="/ansible/latest/">the latest Ansible documentation</a>. Note that this statement does not apply to Red Hat Ansible Automation Platform subscriptions. See the <a href="https://access.redhat.com/support/policy/updates/ansible-automation-platform">Ansible Automation Platform Life Cycle</a>.</p>
 </div>
 {% else %}
   <script>


### PR DESCRIPTION
Because I can't be trusted on my own - merged the last PR without actually applying Don's suggested edit.

This clarifies the EOL is for community only, not RH product.