### PR TITLE
[stable-2.15] Fix supported Python list for 2.15

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/compile.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/compile.rst
@@ -19,6 +19,9 @@ Controller code, including plugins in Ansible Collections, must support the foll
 Code which runs on targets (``modules`` and ``module_utils``) must support all controller supported Python versions,
 as well as the additional Python versions supported only on targets:
 
+- 3.11
+- 3.10
+- 3.9
 - 3.8
 - 3.7
 - 3.6


### PR DESCRIPTION
See https://docs.ansible.com/ansible-core/devel/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix. This can be backported to stable-2.14 since that version has the same list of supported Python versions as 2.15.