### PR TITLE
Harmonize formatting of group names in docs/docsite/rst/inventory_guide/intro_inventory.rst

### DIFF
--- a/docs/docsite/rst/inventory_guide/intro_inventory.rst
+++ b/docs/docsite/rst/inventory_guide/intro_inventory.rst
@@ -500,7 +500,7 @@ The default vars plugin that Ansible ships with, :ref:`host_group_vars <host_gro
 
 For the ``host_group_vars`` plugin, your host and group variable files must use YAML syntax. Valid file extensions are '.yml', '.yaml', '.json', or no file extension. See :ref:`yaml_syntax` if you are new to YAML.
 
-The ``host_group_vars`` plugin loads host and group variable files by searching paths relative to the inventory source or the playbook file. If your inventory file at ``/etc/ansible/hosts`` contains a host named 'foosball' that belongs to the 'raleigh' and 'webservers' groups, that host will use variables from the YAML files in the following locations:
+The ``host_group_vars`` plugin loads host and group variable files by searching paths relative to the inventory source or the playbook file. If your inventory file at ``/etc/ansible/hosts`` contains a host named 'foosball' that belongs to the ``raleigh`` and ``webservers`` groups, that host will use variables from the YAML files in the following locations:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Harmonize formatting of group names in docs/docsite/rst/inventory_guide/intro_inventory.rst

I noticed that several group names were formatting with literal single quotes instead of RST double backticks.

Signed-off-by: Anthony D'Atri <anthonyeleven@users.noreply.github.com>