### PR TITLE
Fixes #3041

### DIFF
--- a/.github/workflows/release-porting-guide.yml
+++ b/.github/workflows/release-porting-guide.yml
@@ -74,14 +74,10 @@ jobs:
           GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}
         run: git push origin "${GIT_BRANCH}"
 
-      - name: Create the porting guide PR as draft
+      - name: Create the porting guide PR
         env:
           GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}
           PR_BODY_MESSAGE: |-
-            ##### SUMMARY
-
-            This is a draft PR. Please mark the PR as ready for review to trigger PR checks.
-
             ##### ISSUE TYPE
 
             - Docs Pull Request
@@ -91,7 +87,6 @@ jobs:
             docs/docsite/rst/porting_guides/porting_guide_${{ env.ANSIBLE_VERSION_MAJOR }}.rst
         run: >-
           gh pr create
-          --draft
           --base devel
           --head "${GIT_BRANCH}"
           --title "${CI_COMMIT_MESSAGE}"


### PR DESCRIPTION
Remove `--draft` (and related comments) from the creating porting guide step, as per the noted issue.