### PR TITLE
Add 13 to package doc build

### DIFF
--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -28,6 +28,7 @@ name: Build and deploy docs
         default: devel
         options:
         - devel
+        - '13'
         - '12'
         - '11'
         - '10'


### PR DESCRIPTION
Goes with https://github.com/ansible-community/package-doc-builds/tree/13

Following instructions from https://github.com/ansible/ansible-documentation/blob/devel/MAINTAINERS.md#updating-the-package-doc-builds-repository