### PR TITLE
Add stable-2.20 to tagger and pip-compile-dev workflow

### DIFF
--- a/.github/workflows/pip-compile-dev.yml
+++ b/.github/workflows/pip-compile-dev.yml
@@ -29,6 +29,14 @@ jobs:
               'pip-compile(tag)'
               'pip-compile(pip-compile)'
             python-versions: "3.12"
+          - base-branch: stable-2.20
+            pr-branch: pip-compile/stable-2.20/dev
+            nox-args: >-
+              -e 'pip-compile(formatters)'
+              'pip-compile(typing)'
+              'pip-compile(static)'
+              'pip-compile(spelling)'
+            python-versions: "3.12"
           - base-branch: stable-2.19
             pr-branch: pip-compile/stable-2.19/dev
             nox-args: >-

--- a/hacking/tagger/tag.py
+++ b/hacking/tagger/tag.py
@@ -46,6 +46,7 @@ DEFAULT_ACTIVE_BRANCHES: tuple[str, ...] = (
     "stable-2.17",
     "stable-2.18",
     "stable-2.19",
+    "stable-2.20",
 )
 
 


### PR DESCRIPTION
Ref: https://github.com/ansible/ansible-documentation/blob/devel/MAINTAINERS.md#branching-for-new-major-stable-versions