### PR TITLE
Update platform_routeros.rst

### DIFF
--- a/docs/docsite/rst/network/user_guide/platform_routeros.rst
+++ b/docs/docsite/rst/network/user_guide/platform_routeros.rst
@@ -70,7 +70,7 @@ Example CLI ``group_vars/routeros.yml``
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
 - If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.
-- If you are getting timeout errors you may want to add ``+cet1024w`` suffix to your username which will disable console colors, enable "dumb" mode, tell RouterOS not to try detecting terminal capabilities and set terminal width to 1024 columns. See article `Console login process <https://wiki.mikrotik.com/wiki/Manual:Console_login_process>`_ in MikroTik wiki for more information.
+- If you are getting timeout errors you may want to add ``+cet1024w`` suffix to your username which will disable console colors, enable "dumb" mode, tell RouterOS not to try detecting terminal capabilities and set terminal width to 1024 columns. See article `Console login process <https://wiki.mikrotik.com/Manual:Console_login_process>`_ in MikroTik wiki for more information.
 - More notes can be found in the :ref:`the community.routeros collection's SSH guide <ansible_collections.community.routeros.docsite.ssh-guide>`.
 
 Example CLI task


### PR DESCRIPTION
As user of the User Guide, when I go to the RouterOS platform page, and click on the Console login process link, it should open the  RouterOS wiki page for Manual Console login process page.  Current page does not. Seems like URLs on the wiki site was updated to: https://wiki.mikrotik.com/Manual:Console_login_process