### PR TITLE
Update maximum galaxy artifact size

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_collections_distributing.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_distributing.rst
@@ -148,7 +148,7 @@ This command builds a tarball of the collection in the current directory, which 
 
 .. note::
    * To reduce the size of collections, certain files and folders are excluded from the collection tarball by default. See :ref:`ignoring_files_and_folders_collections` if your collection directory contains other files you want to exclude.
-   * The current Galaxy maximum tarball size is 2 MB.
+   * The current Galaxy maximum tarball size is 200 MB.
 
 You can upload your tarball to one or more distribution servers. You can also distribute your collection locally by copying the tarball to install your collection directly on target systems.
 


### PR DESCRIPTION
I'm not sure if this is correct for community Galaxy (200 MB is documented for Hub https://github.com/ansible/aap-docs/pull/4558), so someone with access to wherever the max size is now defined should confirm this change. 2 MB has been out of date since https://github.com/ansible/galaxy/commit/6ca6b972242cf27394463407286c2844a5ce4084.

CC @rochacbruno