### PR TITLE
Replace reference to role removed in Ansible 11

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_collections_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_documenting.rst
@@ -12,7 +12,7 @@ Documenting modules is thoroughly documented in :ref:`module_documenting`. Plugi
 Documenting roles
 =================
 
-To document a role, you have to add a role argument spec by creating a file ``meta/argument_specs.yml`` in your role. See :ref:`role_argument_spec` for details. As an example, you can look at `the argument specs file <https://github.com/sensu/sensu-go-ansible/blob/master/roles/install/meta/argument_specs.yml>`_ of the :ansplugin:`sensu.sensu_go.install role <sensu.sensu_go.install#role>` on GitHub.
+To document a role, you have to add a role argument spec by creating a file ``meta/argument_specs.yml`` in your role. See :ref:`role_argument_spec` for details. As an example, you can look at `the argument specs file <https://github.com/telekom-mms/ansible-collection-icinga-director/blob/main/roles/ansible_icinga/meta/argument_specs.yml>`_ of the :ansplugin:`telekom_mms.icinga_director.ansible_icinga role <telekom_mms.icinga_director.ansible_icinga#role>` on GitHub.
 
 
 .. _verify_collection_docs:


### PR DESCRIPTION
Relates to https://github.com/ansible/ansible-documentation/pull/3089 and fixes this docs build error:

```
docs/docsite/rst/dev_guide/developing_collections_documenting.rst:15:0: undefined-label: undefined label: 'ansible_collections.sensu.sensu_go.install_role'
```