### PR TITLE
docs: clarify dict2items usage in loops with group module (follow-up to ansible#85897)

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_loops.rst
@@ -144,37 +144,23 @@ To loop over a dict, use the  :ref:`dict2items <dict_filter>`:
 
     - name: Using dict2items
       ansible.builtin.debug:
-        msg: "{{ item.key }} - {{ item.value }}"
-      loop: "{{ tag_data | dict2items }}"
+        msg: "{{ item.key }}: {{ item.value.ip_address }} {{ item.value.role }}"
+      loop: "{{ server_configs | dict2items }}"
       vars:
-        tag_data:
-          Environment: dev
-          Application: payment
+        server_configs:
+          web_01:
+            ip_address: "10.1.1.50"
+            role: "frontend"
+          db_01:
+            ip_address: "10.1.1.100"
+            role: "backend_db"
 
-Here, we are iterating over `tag_data` and printing the key and the value from it.
+Here, we are iterating over `server_configs` and printing the key and selected nested fields.
 
 If the values in the dictionary are themselves dictionaries (for example, each group maps
 to a dict containing a ``gid``), remember that after applying ``dict2items`` each loop item
 has two attributes: ``item.key`` and ``item.value``. Access nested fields via
 ``item.value.<field>``.
-
-**Example (using the ``group`` module):**
-
-.. code-block:: yaml+jinja
-
-    - name: Create groups from a dictionary
-      ansible.builtin.group:
-        name: "{{ item.key }}"
-        gid: "{{ item.value.gid }}"
-        state: present
-      loop: "{{ global_groups | dict2items }}"
-
-**Common mistake**
-
-.. code-block:: yaml+jinja
-
-    gid: "{{ item.gid }}"   # ❌ Fails because item.gid does not exist when using dict2items
-
 
 Registering variables with a loop
 ---------------------------------

--- a/docs/docsite/rst/playbook_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_loops.rst
@@ -152,6 +152,38 @@ To loop over a dict, use the  :ref:`dict2items <dict_filter>`:
           Application: payment
 
 Here, we are iterating over `tag_data` and printing the key and the value from it.
+.. _dict2items-example-with-group:
+
+Using ``dict2items`` in Loops with the ``group`` Module
+-------------------------------------------------------
+
+When looping over dictionaries that contain structured data (for example, group names and GIDs),
+use the ``dict2items`` filter to convert the dictionary into a list of key–value pairs.
+
+Each loop item will then have two attributes: ``item.key`` and ``item.value``.
+If ``item.value`` itself is a dictionary, access its fields using dot notation.
+
+**Example:**
+
+.. code-block:: yaml
+
+    - name: Add groups using dict2items
+      hosts: all
+      tasks:
+        - name: Create groups from a dictionary
+          ansible.builtin.group:
+            name: "{{ item.key }}"
+            gid: "{{ item.value.gid }}"
+            state: present
+          loop: "{{ global_groups | dict2items }}"
+
+**Incorrect usage (common mistake):**
+
+.. code-block:: yaml
+
+    gid: "{{ item.gid }}"   # ❌ Fails because item.gid does not exist
+
+(Added as a follow-up to ansible/ansible#85897.)
 
 Registering variables with a loop
 ---------------------------------

--- a/docs/docsite/rst/playbook_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_loops.rst
@@ -152,38 +152,29 @@ To loop over a dict, use the  :ref:`dict2items <dict_filter>`:
           Application: payment
 
 Here, we are iterating over `tag_data` and printing the key and the value from it.
-.. _dict2items-example-with-group:
 
-Using ``dict2items`` in Loops with the ``group`` Module
--------------------------------------------------------
+If the values in the dictionary are themselves dictionaries (for example, each group maps
+to a dict containing a ``gid``), remember that after applying ``dict2items`` each loop item
+has two attributes: ``item.key`` and ``item.value``. Access nested fields via
+``item.value.<field>``.
 
-When looping over dictionaries that contain structured data (for example, group names and GIDs),
-use the ``dict2items`` filter to convert the dictionary into a list of key–value pairs.
+**Example (using the ``group`` module):**
 
-Each loop item will then have two attributes: ``item.key`` and ``item.value``.
-If ``item.value`` itself is a dictionary, access its fields using dot notation.
+.. code-block:: yaml+jinja
 
-**Example:**
+    - name: Create groups from a dictionary
+      ansible.builtin.group:
+        name: "{{ item.key }}"
+        gid: "{{ item.value.gid }}"
+        state: present
+      loop: "{{ global_groups | dict2items }}"
 
-.. code-block:: yaml
+**Common mistake**
 
-    - name: Add groups using dict2items
-      hosts: all
-      tasks:
-        - name: Create groups from a dictionary
-          ansible.builtin.group:
-            name: "{{ item.key }}"
-            gid: "{{ item.value.gid }}"
-            state: present
-          loop: "{{ global_groups | dict2items }}"
+.. code-block:: yaml+jinja
 
-**Incorrect usage (common mistake):**
+    gid: "{{ item.gid }}"   # ❌ Fails because item.gid does not exist when using dict2items
 
-.. code-block:: yaml
-
-    gid: "{{ item.gid }}"   # ❌ Fails because item.gid does not exist
-
-(Added as a follow-up to ansible/ansible#85897.)
 
 Registering variables with a loop
 ---------------------------------


### PR DESCRIPTION
### Summary
Clarifies correct `dict2items` usage in playbook loops by showing that nested values
must be accessed via `item.value.*` (for example, `item.value.gid`) when looping over
a dict converted with `dict2items`.

### Motivation
Addresses recurring confusion discussed in ansible/ansible#85897.

### Changes
- Updates `playbook_guide/playbooks_loops.rst` with a concise example and a “common mistake” note.

### Notes
A prior attempt in ansible/ansible#85964 failed sanity because `docs/docsite/rst/`
and `examples/` are obsolete in the core repo. This PR moves the content to the
correct documentation repository.
