### PR TITLE
Add Zizmor Scanning on push/pull request

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,31 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  schedule:
+    # Daily
+    - cron: "23 7 * * *"
+  push:
+    paths:
+      - .github/workflows/*
+  pull_request:
+    paths:
+      - .github/workflows/*
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      # contents: read # only needed for private repos
+      # actions: read # only needed for private repos
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@e673c3917a1aef3c65c972347ed84ccd013ecda4 # v0.2.0

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -19,8 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       security-events: write
-      # contents: read # only needed for private repos
-      # actions: read # only needed for private repos
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
Per discussion in #2681, adding zizmor scanning. 

There are several things we could tweak on this.
- only scan specific branches
- only scan specific events

I've left this as all branches on push and on pull request at this point, but would be happy to adjust if that doesn't work for some reason.

Resolves #2681.