### PR TITLE
Convert reusable-nox workflowk to using nox GHA

### DIFF
--- a/.github/workflows/reusable-nox.yml
+++ b/.github/workflows/reusable-nox.yml
@@ -15,13 +15,13 @@ jobs:
           #   session: name of session
           #   python-versions: comma-separated list of Python versions to install
           #   extra-args (optional): extra arguments to pass to nox session.
-          - session: static
+          - session: "static"
             python-versions: "3.12"
-          - session: formatters_check
+          - session: "formatters_check"
             python-versions: "3.12"
-          - session: typing
+          - session: "typing"
             python-versions: "3.12"
-          - session: spelling
+          - session: "spelling"
             python-versions: "3.12"
           - session: "checkers(rstcheck)"
             python-versions: "3.12"
@@ -46,15 +46,15 @@ jobs:
           python-versions: "${{ inputs.python-versions }}"
 
       - name: Graft ansible-core
-        uses: x1101/github-action-run-nox@ca8b16f76c53a04b14952620e7a4ac5c7dc29812
+        uses: ansible-community/github-action-run-nox@v1
         with:
           sessions: clone-core
           force-pythons: "${{ inputs.python-versions }}"
 
       - name: "Run nox session"
-        uses: x1101/github-action-run-nox@ca8b16f76c53a04b14952620e7a4ac5c7dc29812
+        uses: ansible-community/github-action-run-nox@v1
         with:
-          sessions: "${{ matrix.sessions }}"
-          extra-args: ${{ inputs.extra-args || '' }}
+          sessions: "${{ matrix.session }}"
+          extra-args: "${{ inputs.extra-args || '' }}"
           force-pythons: "${{ inputs.python-versions }}"
 

--- a/.github/workflows/reusable-nox.yml
+++ b/.github/workflows/reusable-nox.yml
@@ -3,50 +3,44 @@ name: nox
 
 "on":
   workflow_call:
+    inputs:
+      python-versions:
+        description: Space-seperated list of python version(s) to run nox sessions with
+        type: string
+        required: false
+        default: "3.12"
+      sessions:
+        description: Space-seperated list of sessions
+        type: string
+        required: false
+        default: "static formatters_check typing spelling checkers(rstcheck) checkers(rst-yamllint) checkers(docs-build) actionlint"
+
 
 jobs:
   nox:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # Inputs:
-          #   session: name of session
-          #   python-versions: comma-separated list of Python versions to install
-          #   extra-args (optional): extra arguments to pass to nox session.
-          - session: static
-            python-versions: "3.12"
-          - session: formatters_check
-            python-versions: "3.12"
-          - session: typing
-            python-versions: "3.12"
-          - session: spelling
-            python-versions: "3.12"
-          - session: "checkers(rstcheck)"
-            python-versions: "3.12"
-          - session: "checkers(rst-yamllint)"
-            python-versions: "3.12"
-          - session: "checkers(docs-build)"
-            python-versions: "3.12"
-          - session: "actionlint"
-            python-versions: "3.12"
-          - session: "pip-compile"
-            extra-args: "--check"
-            python-versions: "3.12"
-    name: "Run nox ${{ matrix.session }} session"
+    name: "Run nox sessions"
     steps:
       - name: Check out repo
         uses: actions/checkout@v5
+
       - name: Setup nox
         uses: wntrblm/nox@2025.05.01
         with:
-          python-versions: "${{ matrix.python-versions }}"
+          python-versions: "${{ inputs.python-versions }}"
+
       - name: Graft ansible-core
-        run: |
-          nox -e clone-core
-      - name: "Run nox -e ${{ matrix.session }}"
-        run: |
-          # Using GHA expression interpolation is fine here,
-          # as we control all the inputs.
-          nox -e "${{ matrix.session }}" -- ${{ matrix.extra-args }}
+        uses: x1101/github-action-run-nox@ca8b16f76c53a04b14952620e7a4ac5c7dc29812
+        with:
+          sessions: clone-core
+
+      - name: "Run nox sessions"
+        uses: x1101/github-action-run-nox@ca8b16f76c53a04b14952620e7a4ac5c7dc29812
+        with:
+          sessions: "${{ inputs.sessions }}"
+
+      - name: "Run Sessions with Args"
+        uses: x1101/github-action-run-nox@ca8b16f76c53a04b14952620e7a4ac5c7dc29812
+        with:
+          sessions: "pip-compile"
+          extra-args: "--check"

--- a/.github/workflows/reusable-nox.yml
+++ b/.github/workflows/reusable-nox.yml
@@ -3,23 +3,39 @@ name: nox
 
 "on":
   workflow_call:
-    inputs:
-      python-versions:
-        description: Space-seperated list of python version(s) to run nox sessions with
-        type: string
-        required: false
-        default: "3.12"
-      sessions:
-        description: Space-seperated list of sessions
-        type: string
-        required: false
-        default: "static formatters_check typing spelling checkers(rstcheck) checkers(rst-yamllint) checkers(docs-build) actionlint"
-
 
 jobs:
   nox:
     runs-on: ubuntu-latest
-    name: "Run nox sessions"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Inputs:
+          #   session: name of session
+          #   python-versions: comma-separated list of Python versions to install
+          #   extra-args (optional): extra arguments to pass to nox session.
+          - session: static
+            python-versions: "3.12"
+          - session: formatters_check
+            python-versions: "3.12"
+          - session: typing
+            python-versions: "3.12"
+          - session: spelling
+            python-versions: "3.12"
+          - session: "checkers(rstcheck)"
+            python-versions: "3.12"
+          - session: "checkers(rst-yamllint)"
+            python-versions: "3.12"
+          - session: "checkers(docs-build)"
+            python-versions: "3.12"
+          - session: "actionlint"
+            python-versions: "3.12"
+          - session: "pip-compile"
+            extra-args: "--check"
+            python-versions: "3.12"
+
+    name: "Run nox ${{ matrix.session }} session"
     steps:
       - name: Check out repo
         uses: actions/checkout@v5
@@ -33,14 +49,12 @@ jobs:
         uses: x1101/github-action-run-nox@ca8b16f76c53a04b14952620e7a4ac5c7dc29812
         with:
           sessions: clone-core
+          force-pythons: "${{ inputs.python-versions }}"
 
-      - name: "Run nox sessions"
+      - name: "Run nox session"
         uses: x1101/github-action-run-nox@ca8b16f76c53a04b14952620e7a4ac5c7dc29812
         with:
-          sessions: "${{ inputs.sessions }}"
+          sessions: "${{ matrix.sessions }}"
+          extra-args: ${{ inputs.extra-args || '' }}
+          force-pythons: "${{ inputs.python-versions }}"
 
-      - name: "Run Sessions with Args"
-        uses: x1101/github-action-run-nox@ca8b16f76c53a04b14952620e7a4ac5c7dc29812
-        with:
-          sessions: "pip-compile"
-          extra-args: "--check"

--- a/.github/workflows/reusable-nox.yml
+++ b/.github/workflows/reusable-nox.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Inputs:
+          # matrix:
           #   session: name of session
           #   python-versions: comma-separated list of Python versions to install
           #   extra-args (optional): extra arguments to pass to nox session.
@@ -43,18 +43,18 @@ jobs:
       - name: Setup nox
         uses: wntrblm/nox@2025.05.01
         with:
-          python-versions: "${{ inputs.python-versions }}"
+          python-versions: "${{ matrix.python-versions }}"
 
       - name: Graft ansible-core
         uses: ansible-community/github-action-run-nox@v1
         with:
           sessions: clone-core
-          force-pythons: "${{ inputs.python-versions }}"
+          force-pythons: "${{ matrix.python-versions }}"
 
       - name: "Run nox session"
         uses: ansible-community/github-action-run-nox@v1
         with:
           sessions: "${{ matrix.session }}"
-          extra-args: "${{ inputs.extra-args || '' }}"
-          force-pythons: "${{ inputs.python-versions }}"
+          extra-args: "${{ matrix.extra-args || '' }}"
+          force-pythons: "${{ matrix.python-versions }}"
 

--- a/.github/workflows/reusable-nox.yml
+++ b/.github/workflows/reusable-nox.yml
@@ -15,11 +15,11 @@ jobs:
           #   session: name of session
           #   python-versions: comma-separated list of Python versions to install
           #   extra-args (optional): extra arguments to pass to nox session.
-          - session: "static"
+          - session: static
             python-versions: "3.12"
-          - session: "formatters_check"
+          - session: formatters_check
             python-versions: "3.12"
-          - session: "typing"
+          - session: typing
             python-versions: "3.12"
           - session: "spelling"
             python-versions: "3.12"

--- a/.github/workflows/reusable-nox.yml
+++ b/.github/workflows/reusable-nox.yml
@@ -23,15 +23,15 @@ jobs:
             python-versions: "3.12"
           - session: spelling
             python-versions: "3.12"
-          - session: "checkers(rstcheck)"
+          - session: checkers(rstcheck)
             python-versions: "3.12"
-          - session: "checkers(rst-yamllint)"
+          - session: checkers(rst-yamllint)
             python-versions: "3.12"
-          - session: "checkers(docs-build)"
+          - session: checkers(docs-build)
             python-versions: "3.12"
-          - session: "actionlint"
+          - session: actionlint
             python-versions: "3.12"
-          - session: "pip-compile"
+          - session: pip-compile
             extra-args: "--check"
             python-versions: "3.12"
 
@@ -46,13 +46,13 @@ jobs:
           python-versions: "${{ inputs.python-versions }}"
 
       - name: Graft ansible-core
-        uses: x1101/github-action-run-nox@ca8b16f76c53a04b14952620e7a4ac5c7dc29812
+        uses: ansible-community/github-action-run-nox@v1
         with:
           sessions: clone-core
           force-pythons: "${{ inputs.python-versions }}"
 
       - name: "Run nox session"
-        uses: x1101/github-action-run-nox@ca8b16f76c53a04b14952620e7a4ac5c7dc29812
+        uses: ansible-community/github-action-run-nox@v1
         with:
           sessions: "${{ matrix.sessions }}"
           extra-args: ${{ inputs.extra-args || '' }}


### PR DESCRIPTION
Marked as a DRAFT because it depends on a local fork of mine making changes to the upstream GHA. I have a PR in for that change. Once that's accepted, or the feature added in other ways, we can more accurately review this.

Addressed the request in #2511.

I am a little unsure of the approach I took on this, as the GHA looks for a single list of sessions to run. I converted the matrix over to that, but I'm unclear on what (if any) visibility into the details we'll lose that way. The other potential loss is if we intend to run different sessions against different python version in the same run (as opposed to running the whole action against a matrix of python versions). 

If we determine that we're losing too many details or that we do need the ability to target multiple distinct pythons for different parts of the run, I can easily swap it back to the matrix setup, but still using this GHA.

Thoughts/questions/comments greatly appreciated. 