### PR TITLE
Fix maximum artifact size for Galaxy

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_collections_distributing.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_distributing.rst
@@ -148,7 +148,7 @@ This command builds a tarball of the collection in the current directory, which 
 
 .. note::
    * To reduce the size of collections, certain files and folders are excluded from the collection tarball by default. See :ref:`ignoring_files_and_folders_collections` if your collection directory contains other files you want to exclude.
-   * The current Galaxy maximum tarball size is 200 MB.
+   * The current Galaxy maximum tarball size is 20 MB.
 
 You can upload your tarball to one or more distribution servers. You can also distribute your collection locally by copying the tarball to install your collection directly on target systems.
 


### PR DESCRIPTION
Reattempt https://github.com/ansible/ansible-documentation/pull/3099.

The largest collection version I can find on Galaxy is under 20 MB, and [there's evidence of a 26 MB upload failing](https://github.com/ansible/ansible-documentation/pull/3099#issuecomment-3482455216), so this should have been updated from 2 MB to 20 MB.