### PR TITLE
Update tagger and pip-compile workflow for active stable versions

### DIFF
--- a/.github/workflows/pip-compile-dev.yml
+++ b/.github/workflows/pip-compile-dev.yml
@@ -53,14 +53,6 @@ jobs:
               'pip-compile(static)'
               'pip-compile(spelling)'
             python-versions: "3.11"
-          - base-branch: stable-2.17
-            pr-branch: pip-compile/stable-2.17/dev
-            nox-args: >-
-              -e 'pip-compile(formatters)'
-              'pip-compile(typing)'
-              'pip-compile(static)'
-              'pip-compile(spelling)'
-            python-versions: "3.10"
     name: "Refresh dev dependencies"
     uses: ./.github/workflows/reusable-pip-compile.yml
     with:

--- a/hacking/tagger/tag.py
+++ b/hacking/tagger/tag.py
@@ -42,8 +42,6 @@ ROOT = HERE.parent.parent
 DEFAULT_ANSIBLE_CORE_CHECKOUT = ROOT.parent.joinpath("ansible")
 DEFAULT_REMOTE = "origin"
 DEFAULT_ACTIVE_BRANCHES: tuple[str, ...] = (
-    "stable-2.16",
-    "stable-2.17",
     "stable-2.18",
     "stable-2.19",
     "stable-2.20",


### PR DESCRIPTION
Now that stable-2.17 is EOL we should drop it from the tagger script and the pip-compile workflow.