### PR TITLE
[stable-2.18] update subdomain for readthedocs hosting

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -222,7 +222,7 @@ html_theme = 'sphinx_ansible_theme'
 html_show_sphinx = False
 
 html_theme_options = {
-    'canonical_url': "https://docs.ansible.com/ansible/latest/",
+    'canonical_url': "https://docs.ansible.com/projects/ansible/latest/",
     'hubspot_id': '330046',
     'satellite_tracking': True,
     'show_extranav': True,
@@ -383,8 +383,8 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/2/', None),
     'python3': ('https://docs.python.org/3/', None),
     'jinja2': ('http://jinja.palletsprojects.com/', None),
-    'ansible_2_9': ('https://docs.ansible.com/ansible/2.9/', None),
-    'ansible_11': ('https://docs.ansible.com/ansible/11/', None),
+    'ansible_2_9': ('https://docs.ansible.com/projects/ansible/2.9/', None),
+    'ansible_11': ('https://docs.ansible.com/projects/ansible/11/', None),
 }
 
 # linckchecker settings


### PR DESCRIPTION
Manual backport of https://github.com/ansible/ansible-documentation/pull/3144