### PR TITLE
Allow to configure Python version to compile docs build dependencies

### DIFF
--- a/.github/workflows/pip-compile-docs.yml
+++ b/.github/workflows/pip-compile-docs.yml
@@ -18,6 +18,12 @@ name: "Refresh docs build dependencies"
       labels:
         required: false
         type: string
+      python-version:
+        description: >-
+          Python version to use to compile the dependencies.
+          Must be correctly chosen for every stable branch.
+        type: string
+        default: "3.12"
 
 jobs:
   refresh:
@@ -32,5 +38,5 @@ jobs:
         'pip-compile(requirements)'
       reset-branch: "${{ inputs.reset-branch || false }}"
       labels: "${{ inputs.labels || 'doc builds,no_backport' }}"
-      python-versions: "3.12"
+      python-versions: "${{ inputs.python-version }}"
     secrets: inherit


### PR DESCRIPTION
I tried to update antsibull-docs for stable-2.18, stable-2.19, stable-2.20, and devel, but only succeeded for the later two ones. The workflow failed for the former two since it must use Python 3.11 instead of 3.12:
- https://github.com/ansible/ansible-documentation/actions/runs/19411130922/job/55532629082
- https://github.com/ansible/ansible-documentation/actions/runs/19411132866/job/55532633336

Unfortunately it is not possible to configure that.

This PR implements a first - cheap - solution: allow to inject the Python version into the workflow. I'm sure there are better solutions (like installing all possible Python versions for the branches in question), and we should eventually have something better.