### PR TITLE
bulk update urls to insert the projects subdir

### DIFF
--- a/docs/docsite/rst/community/collection_contributors/collection_release_with_branches.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_release_with_branches.rst
@@ -12,7 +12,7 @@ Collections MUST follow the `semantic versioning <https://semver.org/>`_ rules. 
 Release planning and announcement
 ----------------------------------
 
-#. Announce your intention to release the collection in a corresponding pinned release issue/community pinboard of the collection and in the ``#ansible-community`` `Matrix/IRC channel <https://docs.ansible.com/ansible/devel/community/communication.html#real-time-chat>`_. Repeat the announcement in any other dedicated channels if they exist.
+#. Announce your intention to release the collection in a corresponding pinned release issue/community pinboard of the collection and in the ``#ansible-community`` `Matrix/IRC channel <https://docs.ansible.com/projects/ansible/devel/community/communication.html#real-time-chat>`_. Repeat the announcement in any other dedicated channels if they exist.
 
 #. Ensure all the other repository maintainers are informed about the time of the following release.
 
@@ -152,7 +152,7 @@ Publishing the collection
 
 5. Announce the release through the `Bullhorn Newsletter <https://forum.ansible.com/c/news/bullhorn/17>`_.
 
-6. Announce the release in the pinned release issue/community pinboard of the collection and in the ``#ansible-community`` `Matrix/Libera.Chat IRC channel <https://docs.ansible.com/ansible/devel/community/communication.html#real-time-chat>`_.
+6. Announce the release in the pinned release issue/community pinboard of the collection and in the ``#ansible-community`` `Matrix/Libera.Chat IRC channel <https://docs.ansible.com/projects/ansible/devel/community/communication.html#real-time-chat>`_.
 
 7. In the ``stable-X`` branch, update the version in ``galaxy.yml`` to the next **expected** version, for example, ``X.1.0``. Add, commit and push to the **upstream** repository.
 
@@ -207,7 +207,7 @@ Publishing the collection
 
 4. Announce the release through the `Bullhorn Newsletter <https://forum.ansible.com/c/news/bullhorn/17>`_.
 
-5. Announce the release in the pinned release issue/community pinboard of the collection and in the ``#ansible-community`` `Matrix/IRC channel <https://docs.ansible.com/ansible/devel/community/communication.html#real-time-chat>`_. Additionally, you can announce it using GitHub's Releases system.
+5. Announce the release in the pinned release issue/community pinboard of the collection and in the ``#ansible-community`` `Matrix/IRC channel <https://docs.ansible.com/projects/ansible/devel/community/communication.html#real-time-chat>`_. Additionally, you can announce it using GitHub's Releases system.
 
 6. In the ``stable-X`` branch, update the version in ``galaxy.yml`` to the next **expected** version, for example, if you have released ``X.1.0``, the next expected version could be ``X.2.0``. Add, commit and push to the **upstream** repository.
 
@@ -291,7 +291,7 @@ Releasing when more minor versions are expected
 
 4. Announce the release through the `Bullhorn Newsletter <https://forum.ansible.com/c/news/bullhorn/17>`_.
 
-5. Announce the release in the pinned release issue/community pinboard of the collection and in the ``#ansible-community`` `Matrix/IRC channel <https://docs.ansible.com/ansible/devel/community/communication.html#real-time-chat>`.
+5. Announce the release in the pinned release issue/community pinboard of the collection and in the ``#ansible-community`` `Matrix/IRC channel <https://docs.ansible.com/projects/ansible/devel/community/communication.html#real-time-chat>`.
 
 
 Releasing when no more minor versions are expected
@@ -338,4 +338,4 @@ Releasing when no more minor versions are expected
 
 4. Announce the release through the `Bullhorn Newsletter <https://forum.ansible.com/c/news/bullhorn/17>`_.
 
-5. Announce the release in the pinned issue/community pinboard of the collection and in the ``#ansible-community`` `Matrix/IRC channel <https://docs.ansible.com/ansible/devel/community/communication.html#real-time-chat>`_.
+5. Announce the release in the pinned issue/community pinboard of the collection and in the ``#ansible-community`` `Matrix/IRC channel <https://docs.ansible.com/projects/ansible/devel/community/communication.html#real-time-chat>`_.

--- a/docs/docsite/rst/community/contributing_maintained_collections.rst
+++ b/docs/docsite/rst/community/contributing_maintained_collections.rst
@@ -72,7 +72,7 @@ The following table shows:
       <td>✓</td>
       <td>Zuul</td>
       <td>✓</td>
-      <td><a href="https://docs.ansible.com/ansible/devel/collections/amazon/aws/docsite/dev_guidelines.html">AWS guide</a></td>
+      <td><a href="https://docs.ansible.com/projects/ansible/devel/collections/amazon/aws/docsite/dev_guidelines.html">AWS guide</a></td>
     </tr>
     <tr>
       <td><a href="https://galaxy.ansible.com/ansible/netcommon">ansible.netcommon***</a></td>
@@ -83,7 +83,7 @@ The following table shows:
       <td>✓</td>
       <td>Zuul</td>
       <td>✓</td>
-      <td><a href="https://docs.ansible.com/ansible/devel/network/dev_guide/index.html">Network guide</a></td>
+      <td><a href="https://docs.ansible.com/projects/ansible/devel/network/dev_guide/index.html">Network guide</a></td>
     </tr>
     <tr>
       <td><a href="https://galaxy.ansible.com/ansible/posix">ansible.posix</a></td>
@@ -94,7 +94,7 @@ The following table shows:
       <td></td>
       <td>Zuul</td>
       <td>✓</td>
-      <td><a href="https://docs.ansible.com/ansible/latest/dev_guide/index.html">Developer guide</a></td>
+      <td><a href="https://docs.ansible.com/projects/ansible/latest/dev_guide/index.html">Developer guide</a></td>
     </tr>
     <tr>
       <td><a href="https://galaxy.ansible.com/ansible/windows">ansible.windows</a></td>
@@ -105,7 +105,7 @@ The following table shows:
       <td>✓</td>
       <td>Azure Pipelines and Zuul</td>
       <td>✓</td>
-      <td><a href="https://docs.ansible.com/ansible/devel/dev_guide/developing_modules_general_windows.html#developing-modules-general-windows">Windows guide</a></td>
+      <td><a href="https://docs.ansible.com/projects/ansible/devel/dev_guide/developing_modules_general_windows.html#developing-modules-general-windows">Windows guide</a></td>
     </tr>
     <tr>
       <td><a href="https://galaxy.ansible.com/arista/eos">arista.eos</a></td>
@@ -116,7 +116,7 @@ The following table shows:
       <td>✓</td>
       <td>Zuul</td>
       <td>✓</td>
-      <td><a href="https://docs.ansible.com/ansible/devel/network/dev_guide/index.html">Network guide</a></td>
+      <td><a href="https://docs.ansible.com/projects/ansible/devel/network/dev_guide/index.html">Network guide</a></td>
     </tr>
     <tr>
       <td><a href="https://galaxy.ansible.com/cisco/asa">cisco.asa</a></td>
@@ -127,7 +127,7 @@ The following table shows:
       <td>✓</td>
       <td>Zuul</td>
       <td>✓</td>
-      <td><a href="https://docs.ansible.com/ansible/latest/dev_guide/index.html">Developer guide</a></td>
+      <td><a href="https://docs.ansible.com/projects/ansible/latest/dev_guide/index.html">Developer guide</a></td>
     </tr>
     <tr>
       <td><a href="https://galaxy.ansible.com/cisco/ios">cisco.ios</a></td>
@@ -138,7 +138,7 @@ The following table shows:
       <td>✓</td>
       <td>Zuul</td>
       <td>✓</td>
-      <td><a href="https://docs.ansible.com/ansible/devel/network/dev_guide/index.html">Network guide</a></td>
+      <td><a href="https://docs.ansible.com/projects/ansible/devel/network/dev_guide/index.html">Network guide</a></td>
     </tr>
     <tr>
       <td><a href="https://galaxy.ansible.com/cisco/iosxr">cisco.iosxr</a></td>
@@ -149,7 +149,7 @@ The following table shows:
       <td>✓</td>
       <td>Zuul</td>
       <td>✓</td>
-      <td><a href="https://docs.ansible.com/ansible/devel/network/dev_guide/index.html">Network guide</a></td>
+      <td><a href="https://docs.ansible.com/projects/ansible/devel/network/dev_guide/index.html">Network guide</a></td>
     </tr>
     <tr>
       <td><a href="https://galaxy.ansible.com/cisco/nxos">cisco.nxos</a></td>
@@ -160,7 +160,7 @@ The following table shows:
       <td>✓</td>
       <td>Zuul</td>
       <td>✓</td>
-      <td><a href="https://docs.ansible.com/ansible/devel/network/dev_guide/index.html">Network guide</a></td>
+      <td><a href="https://docs.ansible.com/projects/ansible/devel/network/dev_guide/index.html">Network guide</a></td>
     </tr>
     <tr>
       <td><a href="https://galaxy.ansible.com/ibm/qradar">ibm.qradar</a></td>
@@ -171,7 +171,7 @@ The following table shows:
       <td>✓</td>
       <td>Zuul</td>
       <td>✓</td>
-      <td><a href="https://docs.ansible.com/ansible/latest/dev_guide/index.html">Developer guide</a></td>
+      <td><a href="https://docs.ansible.com/projects/ansible/latest/dev_guide/index.html">Developer guide</a></td>
     </tr>
     <tr>
       <td><a href="https://galaxy.ansible.com/junipernetworks/junos">junipernetworks.junos</a></td>
@@ -182,7 +182,7 @@ The following table shows:
       <td>✓</td>
       <td>Zuul</td>
       <td>✓</td>
-      <td><a href="https://docs.ansible.com/ansible/devel/network/dev_guide/index.html">Network guide</a></td>
+      <td><a href="https://docs.ansible.com/projects/ansible/devel/network/dev_guide/index.html">Network guide</a></td>
     </tr>
     <tr>
       <td><a href="https://galaxy.ansible.com/kubernetes/core">kubernetes.core</a></td>
@@ -214,7 +214,7 @@ The following table shows:
       <td>✓</td>
       <td>Zuul</td>
       <td>✓</td>
-      <td><a href="https://docs.ansible.com/ansible/devel/network/dev_guide/index.html">Network guide</a></td>
+      <td><a href="https://docs.ansible.com/projects/ansible/devel/network/dev_guide/index.html">Network guide</a></td>
     </tr>
     <tr>
       <td><a href="https://github.com/ansible-collections/splunk.es">splunk.es</a></td>
@@ -225,7 +225,7 @@ The following table shows:
       <td>✓</td>
       <td>Zuul</td>
       <td>✓</td>
-      <td><a href="https://docs.ansible.com/ansible/latest/dev_guide/index.html">Developer guide</a></td>
+      <td><a href="https://docs.ansible.com/projects/ansible/latest/dev_guide/index.html">Developer guide</a></td>
     </tr>
     <tr>
       <td><a href="https://galaxy.ansible.com/vyos/vyos">vyos.vyos</a></td>
@@ -236,7 +236,7 @@ The following table shows:
       <td>✓</td>
       <td>Zuul</td>
       <td>✓</td>
-      <td><a href="https://docs.ansible.com/ansible/devel/network/dev_guide/index.html">Network guide</a></td>
+      <td><a href="https://docs.ansible.com/projects/ansible/devel/network/dev_guide/index.html">Network guide</a></td>
     </tr>
     <tr>
       <td><a href="https://galaxy.ansible.com/vmware/vmware_rest">vmware.vmware_rest</a></td>
@@ -247,7 +247,7 @@ The following table shows:
       <td>✓</td>
       <td>Zuul</td>
       <td>✓</td>
-      <td><a href="https://docs.ansible.com/ansible/devel/collections/vmware/vmware_rest/docsite/dev_guide.html">VMware REST guide</a></td>
+      <td><a href="https://docs.ansible.com/projects/ansible/devel/collections/vmware/vmware_rest/docsite/dev_guide.html">VMware REST guide</a></td>
     </tr>
 
   </table>

--- a/docs/docsite/rst/community/contributor_path.rst
+++ b/docs/docsite/rst/community/contributor_path.rst
@@ -22,7 +22,7 @@ Find the corresponding project
 These are multiple community projects in the Ansible ecosystem you could contribute to:
 
 - `Ansible Core <https://docs.ansible.com/ansible-core/devel/index.html>`_
-- `Collections <https://docs.ansible.com/ansible/latest/user_guide/collections_using.html>`_
+- `Collections <https://docs.ansible.com/projects/ansible/latest/user_guide/collections_using.html>`_
 - `AWX <https://github.com/ansible/awx>`_
 - `Galaxy <https://galaxy.ansible.com/>`_
 - `ansible-lint <https://ansible-lint.readthedocs.io/en/latest/>`_

--- a/docs/docsite/rst/community/steering/steering_committee_membership.rst
+++ b/docs/docsite/rst/community/steering/steering_committee_membership.rst
@@ -129,7 +129,7 @@ In case of absence or irregular participation, the removal process consists of t
 Ansible Community Code of Conduct violations
 .............................................
 
-In case of the `Ansible Community Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_ violations, the process is the same as above except steps 1-2. Instead:
+In case of the `Ansible Community Code of Conduct <https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html>`_ violations, the process is the same as above except steps 1-2. Instead:
 
 #. The initiator reports the case to the Committee by email.
 

--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -325,7 +325,7 @@ html_copy_source = False
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-# html_use_opensearch = 'https://docs.ansible.com/ansible/latest'
+# html_use_opensearch = 'https://docs.ansible.com/projects/ansible/latest'
 
 # If nonempty, this is the file name suffix for HTML files (e.g. ".xhtml").
 # html_file_suffix = ''

--- a/docs/docsite/rst/dev_guide/developing_collections_structure.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_structure.rst
@@ -71,9 +71,9 @@ For community collections included in the Ansible PyPI package, docs.ansible.com
      toctree:
        - scenario_guide
 
-The index page of the documentation for your collection displays the title you define in ``docs/docsite/extra-docs.yml`` with a link to your extra documentation. For an example, see the `community.docker collection repo <https://github.com/ansible-collections/community.docker/tree/main/docs/docsite>`_ and the `community.docker collection documentation <https://docs.ansible.com/ansible/latest/collections/community/docker/index.html>`_.
+The index page of the documentation for your collection displays the title you define in ``docs/docsite/extra-docs.yml`` with a link to your extra documentation. For an example, see the `community.docker collection repo <https://github.com/ansible-collections/community.docker/tree/main/docs/docsite>`_ and the `community.docker collection documentation <https://docs.ansible.com/projects/ansible/latest/collections/community/docker/index.html>`_.
 
-You can add extra links to your collection index page and plugin pages with the ``docs/docsite/links.yml`` file. This populates the links under `Description and Communications <https://docs.ansible.com/ansible/devel/collections/community/dns/index.html#plugins-in-community-dns>`_ headings as well as links at the end of the individual plugin pages. See the `collection_template links.yml file <https://github.com/ansible-collections/collection_template/blob/main/docs/docsite/links.yml>`_ for a complete description of the structure and use of this file to create links.
+You can add extra links to your collection index page and plugin pages with the ``docs/docsite/links.yml`` file. This populates the links under `Description and Communications <https://docs.ansible.com/projects/ansible/devel/collections/community/dns/index.html#plugins-in-community-dns>`_ headings as well as links at the end of the individual plugin pages. See the `collection_template links.yml file <https://github.com/ansible-collections/collection_template/blob/main/docs/docsite/links.yml>`_ for a complete description of the structure and use of this file to create links.
 
 Plugin and module documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -180,7 +180,7 @@ information, including instructions for :ref:`testing module documentation <test
 
 .. note::
   If contributing to Ansible, every new module and plugin should have integration tests, even if the tests cannot be run on Ansible CI infrastructure.
-  In this case, the tests should be marked with the ``unsupported`` alias in `aliases file <https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/integration-aliases.html>`_.
+  In this case, the tests should be marked with the ``unsupported`` alias in `aliases file <https://docs.ansible.com/projects/ansible/latest/dev_guide/testing/sanity/integration-aliases.html>`_.
 
 
 Contributing back to Ansible

--- a/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
@@ -502,8 +502,8 @@ Modules can access this parameter by using the public ``tmpdir`` property. The `
 The directory name is generated randomly, and the the root of the directory is determined by one of these:
 
 * :ref:`DEFAULT_LOCAL_TMP`
-* `remote_tmp <https://docs.ansible.com/ansible/latest/collections/ansible/builtin/sh_shell.html#parameter-remote_tmp>`_
-* `system_tmpdirs <https://docs.ansible.com/ansible/latest/collections/ansible/builtin/sh_shell.html#parameter-system_tmpdirs>`_
+* `remote_tmp <https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/sh_shell.html#parameter-remote_tmp>`_
+* `system_tmpdirs <https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/sh_shell.html#parameter-system_tmpdirs>`_
 
 As a result, using the ``ansible.cfg`` configuration file to activate or customize this setting will not guarantee that you control the full value.
 
@@ -511,7 +511,7 @@ As a result, using the ``ansible.cfg`` configuration file to activate or customi
 _ansible_remote_tmp
 ^^^^^^^^^^^^^^^^^^^
 
-The module's ``tmpdir`` property creates a randomized directory name in this directory if the action plugin did not set ``_ansible_tmpdir``. For more details, see the `remote_tmp <https://docs.ansible.com/ansible/latest/collections/ansible/builtin/sh_shell.html#parameter-remote_tmp>`_ parameter of the shell plugin.
+The module's ``tmpdir`` property creates a randomized directory name in this directory if the action plugin did not set ``_ansible_tmpdir``. For more details, see the `remote_tmp <https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/sh_shell.html#parameter-remote_tmp>`_ parameter of the shell plugin.
 
 
 .. _flow_module_return_values:

--- a/docs/docsite/rst/dev_guide/testing/sanity/import.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/import.rst
@@ -132,7 +132,7 @@ Ansible allows the following unchecked imports from these specific directories:
 * collections:
 
   * For ``plugins/modules/`` and ``plugins/module_utils/``, unchecked imports are only allowed from the Python standard library;
-  * For other directories in ``plugins/`` (see `the community collection requirements <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html#modules-plugins>`_ for a list), unchecked imports are only allowed from the Python standard library, from public dependencies of ansible-core, and from ansible-core itself.
+  * For other directories in ``plugins/`` (see `the community collection requirements <https://docs.ansible.com/projects/ansible/devel/community/collection_contributors/collection_requirements.html#modules-plugins>`_ for a list), unchecked imports are only allowed from the Python standard library, from public dependencies of ansible-core, and from ansible-core itself.
 
 Public dependencies of ansible-core are:
 

--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -18,7 +18,7 @@ Some tests may require root.
 
 .. note::
   Every new module and plugin should have integration tests, even if the tests cannot be run on Ansible CI infrastructure.
-  In this case, the tests should be marked with the ``unsupported`` alias in `aliases file <https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/integration-aliases.html>`_.
+  In this case, the tests should be marked with the ``unsupported`` alias in `aliases file <https://docs.ansible.com/projects/ansible/latest/dev_guide/testing/sanity/integration-aliases.html>`_.
 
 Quick Start
 ===========

--- a/docs/docsite/rst/inventory_guide/intro_inventory.rst
+++ b/docs/docsite/rst/inventory_guide/intro_inventory.rst
@@ -19,7 +19,7 @@ Ansible :ref:`inventory_plugins` supports a range of formats and sources, which 
 .. contents::
    :local:
 
-The following YAML snippets include an ellipsis (...) to indicate that the snippets are part of a larger YAML file. You can find out more about YAML syntax at `YAML Basics <https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html#yaml-basics">`_.
+The following YAML snippets include an ellipsis (...) to indicate that the snippets are part of a larger YAML file. You can find out more about YAML syntax at `YAML Basics <https://docs.ansible.com/projects/ansible/latest/reference_appendices/YAMLSyntax.html#yaml-basics">`_.
 
 .. _inventoryformat:
 

--- a/docs/docsite/rst/locales/ja/LC_MESSAGES/dev_guide.po
+++ b/docs/docsite/rst/locales/ja/LC_MESSAGES/dev_guide.po
@@ -1092,8 +1092,8 @@ msgid "Migrating Ansible content to a different collection"
 msgstr "Ansible コンテンツのコレクションへの移行"
 
 #: ../../rst/dev_guide/developing_collections.rst:537
-msgid "First, look at `Ansible Collection Requirements <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html>`_."
-msgstr "まず `Ansible Collectionの要件 <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html>`_ を確認します。"
+msgid "First, look at `Ansible Collection Requirements <https://docs.ansible.com/projects/ansible/devel/community/collection_contributors/collection_requirements.html>`_."
+msgstr "まず `Ansible Collectionの要件 <https://docs.ansible.com/projects/ansible/devel/community/collection_contributors/collection_requirements.html>`_ を確認します。"
 
 #: ../../rst/dev_guide/developing_collections.rst:539
 msgid "To migrate content from one collection to another, if the collections are parts of `Ansible distribution <https://github.com/ansible-community/ansible-build-data/blob/main/2.10/ansible.in>`_:"
@@ -3689,8 +3689,8 @@ msgstr "以下の 2 つの例は、モジュールコードのテストを開始
 
 #: ../../rst/dev_guide/developing_modules_general.rst:167
 #: ../../rst/dev_guide/testing_integration.rst:20
-msgid "Every new module and plugin should have integration tests, even if the tests cannot be run on Ansible CI infrastructure. In this case, the tests should be marked with the ``unsupported`` alias in `aliases file <https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/integration-aliases.html>`_."
-msgstr "テストを Ansible CI インフラストラクチャーで実行できない場合でも、新しいモジュールとプラグインには統合テストが必要です。この場合、テストは `aliases file <https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/integration-aliases.html>`_ の ``unsupported`` エイリアスでマーク付けする必要があります。"
+msgid "Every new module and plugin should have integration tests, even if the tests cannot be run on Ansible CI infrastructure. In this case, the tests should be marked with the ``unsupported`` alias in `aliases file <https://docs.ansible.com/projects/ansible/latest/dev_guide/testing/sanity/integration-aliases.html>`_."
+msgstr "テストを Ansible CI インフラストラクチャーで実行できない場合でも、新しいモジュールとプラグインには統合テストが必要です。この場合、テストは `aliases file <https://docs.ansible.com/projects/ansible/latest/dev_guide/testing/sanity/integration-aliases.html>`_ の ``unsupported`` エイリアスでマーク付けする必要があります。"
 
 #: ../../rst/dev_guide/developing_modules_general.rst:171
 msgid "Performing sanity tests"
@@ -11175,8 +11175,8 @@ msgid "For ``plugins/modules/`` and ``plugins/module_utils/``, unchecked imports
 msgstr "``plugins/modules/`` および ``plugins/module_utils/`` の場合、チェックされていないインポートは Python 標準ライブラリーでのみ利用可能です。"
 
 #: ../../rst/dev_guide/testing/sanity/import.rst:68
-msgid "For other directories in ``plugins/`` (see `the community collection requirements <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html#modules-plugins>`_ for a list), unchecked imports are only allowed from the Python standard library, from dependencies of ansible-core, and from ansible-core itself."
-msgstr "``plugins/`` のその他のディレクトリー (一覧は「`コミュニティーコレクション要件 <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html#modules-plugins>`_」を参照) では、チェックされていないインポートは Python 標準ライブラリー、ansible-core の依存関係、および ansible-core 自体からのみ許可されます。"
+msgid "For other directories in ``plugins/`` (see `the community collection requirements <https://docs.ansible.com/projects/ansible/devel/community/collection_contributors/collection_requirements.html#modules-plugins>`_ for a list), unchecked imports are only allowed from the Python standard library, from dependencies of ansible-core, and from ansible-core itself."
+msgstr "``plugins/`` のその他のディレクトリー (一覧は「`コミュニティーコレクション要件 <https://docs.ansible.com/projects/ansible/devel/community/collection_contributors/collection_requirements.html#modules-plugins>`_」を参照) では、チェックされていないインポートは Python 標準ライブラリー、ansible-core の依存関係、および ansible-core 自体からのみ許可されます。"
 
 #: ../../rst/dev_guide/testing/sanity/index.rst:4
 #: ../../rst/dev_guide/testing_sanity.rst:7

--- a/docs/docsite/rst/locales/ja/LC_MESSAGES/porting_guides.po
+++ b/docs/docsite/rst/locales/ja/LC_MESSAGES/porting_guides.po
@@ -406,8 +406,8 @@ msgid "Ansible 2.10 Porting Guide"
 msgstr "Ansible 2.10 移植ガイド"
 
 #: ../../rst/porting_guides/porting_guide_2.10.rst:12
-msgid "In Ansible 2.10, many plugins and modules have migrated to Collections on `Ansible Galaxy <https://galaxy.ansible.com>`_. Your playbooks should continue to work without any changes. We recommend you start using the fully-qualified collection name (FQCN) in your playbooks as the explicit and authoritative indicator of which collection to use as some collections may contain duplicate module names. You can search the `index of all modules <https://docs.ansible.com/ansible/2.10/collections/index_module.html>`_ to find the collection a module has been relocated to."
-msgstr "Ansible 2.10 では、多くのプラグインやモジュールが、`Ansible Galaxy <https://galaxy.ansible.com>`_ のコレクションに移行しました。お使いの Playbook は何の変更もなく継続してお使いいただけます。一部のコレクションではモジュール名が重複している可能性があるため、どのコレクションを使用するかの明示的かつ権威的な指標として、Playbook で、完全修飾コレクション名（FQCN）を使用することが推奨されます。`すべてのモジュールのインデックス <https://docs.ansible.com/ansible/2.10/collections/index_module.html>`_ を検索すると、モジュールが再配置されたコレクションを見つけることができます。"
+msgid "In Ansible 2.10, many plugins and modules have migrated to Collections on `Ansible Galaxy <https://galaxy.ansible.com>`_. Your playbooks should continue to work without any changes. We recommend you start using the fully-qualified collection name (FQCN) in your playbooks as the explicit and authoritative indicator of which collection to use as some collections may contain duplicate module names. You can search the `index of all modules <https://docs.ansible.com/projects/ansible/2.10/collections/index_module.html>`_ to find the collection a module has been relocated to."
+msgstr "Ansible 2.10 では、多くのプラグインやモジュールが、`Ansible Galaxy <https://galaxy.ansible.com>`_ のコレクションに移行しました。お使いの Playbook は何の変更もなく継続してお使いいただけます。一部のコレクションではモジュール名が重複している可能性があるため、どのコレクションを使用するかの明示的かつ権威的な指標として、Playbook で、完全修飾コレクション名（FQCN）を使用することが推奨されます。`すべてのモジュールのインデックス <https://docs.ansible.com/projects/ansible/2.10/collections/index_module.html>`_ を検索すると、モジュールが再配置されたコレクションを見つけることができます。"
 
 #: ../../rst/porting_guides/porting_guide_2.10.rst:14
 msgid "This section discusses the behavioral changes between Ansible 2.9 and Ansible 2.10."
@@ -1303,8 +1303,8 @@ msgid "The individual collections that make up the ansible-2.10.0 package can be
 msgstr "ansible-2.10.0 パッケージを構成する個々のコレクションは個別に表示できますが、現在 ansible-galaxy により一覧表示されていません。ansible-galaxy でこれらのコレクションを表示するには、ansible がコレクションをインストールした場所を明示的に指定します。``COLLECTION_INSTALL=$(python -c 'import ansible, os.path ; print(\"%s/../ansible_collections\" % os.path.dirname(ansible.__file__))') ansible-galaxy collection list -p \"$COLLECTION_INSTALL\"``"
 
 #: ../../rst/porting_guides/porting_guide_2.10.rst:450
-msgid "These fortios modules are not automatically redirected from their 2.9.x names to the new 2.10.x names within collections. You must modify your playbooks to use fully qualified collection names for them. You can use the documentation (https://docs.ansible.com/ansible/2.10/collections/fortinet/fortios/) for the ``fortinet.fortios`` collection to determine what the fully qualified collection names are."
-msgstr "これらの fortios モジュールは、コレクション内で 2.9.x の名前から新しい 2.10.x の名前に自動的にリダイレクトされません。これらのモジュールに完全修飾コレクション名を使用するように Playbook を変更する必要があります。完全修飾コレクション名については、``fortinet.fortios`` コレクションのドキュメント (https://docs.ansible.com/ansible/2.10/collections/fortinet/fortios/)) を参照してください。"
+msgid "These fortios modules are not automatically redirected from their 2.9.x names to the new 2.10.x names within collections. You must modify your playbooks to use fully qualified collection names for them. You can use the documentation (https://docs.ansible.com/projects/ansible/2.10/collections/fortinet/fortios/) for the ``fortinet.fortios`` collection to determine what the fully qualified collection names are."
+msgstr "これらの fortios モジュールは、コレクション内で 2.9.x の名前から新しい 2.10.x の名前に自動的にリダイレクトされません。これらのモジュールに完全修飾コレクション名を使用するように Playbook を変更する必要があります。完全修飾コレクション名については、``fortinet.fortios`` コレクションのドキュメント (https://docs.ansible.com/projects/ansible/2.10/collections/fortinet/fortios/)) を参照してください。"
 
 #: ../../rst/porting_guides/porting_guide_2.10.rst:452
 msgid "fortios_address"
@@ -2690,8 +2690,8 @@ msgid "nxos_mtu use :ref:`nxos_system <nxos_system_module>` instead"
 msgstr "nxos_mtu は、代わりに :ref:`nxos_system <nxos_system_module>` を使用します。"
 
 #: ../../rst/porting_guides/porting_guide_2.3.rst:134
-msgid "These modules may no longer have documentation in the current release.  Please see the `Ansible 2.3 module documentation <https://docs.ansible.com/ansible/2.3/list_of_all_modules.html>`_ if you need to know how they worked for porting your playbooks."
-msgstr "これらのモジュールには現在のリリースのドキュメントが含まれていない可能性があります。Playbook の移植方法を把握する必要がある場合は、`Ansible 2.3 モジュールドキュメント <https://docs.ansible.com/ansible/2.3/list_of_all_modules.html>`_ を確認してください。"
+msgid "These modules may no longer have documentation in the current release.  Please see the `Ansible 2.3 module documentation <https://docs.ansible.com/projects/ansible/2.3/list_of_all_modules.html>`_ if you need to know how they worked for porting your playbooks."
+msgstr "これらのモジュールには現在のリリースのドキュメントが含まれていない可能性があります。Playbook の移植方法を把握する必要がある場合は、`Ansible 2.3 モジュールドキュメント <https://docs.ansible.com/projects/ansible/2.3/list_of_all_modules.html>`_ を確認してください。"
 
 #: ../../rst/porting_guides/porting_guide_2.3.rst:144
 msgid "AWS lambda"
@@ -3335,8 +3335,8 @@ msgid "docker use :ref:`docker_container <ansible_2_5:docker_container_module>` 
 msgstr "docker は、代わりに :ref:`docker_container <ansible_2_5:docker_container_module>` および :ref:`docker_image <ansible_2_5:docker_image_module>` を使用します。"
 
 #: ../../rst/porting_guides/porting_guide_2.5.rst:186
-msgid "These modules may no longer have documentation in the current release.  Please see the `Ansible 2.4 module documentation <https://docs.ansible.com/ansible/2.4/list_of_all_modules.html>`_ if you need to know how they worked for porting your playbooks."
-msgstr "これらのモジュールには現在のリリースのドキュメントが含まれていない可能性があります。Playbook の移植方法を把握する必要がある場合は、`Ansible 2.4 モジュールのドキュメント <https://docs.ansible.com/ansible/2.4/list_of_all_modules.html>`_ を確認してください。"
+msgid "These modules may no longer have documentation in the current release.  Please see the `Ansible 2.4 module documentation <https://docs.ansible.com/projects/ansible/2.4/list_of_all_modules.html>`_ if you need to know how they worked for porting your playbooks."
+msgstr "これらのモジュールには現在のリリースのドキュメントが含まれていない可能性があります。Playbook の移植方法を把握する必要がある場合は、`Ansible 2.4 モジュールのドキュメント <https://docs.ansible.com/projects/ansible/2.4/list_of_all_modules.html>`_ を確認してください。"
 
 #: ../../rst/porting_guides/porting_guide_2.5.rst:196
 msgid "The following modules will be removed in Ansible 2.9. Please update your playbooks accordingly."

--- a/docs/docsite/rst/locales/ja/LC_MESSAGES/reference_appendices.po
+++ b/docs/docsite/rst/locales/ja/LC_MESSAGES/reference_appendices.po
@@ -3732,8 +3732,8 @@ msgid "Root docsite URL used to generate docs URLs in warning/error text; must b
 msgstr "警告/エラーテキストでドキュメント URL を生成するために使用されるルートドキュメントサイト URL。有効なスキームおよび末尾のスラッシュが含まれる絶対 URL でなければなりません。"
 
 #: ../../rst/reference_appendices/config.rst:2145
-msgid "https://docs.ansible.com/ansible/"
-msgstr "https://docs.ansible.com/ansible/"
+msgid "https://docs.ansible.com/projects/ansible/"
+msgstr "https://docs.ansible.com/projects/ansible/"
 
 #: ../../rst/reference_appendices/config.rst:2149
 msgid "docsite_root_url"

--- a/docs/docsite/rst/locales/ja/LC_MESSAGES/scenario_guides.po
+++ b/docs/docsite/rst/locales/ja/LC_MESSAGES/scenario_guides.po
@@ -4127,8 +4127,8 @@ msgid "Since `Vultr <https://www.vultr.com>`_ offers a public API, the execution
 msgstr "`Vultr <https://www.vultr.com>`_ は、パブリック API を提供するため、プラットフォーム上のインフラストラクチャーを管理するためのモジュールの実行はローカルホストで行われます。これは、以下に変換されます。"
 
 #: ../../rst/scenario_guides/guide_vultr.rst:96
-msgid "From that point on, only your creativity is the limit. Make sure to read the documentation of the `available modules <https://docs.ansible.com/ansible/latest/modules/list_of_cloud_modules.html#vultr>`_."
-msgstr "これ以降は、ユーザーの創造性だけが限界となります。`利用可能なモジュール <https://docs.ansible.com/ansible/latest/modules/list_of_cloud_modules.html#vultr>`_ のドキュメントを確認してください。"
+msgid "From that point on, only your creativity is the limit. Make sure to read the documentation of the `available modules <https://docs.ansible.com/projects/ansible/latest/modules/list_of_cloud_modules.html#vultr>`_."
+msgstr "これ以降は、ユーザーの創造性だけが限界となります。`利用可能なモジュール <https://docs.ansible.com/projects/ansible/latest/modules/list_of_cloud_modules.html#vultr>`_ のドキュメントを確認してください。"
 
 #: ../../rst/scenario_guides/guide_vultr.rst:100
 msgid "Dynamic Inventory"

--- a/docs/docsite/rst/playbook_guide/playbooks_privilege_escalation.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_privilege_escalation.rst
@@ -213,7 +213,7 @@ a warning and allow the task to run as it did prior to 2.1.
 
 .. versionchanged:: 2.10
 
-.. _the world_readable_temp option: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/sh_shell.html#parameter-world_readable_temp
+.. _the world_readable_temp option: https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/sh_shell.html#parameter-world_readable_temp
 
 Ansible 2.10 introduces the above-mentioned ``ansible_common_remote_group``
 fallback. As mentioned above, if enabled, it is used when ``remote_user`` and

--- a/docs/docsite/rst/playbook_guide/playbooks_tests.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_tests.rst
@@ -195,7 +195,7 @@ In Ansible 2.14, the ``pep440`` option for ``version_type`` was added, and the r
 
    "{{ '2.14.0rc1' is version('2.14.0', 'lt', version_type='pep440') }}"
 
-When using ``version`` in a playbook or role, don't use ``{{ }}`` as described in the `FAQ <https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#when-should-i-use-also-how-to-interpolate-variables-or-dynamic-variable-names>`_
+When using ``version`` in a playbook or role, don't use ``{{ }}`` as described in the `FAQ <https://docs.ansible.com/projects/ansible/latest/reference_appendices/faq.html#when-should-i-use-also-how-to-interpolate-variables-or-dynamic-variable-names>`_
 
 .. code-block:: yaml
 

--- a/docs/docsite/rst/playbook_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_variables.rst
@@ -222,7 +222,7 @@ To merge variables that match the given prefixes, suffixes, or regular expressio
 
     merged_variable: "{{ lookup('community.general.merge_variables', '__my_pattern', pattern_type='suffix') }}"
 
-For more details and example usage, refer to the `community.general.merge_variables lookup documentation <https://docs.ansible.com/ansible/latest/collections/community/general/merge_variables_lookup.html>`_.
+For more details and example usage, refer to the `community.general.merge_variables lookup documentation <https://docs.ansible.com/projects/ansible/latest/collections/community/general/merge_variables_lookup.html>`_.
 
 .. _registered_variables:
 

--- a/docs/docsite/rst/roadmap/COLLECTIONS_12.rst
+++ b/docs/docsite/rst/roadmap/COLLECTIONS_12.rst
@@ -1,7 +1,7 @@
 ..
    THIS DOCUMENT IS OWNED BY THE ANSIBLE COMMUNITY STEERING COMMITTEE. ALL CHANGES MUST BE APPROVED BY THE STEERING COMMITTEE!
    For small changes (fixing typos, language errors, etc.) create a PR and ping @ansible/steering-committee.
-   For other changes, create a discussion as described in https://docs.ansible.com/ansible/devel/community/steering/community_topics_workflow.html#creating-a-topic
+   For other changes, create a discussion as described in https://docs.ansible.com/projects/ansible/devel/community/steering/community_topics_workflow.html#creating-a-topic
    to discuss the changes.
    (Creating a draft PR for this file and mentioning it in the community topic is also OK.)
 
@@ -42,7 +42,7 @@ The schedule has been updated to match the :ref:`ansible-core 2.19 release sched
 
 .. [3] After this date only changes blocking a release are accepted. Accepted changes require creating a new release candidate and may slip the final release date.
 
-.. [4] Collections will be updated to a new version only if a blocker is approved. Collection owners should discuss any blockers at a community meeting (before this freeze) to decide whether to bump the version of the collection for a fix. See the `creating an Ansible Community Topic workflow <https://docs.ansible.com/ansible/devel/community/steering/community_topics_workflow.html#creating-a-topic>`_.
+.. [4] Collections will be updated to a new version only if a blocker is approved. Collection owners should discuss any blockers at a community meeting (before this freeze) to decide whether to bump the version of the collection for a fix. See the `creating an Ansible Community Topic workflow <https://docs.ansible.com/projects/ansible/devel/community/steering/community_topics_workflow.html#creating-a-topic>`_.
 
 .. note::
 

--- a/docs/docsite/rst/roadmap/COLLECTIONS_13.rst
+++ b/docs/docsite/rst/roadmap/COLLECTIONS_13.rst
@@ -1,7 +1,7 @@
 ..
    THIS DOCUMENT IS OWNED BY THE ANSIBLE COMMUNITY STEERING COMMITTEE. ALL CHANGES MUST BE APPROVED BY THE STEERING COMMITTEE!
    For small changes (fixing typos, language errors, etc.) create a PR and ping @ansible/steering-committee.
-   For other changes, create a discussion as described in https://docs.ansible.com/ansible/devel/community/steering/community_topics_workflow.html#creating-a-topic
+   For other changes, create a discussion as described in https://docs.ansible.com/projects/ansible/devel/community/steering/community_topics_workflow.html#creating-a-topic
    to discuss the changes.
    (Creating a draft PR for this file and mentioning it in the community topic is also OK.)
 

--- a/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
+++ b/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
@@ -66,9 +66,9 @@ Adding a comment (any line starting with ``#``) helps others (and possibly yours
 Use fully qualified collection names
 ------------------------------------
 
-Use `fully qualified collection names (FQCN) <https://docs.ansible.com/ansible/latest/reference_appendices/glossary.html#term-Fully-Qualified-Collection-Name-FQCN>`_ to avoid ambiguity in which collection to search for the correct module or plugin for each task.
+Use `fully qualified collection names (FQCN) <https://docs.ansible.com/projects/ansible/latest/reference_appendices/glossary.html#term-Fully-Qualified-Collection-Name-FQCN>`_ to avoid ambiguity in which collection to search for the correct module or plugin for each task.
 
-For `builtin modules and plugins <https://docs.ansible.com/ansible/latest/collections/ansible/builtin/index.html#plugin-index>`_, use the ``ansible.builtin`` collection name as a prefix, for example, ``ansible.builtin.copy``.
+For `builtin modules and plugins <https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/index.html#plugin-index>`_, use the ``ansible.builtin`` collection name as a prefix, for example, ``ansible.builtin.copy``.
 
 .. _inventory_tips:
 


### PR DESCRIPTION
This change modifies url references to the community package docs on docs.ansible.com to include the Read the Docs projects subdirectory.