### PR TITLE
Disable version switcher in theme

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -231,7 +231,8 @@ html_theme_options = {
     'satellite_tracking': True,
     'show_extranav': True,
     'tag_manager_id': 'GTM-PSB293',
-    'vcs_pageview_mode': 'edit'
+    'vcs_pageview_mode': 'edit',
+    'display_version': False,
 }
 
 html_context = {

--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -233,6 +233,7 @@ html_theme_options = {
     'tag_manager_id': 'GTM-PSB293',
     'vcs_pageview_mode': 'edit',
     'display_version': False,
+    'version_selector': False,
 }
 
 html_context = {


### PR DESCRIPTION
Now that docs are hosted on Read the Docs, we can remove the version switcher. Users can toggle versions from the flyout menu provided by RTD.