### PR TITLE
fix: handle missing directories in docs-build test

### DIFF
--- a/tests/checkers/docs-build.py
+++ b/tests/checkers/docs-build.py
@@ -34,10 +34,14 @@ def main():
 
     with tempfile.TemporaryDirectory(prefix='docs-build-', suffix='-sanity') as temp_dir:
         for keep_dir in keep_dirs:
-            shutil.copytree(os.path.join(base_dir, keep_dir), os.path.join(temp_dir, keep_dir), symlinks=True)
+            src_path = os.path.join(base_dir, keep_dir)
+            if os.path.exists(src_path):
+                shutil.copytree(src_path, os.path.join(temp_dir, keep_dir), symlinks=True)
 
         for keep_file in keep_files:
-            shutil.copy2(os.path.join(base_dir, keep_file), os.path.join(temp_dir, keep_file))
+            src_file = os.path.join(base_dir, keep_file)
+            if os.path.exists(src_file):
+                shutil.copy2(src_file, os.path.join(temp_dir, keep_file))
 
         paths = os.environ['PATH'].split(os.pathsep)
         paths = [f'{temp_dir}/bin' if path == f'{current_dir}/bin' else path for path in paths]


### PR DESCRIPTION
The docs-build.py checker was failing with FileNotFoundError when trying to copy directories and files that don't exist in the repository (such as 'bin', 'lib', etc.). These directories are only present after cloning ansible-core using 'nox -s clone-core'.

This fix adds existence checks before attempting to copy directories and files, making the test more robust and preventing errors when running in environments where ansible-core hasn't been cloned yet.