### PR TITLE
[stable-2.20] ci: fix issues identified by zizmor GHA linter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,9 @@ name: Ansible Docsite CI
     - ready_for_review  # used in PRs created from GitHub Actions workflows
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   nox:
     uses: ./.github/workflows/reusable-nox.yml

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -29,6 +29,9 @@
 
 name: "Triage Issues and PRs"
 
+permissions:
+  contents: read
+
 jobs:
   label_prs:
     runs-on: ubuntu-latest
@@ -48,6 +51,8 @@ jobs:
           private-key: ${{ secrets.BOT_APP_KEY }}
       - name: Checkout parent repository
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Install Python 3.12
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/reusable-nox.yml
+++ b/.github/workflows/reusable-nox.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Setup nox
         uses: wntrblm/nox@2025.10.16
         with:


### PR DESCRIPTION
Manual backport of https://github.com/ansible/ansible-documentation/pull/3188

I would say it's sensible to backport these changes from the original PR. I don't think we need to integrate the zizmor session into the noxfile or add any of the comments related to zizmor. Totally open to suggestions there.

Also noticed `actions/checkout@v5` on stable branches needs to be bumped to `v6`. Debating whether to do that in a separate PR or include it here.