### PR TITLE
[stable-2.19] bump action versions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -45,11 +45,11 @@ jobs:
           app-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_KEY }}
       - name: Checkout parent repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Install Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Set up UV

--- a/.github/workflows/reusable-nox.yml
+++ b/.github/workflows/reusable-nox.yml
@@ -37,11 +37,11 @@ jobs:
     name: "Run nox ${{ matrix.session }} session"
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Setup nox
-        uses: wntrblm/nox@2025.10.16
+        uses: wntrblm/nox@2025.11.12
         with:
           python-versions: "${{ matrix.python-versions }}"
       - name: Graft ansible-core


### PR DESCRIPTION
Follows up on https://github.com/ansible/ansible-documentation/pull/3331 to manually bump action versions.