### PR TITLE
Expand basic Ansible concepts with explanations and example

### DIFF
--- a/docs/docsite/rst/getting_started/basic_concepts.rst
+++ b/docs/docsite/rst/getting_started/basic_concepts.rst
@@ -1,13 +1,52 @@
-.. _basic_concepts:
-
-****************
 Ansible concepts
-****************
+----------------
 
-These concepts are common to all uses of Ansible.
-You should understand them before using Ansible or reading the documentation.
+These concepts are common to all uses of Ansible. Understanding them will help
+you navigate the documentation and build your first automation tasks.
 
-.. contents::
-   :local:
+Core concepts
+=============
 
-.. include:: /shared_snippets/basic_concepts.txt
+Below are the fundamental ideas behind how Ansible works:
+
+* **Control node** – The machine from which you run Ansible commands and
+  playbooks. It connects to managed hosts using SSH or other remote protocols.
+
+* **Managed nodes** – The remote systems you want to configure or automate.
+  Ansible does not require any agent to be installed on these machines.
+
+* **Inventory** – A file (usually ``inventory`` or ``hosts``) that lists your
+  managed nodes and groups them logically.
+
+* **Modules** – Reusable units of work that Ansible executes on managed nodes.
+  Examples include ``ping``, ``copy``, ``package``, and many more.
+
+* **Tasks** – Individual actions executed by Ansible modules. Tasks run in
+  the order they are written.
+
+* **Playbooks** – YAML files that contain plays and tasks, describing the
+  desired state of your systems.
+
+* **Plays** – Mappings between a group of hosts and the tasks that should run
+  on them.
+
+Example
+=======
+
+The following simple playbook demonstrates a few of these concepts:
+
+.. code-block:: yaml
+
+   - name: Test connectivity to all servers
+     hosts: all
+     tasks:
+       - name: Ping remote machines
+         ansible.builtin.ping:
+
+This example uses:
+
+* an **inventory** containing your hosts,
+* a **play** targeting the group ``all``,
+* a **task** that uses the ``ping`` **module**.
+
+These concepts form the building blocks of all Ansible automation.


### PR DESCRIPTION
This contribution expands the basic_concepts page by adding a structured overview of fundamental Ansible concepts (control node, managed nodes, inventory, modules, tasks, plays, and playbooks). A simple example playbook has been added to illustrate how these concepts relate in practice.

This makes the page more helpful for new users discovering Ansible for the first time.
