### PR TITLE
Update pipx inject commands for Ansible

### DIFF
--- a/docs/docsite/rst/os_guide/windows_winrm_kerberos.rst
+++ b/docs/docsite/rst/os_guide/windows_winrm_kerberos.rst
@@ -55,8 +55,8 @@ If you chose the ``pipx`` install instructions for Ansible, you can install thos
 
 .. code-block:: shell
 
-   pipx inject "pypsrp[kerberos]<=1.0.0"  # for psrp
-   pipx inject "pywinrm[kerberos]>=0.4.0"  # for winrm
+   pipx inject ansible "pypsrp[kerberos]<=1.0.0"  # for psrp
+   pipx inject ansible "pywinrm[kerberos]>=0.4.0"  # for winrm
 
 Or, if you chose the ``pip`` install instructions:
 


### PR DESCRIPTION
Added missing "ansible" package for pipx inject command. Previous command throws error: `pipx inject: error: the following arguments are required: dependencies`