### PR TITLE
Add additional detail for Debian 13 - trixie install

### DIFF
--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -148,6 +148,15 @@ Set ``UBUNTU_CODENAME=...`` based on the table above (we use ``jammy`` in this e
     $ echo "deb [signed-by=/usr/share/keyrings/ansible-archive-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu $UBUNTU_CODENAME main" | sudo tee /etc/apt/sources.list.d/ansible.list
     $ sudo apt update && sudo apt install ansible
 
+We use ``noble`` in this example for Debian 13 (trixie):
+
+.. code-block:: bash
+
+    $ UBUNTU_CODENAME=noble
+    $ wget -O- "https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=get&search=0x6125E2A8C77F2818FB7BD15B93C4A3FD7BB9C367" | sudo gpg --dearmour -o /etc/apt/trusted.gpg.d/ansible-archive-keyring.gpg
+    $ echo "deb [signed-by=/etc/apt/trusted.gpg.d/ansible-archive-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu $UBUNTU_CODENAME main" | sudo tee /etc/apt/sources.list.d/ansible.list
+    $ sudo apt update && sudo apt install ansible
+
 .. note::
    Use double quotes around the keyserver URL and in the "echo deb" command like in the example above.
 

--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -153,7 +153,7 @@ We use ``noble`` in this example for Debian 13 (trixie):
 .. code-block:: bash
 
     $ UBUNTU_CODENAME=noble
-    $ wget -O- "https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=get&search=0x6125E2A8C77F2818FB7BD15B93C4A3FD7BB9C367" | sudo gpg --dearmour -o /etc/apt/trusted.gpg.d/ansible-archive-keyring.gpg
+    $ wget -O- "https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=get&search=0x6125E2A8C77F2818FB7BD15B93C4A3FD7BB9C367" | sudo gpg --dearmour -o /usr/share/keyrings/ansible-archive-keyring.gpg
     $ echo "deb [signed-by=/usr/share/keyrings/ansible-archive-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu $UBUNTU_CODENAME main" | sudo tee /etc/apt/sources.list.d/ansible.list
     $ sudo apt update && sudo apt install ansible
 

--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -154,7 +154,7 @@ We use ``noble`` in this example for Debian 13 (trixie):
 
     $ UBUNTU_CODENAME=noble
     $ wget -O- "https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=get&search=0x6125E2A8C77F2818FB7BD15B93C4A3FD7BB9C367" | sudo gpg --dearmour -o /etc/apt/trusted.gpg.d/ansible-archive-keyring.gpg
-    $ echo "deb [signed-by=/etc/apt/trusted.gpg.d/ansible-archive-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu $UBUNTU_CODENAME main" | sudo tee /etc/apt/sources.list.d/ansible.list
+    $ echo "deb [signed-by=/usr/share/keyrings/ansible-archive-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu $UBUNTU_CODENAME main" | sudo tee /etc/apt/sources.list.d/ansible.list
     $ sudo apt update && sudo apt install ansible
 
 .. note::

--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -153,7 +153,7 @@ We use ``noble`` in this example for Debian 13 (trixie):
 .. code-block:: bash
 
     $ UBUNTU_CODENAME=noble
-    $ wget -O- "https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=get&search=0x6125E2A8C77F2818FB7BD15B93C4A3FD7BB9C367" | sudo gpg --dearmour -o /usr/share/keyrings/ansible-archive-keyring.gpg
+    $ wget -O- "https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=get&search=0x6125E2A8C77F2818FB7BD15B93C4A3FD7BB9C367" | sudo gpg --dearmor -o /usr/share/keyrings/ansible-archive-keyring.gpg
     $ echo "deb [signed-by=/usr/share/keyrings/ansible-archive-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu $UBUNTU_CODENAME main" | sudo tee /etc/apt/sources.list.d/ansible.list
     $ sudo apt update && sudo apt install ansible
 


### PR DESCRIPTION
Added a second example for Debian 13 install. The gpg destination and entry for ansible.list change in Debian 13 so the example for previous versions is no longer quite as helpful as it was.

Apologies if I missed the mark on how to submit this request. It's my first.

Thanks!