### PR TITLE
developing_collections_creating.rst: fix min namespace / collection name length specified

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_collections_creating.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_creating.rst
@@ -60,7 +60,7 @@ To start a new collection, run the following command in your collections directo
 
 .. note::
 
-	Both the namespace and collection names use the same strict set of requirements. Both are limited to alphanumeric characters and underscores, must have a minimum length of two characters, and cannot start with an underscore.
+	Both the namespace and collection names use the same strict set of requirements. Both are limited to alphanumeric characters and underscores, must have a minimum length of three characters, and cannot start with an underscore.
 
 It will create the structure ``[my_namespace]/[my_collection]/[collection skeleton]``.
 


### PR DESCRIPTION
developing_collections_creating.rst: fix min namespace / collection name length specified
see https://github.com/ansible/galaxy/issues/3571 for the context