### PR TITLE
Add 2.16 back to the tagger script

### DIFF
--- a/hacking/tagger/tag.py
+++ b/hacking/tagger/tag.py
@@ -40,7 +40,7 @@ ROOT = HERE.parent.parent
 DEFAULT_ANSIBLE_CORE_CHECKOUT = ROOT.parent.joinpath("ansible")
 DEFAULT_REMOTE = "origin"
 DEFAULT_ACTIVE_BRANCHES: tuple[str, ...] = (
-    "stable-2.16", # Keep in sync with core even though EOL upstream
+    "stable-2.16",  # Keep in sync with core even though EOL upstream
     "stable-2.18",
     "stable-2.19",
     "stable-2.20",

--- a/hacking/tagger/tag.py
+++ b/hacking/tagger/tag.py
@@ -40,6 +40,7 @@ ROOT = HERE.parent.parent
 DEFAULT_ANSIBLE_CORE_CHECKOUT = ROOT.parent.joinpath("ansible")
 DEFAULT_REMOTE = "origin"
 DEFAULT_ACTIVE_BRANCHES: tuple[str, ...] = (
+    "stable-2.16", # Keep in sync with core even though EOL upstream
     "stable-2.18",
     "stable-2.19",
     "stable-2.20",


### PR DESCRIPTION
Even though 2.16 is EOL upstream there are still core releases happening so we should continue tagging docs to stay in sync.

Relates: https://forum.ansible.com/t/tagging-ansible-documentation-for-2-16/45267