### PR TITLE
Add note about get_cache_key in the inventory plugin dev guide

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_inventory.rst
+++ b/docs/docsite/rst/dev_guide/developing_inventory.rst
@@ -214,6 +214,8 @@ To see other inventory object methods, see the source code here:
 inventory cache
 ^^^^^^^^^^^^^^^
 
+.. note:: Setting and loading the cache encodes/decodes the cached data to/from an internal format. Inventory plugins can mitigate conversion overhead by loading and setting the cache once, and using a native, in-memory object for mutations.
+
 To cache the inventory, extend the inventory plugin documentation with the inventory_cache documentation fragment and use the Cacheable base class.
 
 .. code-block:: yaml
@@ -247,6 +249,8 @@ Before using the cache plugin, you must retrieve a unique cache key by using the
 
         self.load_cache_plugin()
         cache_key = self.get_cache_key(path)
+
+.. note:: The ``get_cache_key`` method is designed to retrieve a unique key for the plugin name and the ``path`` parameter. Inventory plugins that need to generate many unique keys based on other factors should consider redefining or not using this helper.
 
 Now that you've enabled caching, loaded the correct plugin, and retrieved a unique cache key, you can set up the flow of data between the cache and your inventory using the ``cache`` parameter of the ``parse`` method. This value comes from the inventory manager and indicates whether the inventory is being refreshed (such as by the ``--flush-cache`` or the meta task ``refresh_inventory``). Although the cache shouldn't be used to populate the inventory when being refreshed, the cache should be updated with the new inventory if the user has enabled caching. You can use ``self._cache`` like a dictionary. The following pattern allows refreshing the inventory to work in conjunction with caching.
 

--- a/docs/docsite/rst/dev_guide/developing_inventory.rst
+++ b/docs/docsite/rst/dev_guide/developing_inventory.rst
@@ -214,8 +214,6 @@ To see other inventory object methods, see the source code here:
 inventory cache
 ^^^^^^^^^^^^^^^
 
-.. note:: Setting and loading the cache encodes/decodes the cached data to/from an internal format. Inventory plugins can mitigate conversion overhead by loading and setting the cache once, and using a native, in-memory object for mutations.
-
 To cache the inventory, extend the inventory plugin documentation with the inventory_cache documentation fragment and use the Cacheable base class.
 
 .. code-block:: yaml

--- a/docs/docsite/rst/dev_guide/developing_inventory.rst
+++ b/docs/docsite/rst/dev_guide/developing_inventory.rst
@@ -248,7 +248,7 @@ Before using the cache plugin, you must retrieve a unique cache key by using the
         self.load_cache_plugin()
         cache_key = self.get_cache_key(path)
 
-.. note:: The ``get_cache_key`` is a helper method that retrieves a unique key for the plugin name and the ``path`` parameter. Inventory plugins that generate multiple unique cache entries should not use this helper method because it is designed to get one key per inventory source.
+.. note:: The ``get_cache_key`` is a helper method that retrieves a unique key for the plugin name and the ``path`` parameter. Inventory plugins that generate multiple unique cache entries should not use this helper method because it is designed to get one key per inventory source. In general we recommend that plugin developers refactor to avoid multiple cache entries for inventory sources.
 
 Now that you've enabled caching, loaded the correct plugin, and retrieved a unique cache key, you can set up the flow of data between the cache and your inventory using the ``cache`` parameter of the ``parse`` method. This value comes from the inventory manager and indicates whether the inventory is being refreshed (such as by the ``--flush-cache`` or the meta task ``refresh_inventory``). Although the cache shouldn't be used to populate the inventory when being refreshed, the cache should be updated with the new inventory if the user has enabled caching. You can use ``self._cache`` like a dictionary. The following pattern allows refreshing the inventory to work in conjunction with caching.
 

--- a/docs/docsite/rst/dev_guide/developing_inventory.rst
+++ b/docs/docsite/rst/dev_guide/developing_inventory.rst
@@ -250,7 +250,7 @@ Before using the cache plugin, you must retrieve a unique cache key by using the
         self.load_cache_plugin()
         cache_key = self.get_cache_key(path)
 
-.. note:: The ``get_cache_key`` method is designed to retrieve a unique key for the plugin name and the ``path`` parameter. Inventory plugins that need to generate many unique keys based on other factors should consider redefining or not using this helper.
+.. note:: The ``get_cache_key`` method is designed to retrieve a unique key for the plugin name and the ``path`` parameter. Inventory plugins that need to generate a lot of unique keys based on other factors should consider redefining or not using this helper.
 
 Now that you've enabled caching, loaded the correct plugin, and retrieved a unique cache key, you can set up the flow of data between the cache and your inventory using the ``cache`` parameter of the ``parse`` method. This value comes from the inventory manager and indicates whether the inventory is being refreshed (such as by the ``--flush-cache`` or the meta task ``refresh_inventory``). Although the cache shouldn't be used to populate the inventory when being refreshed, the cache should be updated with the new inventory if the user has enabled caching. You can use ``self._cache`` like a dictionary. The following pattern allows refreshing the inventory to work in conjunction with caching.
 

--- a/docs/docsite/rst/dev_guide/developing_inventory.rst
+++ b/docs/docsite/rst/dev_guide/developing_inventory.rst
@@ -248,7 +248,7 @@ Before using the cache plugin, you must retrieve a unique cache key by using the
         self.load_cache_plugin()
         cache_key = self.get_cache_key(path)
 
-.. note:: The ``get_cache_key`` method is designed to retrieve a unique key for the plugin name and the ``path`` parameter. Inventory plugins that need to generate a lot of unique keys based on other factors should consider redefining or not using this helper.
+.. note:: The ``get_cache_key`` is a helper method that retrieves a unique key for the plugin name and the ``path`` parameter. Inventory plugins that generate multiple unique cache entries should not use this helper method because it is designed to get one key per inventory source.
 
 Now that you've enabled caching, loaded the correct plugin, and retrieved a unique cache key, you can set up the flow of data between the cache and your inventory using the ``cache`` parameter of the ``parse`` method. This value comes from the inventory manager and indicates whether the inventory is being refreshed (such as by the ``--flush-cache`` or the meta task ``refresh_inventory``). Although the cache shouldn't be used to populate the inventory when being refreshed, the cache should be updated with the new inventory if the user has enabled caching. You can use ``self._cache`` like a dictionary. The following pattern allows refreshing the inventory to work in conjunction with caching.
 


### PR DESCRIPTION
Attempt to clarify the overhead of using the cache object and the purpose of the `get_cache_key` helper.

Related issues: https://github.com/ansible/ansible/issues/86504