### PR TITLE
[stable-2.20] Bump wntrblm/nox from 2025.11.12 to 2026.02.09

### DIFF
--- a/.github/workflows/reusable-nox.yml
+++ b/.github/workflows/reusable-nox.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup nox
-        uses: wntrblm/nox@2025.11.12
+        uses: wntrblm/nox@2026.02.09
         with:
           python-versions: "${{ matrix.python-versions }}"
       - name: Graft ansible-core


### PR DESCRIPTION
Follows up on #3480 to update the reusable nox workflow on stable branches.