### PR TITLE
Add multi-parent metagroup example and clarify group_vars inheritance

### DIFF
--- a/docs/docsite/rst/getting_started/get_started_inventory.rst
+++ b/docs/docsite/rst/getting_started/get_started_inventory.rst
@@ -89,20 +89,8 @@ This example inventory contains a ``network`` metagroup that includes all networ
 A group can belong to multiple metagroups.
 For example, the ``network`` group can appear under both ``datacenter`` and ``ops`` metagroups:
 
-.. code-block:: yaml
-
-   network:
-     children:
-       leafs:
-       spines:
-
-   datacenter:
-     children:
-       network:
-
-   ops:
-     children:
-       network:
+.. literalinclude:: yaml/inventory_group_structure.yaml
+   :language: yaml
 
 Variables defined for a parent group's ``group_vars`` apply to hosts in the child groups, but values defined in a child group's ``group_vars`` override the parent values.
 For predictable inheritance, prefer defining each group under only one parent metagroup even though multiple parents are allowed.

--- a/docs/docsite/rst/getting_started/get_started_inventory.rst
+++ b/docs/docsite/rst/getting_started/get_started_inventory.rst
@@ -86,8 +86,26 @@ This example inventory contains a ``network`` metagroup that includes all networ
 .. literalinclude:: yaml/inventory_group_structure.yaml
    :language: yaml
 
+A group can belong to multiple metagroups.
+For example, the ``network`` group can appear under both ``datacenter`` and ``ops`` metagroups:
+
+.. code-block:: yaml
+
+   network:
+     children:
+       leafs:
+       spines:
+
+   datacenter:
+     children:
+       network:
+
+   ops:
+     children:
+       network:
+
 Variables defined for a parent group's ``group_vars`` apply to hosts in the child groups, but values defined in a child group's ``group_vars`` override the parent values.
-For predictable inheritance, define each group under only one parent metagroup.
+For predictable inheritance, prefer defining each group under only one parent metagroup even though multiple parents are allowed.
 
 Create variables
 ----------------

--- a/docs/docsite/rst/getting_started/get_started_inventory.rst
+++ b/docs/docsite/rst/getting_started/get_started_inventory.rst
@@ -86,6 +86,9 @@ This example inventory contains a ``network`` metagroup that includes all networ
 .. literalinclude:: yaml/inventory_group_structure.yaml
    :language: yaml
 
+Variables defined for a parent group's ``group_vars`` apply to hosts in the child groups, but values defined in a child group's ``group_vars`` override the parent values.
+For predictable inheritance, define each group under only one parent metagroup.
+
 Create variables
 ----------------
 

--- a/docs/docsite/rst/getting_started/yaml/inventory_group_structure_multi.yaml
+++ b/docs/docsite/rst/getting_started/yaml/inventory_group_structure_multi.yaml
@@ -1,0 +1,26 @@
+leafs:
+  hosts:
+    leaf01:
+      ansible_host: 192.0.2.100
+    leaf02:
+      ansible_host: 192.0.2.110
+
+spines:
+  hosts:
+    spine01:
+      ansible_host: 192.0.2.120
+    spine02:
+      ansible_host: 192.0.2.130
+
+network:
+  children:
+    leafs:
+    spines:
+
+datacenter:
+  children:
+    network:
+
+ops:
+  children:
+    network:


### PR DESCRIPTION
Meta group docs lacked an example showing a group under multiple metagroups and left ambiguity about inheritance preferences.

- **Multi-parent example**: Added a YAML snippet where `network` is a child of both `datacenter` and `ops` to illustrate allowed multi-parent membership.
- **Guidance tweak**: Clarified that while multiple parents are permitted, preferring a single parent yields predictable `group_vars` inheritance.

```yaml
network:
  children:
    leafs:
    spines:

datacenter:
  children:
    network:

ops:
  children:
    network:
```