### PR TITLE
add py312 as target version for black formatting

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -86,7 +86,7 @@ def formatters(session: nox.Session):
     """
     install(session, req="formatters")
     session.run("isort", *session.posargs, *LINT_FILES)
-    session.run("black", *session.posargs, *LINT_FILES)
+    session.run("black", "--target-version", "py312", *session.posargs, *LINT_FILES)
 
 
 @nox.session
@@ -96,7 +96,9 @@ def formatters_check(session: nox.Session):
     """
     install(session, req="formatters")
     session.run("isort", "--check", *session.posargs, *LINT_FILES)
-    session.run("black", "--check", *session.posargs, *LINT_FILES)
+    session.run(
+        "black", "--check", "--target-version", "py312", *session.posargs, *LINT_FILES
+    )
 
 
 @nox.session


### PR DESCRIPTION
Relates to these PRs:

- https://github.com/ansible/ansible-documentation/pull/3514
- https://github.com/ansible/ansible-documentation/pull/3513
- https://github.com/ansible/ansible-documentation/pull/3512
- https://github.com/ansible/ansible-documentation/pull/3515

In the formatters check you can see:

```
nox > black --check hacking/pr_labeler/pr_labeler noxfile.py docs/bin/clone-core.py docs/bin/find-plugin-refs.py tests/checkers/rst-yamllint.py

Warning: Python 3.12 cannot parse code formatted for Python 3.14. To fix this: run Black with Python 3.14, set --target-version to py312, or use --fast to skip the safety check. Black's safety check verifies equivalence by parsing the AST, which fails when the running Python is older than the target version.
```

Since `pyproject.toml` is grafted from the core repo we can't set the target version there:

```
[tool.black]
target-version = ["py312"]
```

We could open a pull request in the `ansible/ansible` repository. It might be the better, more idiomatic option.

Adding the target version to the noxfile is perhaps more flexible and specific to this project. However it does mean that we'll need to keep the target version updated in args within the noxfile, which does not seem ideal.