### PR TITLE
update pip compile workflow to use GPG signing

### DIFF
--- a/.github/workflows/reusable-pip-compile.yml
+++ b/.github/workflows/reusable-pip-compile.yml
@@ -66,8 +66,8 @@ jobs:
         run: |
           echo "${GPG_PRIVATE_KEY}" | gpg --batch --import
 
-          GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format=long --with-colons | \
-            grep "^sec" | cut -d: -f5)
+          GPG_KEY_ID="$(gpg --list-secret-keys --keyid-format=long --with-colons | \
+            grep "^sec" | cut -d: -f5)"
 
           git config user.signingkey "${GPG_KEY_ID}"
           git config commit.gpgsign true

--- a/.github/workflows/reusable-pip-compile.yml
+++ b/.github/workflows/reusable-pip-compile.yml
@@ -50,24 +50,16 @@ jobs:
           fetch-depth: 0
           ref: "${{ inputs.base-branch }}"
           persist-credentials: false
-
-
       - name: Fetch required contents of ansible-core
         run: |
           python docs/bin/clone-core.py
-
-
       - name: Set up nox
         uses: wntrblm/nox@2026.02.09
         with:
           python-versions: "${{ inputs.python-versions }}"
-
-
       - name: Set up git committer
         run: |
           hacking/get_bot_user.sh "ansible-documentation-bot" "Ansible Documentation Bot"
-
-
       - name: Set up GPG signing
         env:
           GPG_PRIVATE_KEY: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
@@ -79,8 +71,6 @@ jobs:
 
           git config user.signingkey "${GPG_KEY_ID}"
           git config commit.gpgsign true
-
-
       - name: "Use a branch named ${{ inputs.pr-branch }}"
         env:
           base_branch: "${{ inputs.base-branch }}"
@@ -97,8 +87,6 @@ jobs:
             echo "branch-exists=false" >> "${GITHUB_OUTPUT}"
             git switch -c "${pr_branch}"
           fi
-
-
       - name: "Run nox ${{ inputs.nox-args }}"
         env:
           # Ensure the latest pip version is used
@@ -109,23 +97,17 @@ jobs:
         # zizmor: ignore[template-injection]
         run: |
           nox ${{ inputs.nox-args }}
-
-
       - name: Generate temp GITHUB_TOKEN
         id: create_token
         uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_KEY }}
-
-
       # We could rely on the checkout action to persist the token in the
       # repository config, but this way, we can prevent the previous steps
       # from having unnecessary access.
       - name: "Set up token authentication"
         run: gh auth setup-git --force --hostname github.com
-
-
       - name: Push new dependency versions and create a PR
         env:
           GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}

--- a/.github/workflows/reusable-pip-compile.yml
+++ b/.github/workflows/reusable-pip-compile.yml
@@ -50,16 +50,37 @@ jobs:
           fetch-depth: 0
           ref: "${{ inputs.base-branch }}"
           persist-credentials: false
+
+
       - name: Fetch required contents of ansible-core
         run: |
           python docs/bin/clone-core.py
+
+
       - name: Set up nox
         uses: wntrblm/nox@2026.02.09
         with:
           python-versions: "${{ inputs.python-versions }}"
+
+
       - name: Set up git committer
         run: |
           hacking/get_bot_user.sh "ansible-documentation-bot" "Ansible Documentation Bot"
+
+
+      - name: Set up GPG signing
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
+        run: |
+          echo "${GPG_PRIVATE_KEY}" | gpg --batch --import
+
+          GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format=long --with-colons | \
+            grep "^sec" | cut -d: -f5)
+
+          git config user.signingkey "${GPG_KEY_ID}"
+          git config commit.gpgsign true
+
+
       - name: "Use a branch named ${{ inputs.pr-branch }}"
         env:
           base_branch: "${{ inputs.base-branch }}"
@@ -76,6 +97,8 @@ jobs:
             echo "branch-exists=false" >> "${GITHUB_OUTPUT}"
             git switch -c "${pr_branch}"
           fi
+
+
       - name: "Run nox ${{ inputs.nox-args }}"
         env:
           # Ensure the latest pip version is used
@@ -86,17 +109,23 @@ jobs:
         # zizmor: ignore[template-injection]
         run: |
           nox ${{ inputs.nox-args }}
+
+
       - name: Generate temp GITHUB_TOKEN
         id: create_token
         uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_KEY }}
+
+
       # We could rely on the checkout action to persist the token in the
       # repository config, but this way, we can prevent the previous steps
       # from having unnecessary access.
       - name: "Set up token authentication"
         run: gh auth setup-git --force --hostname github.com
+
+
       - name: Push new dependency versions and create a PR
         env:
           GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}


### PR DESCRIPTION
These changes update the reusable-pip-compile workflow to sign Ansible documentation bot commits with a private GPG key. Commits on the default branch must be signed but do not need to be verified.

I've also added the `BOT_GPG_PRIVATE_KEY` secret. I generated it with these details:

```
Key-Type: RSA
Key-Length: 4096
Subkey-Type: RSA
Subkey-Length: 4096
Name-Real: Ansible Documentation Bot
Name-Email: 147556122+ansible-documentation-bot[bot]@users.noreply.github.com
Expire-Date: 0
%no-protection
```

