### PR TITLE
ansible-test: use remote/container aliases, use more modern Python versions in examples

### DIFF
--- a/docs/docsite/rst/community/collection_contributors/collection_integration_add.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_integration_add.rst
@@ -235,7 +235,7 @@ In the second task, we check the ``result`` variable, which is what the first ta
 
 .. code-block:: bash
 
-  ansible-test integration postgresql_info --docker ubuntu2004 -vvv
+  ansible-test integration postgresql_info --docker ubuntu -vvv
 
 The tests should pass. If we look at the output, we should see something like the following:
 

--- a/docs/docsite/rst/community/collection_contributors/collection_integration_running.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_integration_running.rst
@@ -17,7 +17,7 @@ The ``target_name`` is a test role directory containing the tests. For example, 
 
 .. code-block:: bash
 
-  ansible-test integration postgresql_info --docker fedora34
+  ansible-test integration postgresql_info --docker fedora
 
 You can use the ``-vv`` or ``-vvv`` argument if you need more detailed output.
 

--- a/docs/docsite/rst/community/create_pr_quick_start.rst
+++ b/docs/docsite/rst/community/create_pr_quick_start.rst
@@ -136,7 +136,7 @@ If you need to run the tests against a specific distribution, see the :ref:`list
 
 .. code-block:: bash
 
-  $ ansible-test integration name_of_test_subdirectory --docker fedora35 -v
+  $ ansible-test integration name_of_test_subdirectory --docker fedora -v
 
 .. note::
 

--- a/docs/docsite/rst/dev_guide/developing_collections_testing.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_testing.rst
@@ -54,13 +54,13 @@ To run all unit tests only for a specific Python version:
 
 .. code-block:: shell-session
 
-    ansible-test units --docker default -v --python 3.6
+    ansible-test units --docker default -v --python 3.13
 
 To run only a specific unit test:
 
 .. code-block:: shell-session
 
-    ansible-test units --docker default -v --python 3.6 tests/unit/plugins/module_utils/foo/test_bar.py
+    ansible-test units --docker default -v --python 3.13 tests/unit/plugins/module_utils/foo/test_bar.py
 
 You can specify Python requirements in the ``tests/unit/requirements.txt`` file. See :ref:`testing_units` for more information, especially on fixture files.
 
@@ -84,7 +84,7 @@ To execute all integration tests for a collection:
 
 .. code-block:: shell-session
 
-    ansible-test integration --docker fedora35 -v
+    ansible-test integration --docker fedora -v
 
 If you want more detailed output, run the command with ``-vvv`` instead of ``-v``. Alternatively, specify ``--retry-on-error`` to automatically re-run failed tests with higher verbosity levels.
 
@@ -92,7 +92,7 @@ To execute only the integration tests in a specific directory:
 
 .. code-block:: shell-session
 
-    ansible-test integration --docker fedora35 -v connection_bar
+    ansible-test integration --docker fedora -v connection_bar
 
 You can specify multiple target names. Each target name is the name of a directory in ``tests/integration/targets/``.
 

--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -72,13 +72,13 @@ outside of those test subdirectories.  They will also not reconfigure or bounce 
 
 .. note:: Running integration tests within containers
 
-   To protect your system from any potential changes caused by integration tests, and to ensure a sensible set of dependencies are available we recommend that you always run integration tests with the ``--docker`` option, for example ``--docker ubuntu2204``. Get the list of supported container images by running ``ansible-test integration --help``. You can find them in the *target docker images* section of the output. The ``default`` image is used for sanity and unit tests, as well as for platform independent integration tests such as those for cloud modules.
+   To protect your system from any potential changes caused by integration tests, and to ensure a sensible set of dependencies are available we recommend that you always run integration tests with the ``--docker`` option, for example ``--docker ubuntu``. Get the list of supported container images by running ``ansible-test integration --help``. You can find them in the *target docker images* section of the output. The ``default`` image is used for sanity and unit tests, as well as for platform independent integration tests such as those for cloud modules.
 
 Run as follows for all POSIX platform tests executed by our CI system in a Fedora 34 container:
 
 .. code-block:: shell-session
 
-    ansible-test integration shippable/ --docker fedora34
+    ansible-test integration shippable/ --docker fedora
 
 You can exclude a specific test as well, such as for individual modules:
 
@@ -116,7 +116,7 @@ to a virtual environment, such as Docker.  They won't reformat your filesystem:
 
 .. code-block:: shell-session
 
-    ansible-test integration destructive/ --docker fedora34
+    ansible-test integration destructive/ --docker fedora
 
 Windows Tests
 =============
@@ -167,18 +167,18 @@ the Ansible continuous integration (CI) system is recommended.
 Running Integration Tests
 -------------------------
 
-To run all CI integration test targets for POSIX platforms in a Ubuntu 18.04 container:
+To run all CI integration test targets for POSIX platforms in a Ubuntu container:
 
 .. code-block:: shell-session
 
-    ansible-test integration shippable/ --docker ubuntu1804
+    ansible-test integration shippable/ --docker ubuntu
 
 You can also run specific tests or select a different Linux distribution.
-For example, to run tests for the ``ping`` module on a Ubuntu 18.04 container:
+For example, to run tests for the ``ping`` module on a Ubuntu container:
 
 .. code-block:: shell-session
 
-    ansible-test integration ping --docker ubuntu1804
+    ansible-test integration ping --docker ubuntu
 
 .. _test_container_images:
 

--- a/docs/docsite/rst/dev_guide/testing_running_locally.rst
+++ b/docs/docsite/rst/dev_guide/testing_running_locally.rst
@@ -352,7 +352,7 @@ Interactive shell
 Use the ``ansible-test shell`` command to get an interactive shell in the same environment used to run tests. Examples:
 
 * ``ansible-test shell --docker`` - Open a shell in the default docker container.
-* ``ansible-test shell --venv --python 3.10`` - Open a shell in a Python 3.10 virtual environment.
+* ``ansible-test shell --venv --python 3.13`` - Open a shell in a Python 3.13 virtual environment.
 
 Code coverage
 =============

--- a/docs/docsite/rst/dev_guide/testing_units.rst
+++ b/docs/docsite/rst/dev_guide/testing_units.rst
@@ -45,7 +45,7 @@ Or against a specific Python version by doing:
 
 .. code:: shell
 
-   ansible-test units --docker -v --python 2.7 apt
+   ansible-test units --docker -v --python 3.13 apt
 
 If you are running unit tests against things other than modules, such as module utilities, specify the whole file path:
 
@@ -74,7 +74,7 @@ install all the required dependencies needed for unit tests. For example:
 
 .. code:: shell
 
-   ansible-test units --python 2.7 --requirements apache2_module
+   ansible-test units --python 3.12 --requirements apache2_module
 
 
 The list of unit test requirements can be found at `test/units/requirements.txt


### PR DESCRIPTION
With https://github.com/ansible/ansible/pull/86592 and its backports, we can avoid specifying specific container/remote versions for ansible-test examples, which quickly get out of date. (Fedora 34 anyone?)

While looking at that, I also bumped some example Python versions to something less ancient.