### PR TITLE
Document need for signed commits

### DIFF
--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -54,7 +54,7 @@ We do not merge every PR. Here are some tips for making your PR useful, attracti
 Signed commits
 --------------
 
-All commits to repos under https://github.com/ansible/ must be signed. To set up signed commits, consult the github documentation to set up a `gpg key <https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification>`_, `ssh key <https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-signature-verification>`_, or `S/MIME <https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#smime-commit-signature-verification>`_.
+All commits to repos under https://github.com/ansible/ must be signed. To set up signed commits, consult the Github documentation for `GPG keys <https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification>`_, `SSH keys <https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-signature-verification>`_, or `S/MIME <https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#smime-commit-signature-verification>`_.
 
 .. _community_changelogs:
 

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -49,6 +49,13 @@ Making your PR merge-worthy
 
 We do not merge every PR. Here are some tips for making your PR useful, attractive, and merge-worthy.
 
+.. _signed_commits:
+
+Signed commits
+--------------
+
+All commits to repos under https://github.com/ansible/ must be signed. To set up signed commits, consult the github documentation to set up a `gpg key <https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification>`_, `ssh key <https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-signature-verification>`_, or `S/MIME <https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#smime-commit-signature-verification>`_.
+
 .. _community_changelogs:
 
 Changelog fragments


### PR DESCRIPTION
> From Monday 16th March we will be requiring Git signed commits for all repos under [github.com/ansible/](https://github.com/ansible/).
[Source](https://forum.ansible.com/t/important-github-com-ansible-now-requires-signed-commits/45520)

I think this requirement should be mentioned somewhere in the ansible documentation. I put it under the [Making your PR merge worthy](https://docs.ansible.com/projects/ansible/latest/community/development_process.html#making-your-pr-merge-worthy) section, but if it makes more sense somewhere else it can be moved. 