### PR TITLE
Document register projection functionality

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_conditionals.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_conditionals.rst
@@ -194,6 +194,24 @@ Ansible always registers something in a registered variable for every host, even
         
 .. note:: Older versions of Ansible used ``success`` and ``fail``, but ``succeeded`` and ``failed`` use the correct tense. All of these options are now valid.
 
+In loops, you can use the implicit ``_task`` variable to access the previous iteration's result in ``when`` conditionals. Since the result doesn't exist on the first iteration, you must provide a default value:
+
+.. code-block:: yaml
+
+    - name: Skip alternating items based on previous result
+      ansible.builtin.debug:
+        msg: "Item {{ item }}"
+      loop: [1, 2, 3, 4, 5]
+      when: _task.result | default({}) is skipped
+
+You can also use ``_task.loop_result`` to access all accumulated results during iteration:
+
+.. code-block:: yaml
+
+    - name: Stop after two successful items
+      ansible.builtin.shell: /usr/bin/process {{ item }}
+      loop: [1, 2, 3, 4, 5, 6]
+      when: (_task.loop_result.results | default([]) | selectattr('failed', 'equalto', false) | list | length) < 2
 
 Conditionals based on variables
 -------------------------------

--- a/docs/docsite/rst/playbook_guide/playbooks_conditionals.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_conditionals.rst
@@ -198,11 +198,13 @@ In loops, you can use the implicit ``_task`` variable to access the previous ite
 
 .. code-block:: yaml
 
-    - name: Skip alternating items based on previous result
-      ansible.builtin.debug:
-        msg: "Item {{ item }}"
-      loop: [1, 2, 3, 4, 5]
-      when: _task.result | default({}) is skipped
+    - name: Run each step only if the previous one succeeded
+      ansible.builtin.command: "/opt/scripts/{{ item }}.sh"
+      loop:
+        - initialize
+        - validate
+        - deploy
+      when: _task.result | default({}) is not failed
 
 You can also use ``_task.loop_result`` to access all accumulated results during iteration:
 

--- a/docs/docsite/rst/playbook_guide/playbooks_error_handling.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_error_handling.rst
@@ -150,7 +150,7 @@ You may also access task results without registering a variable via the ``result
 
     - name: Fail task when either condition is met
       ansible.builtin.command: /usr/bin/example-command
-      failed_when: _task.result.rc != 0 or 'ERROR' in command_result.stdout
+      failed_when: _task.result.rc != 0 or 'ERROR' in _task.result.stdout
 
 .. _override_the_changed_result:
 

--- a/docs/docsite/rst/playbook_guide/playbooks_error_handling.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_error_handling.rst
@@ -144,6 +144,14 @@ If you have too many conditions to fit neatly into one line, you can split it in
         (ret.stderr != '') or
         (ret.rc == 10)
 
+You may also access task results without registering a variable via the ``result`` property of the implicit variable ``_task``.
+
+.. code-block:: yaml
+
+    - name: Fail task when either condition is met
+      ansible.builtin.command: /usr/bin/example-command
+      failed_when: _task.result.rc != 0 or 'ERROR' in command_result.stdout
+
 .. _override_the_changed_result:
 
 Defining "changed"
@@ -179,6 +187,17 @@ You can also combine multiple conditions to override "changed" result.
       changed_when:
         - '"ERROR" in result.stderr'
         - result.rc == 2
+
+As with ``failed_when``, you may use the implicit variable ``_task`` to avoid registering a variable. The above may be restated as:
+
+.. code-block:: yaml
+
+    - name: Combine multiple conditions to override 'changed' result
+      ansible.builtin.command: /bin/fake_command
+      ignore_errors: True
+      changed_when:
+        - '"ERROR" in _task.result.stderr'
+        - _task.result.rc == 2
 
 You can reference simple variables in conditionals to avoid repeating certain terms, as in the following example:
 

--- a/docs/docsite/rst/playbook_guide/playbooks_error_handling.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_error_handling.rst
@@ -152,6 +152,10 @@ You may also access task results without registering a variable via the ``result
       ansible.builtin.command: /usr/bin/example-command
       failed_when: _task.result.rc != 0 or 'ERROR' in _task.result.stdout
 
+.. note::
+
+   The ``_task`` implicit variable can be used in all conditional keywords, including ``when``, ``until``, ``failed_when``, ``changed_when``, and ``break_when``.
+
 .. _override_the_changed_result:
 
 Defining "changed"

--- a/docs/docsite/rst/playbook_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_loops.rst
@@ -239,6 +239,30 @@ During iteration, the result of the current item will be placed in the variable.
       register: echo
       changed_when: echo.stdout != "one"
 
+The result of the current item during iteration is also accessible in the ``result`` property of the implicit variable ``_task``. This allows for accessing loop item results without first registering a variable
+
+.. code-block:: yaml+jinja
+
+    - name: Place the result of the current item in the variable
+      ansible.builtin.shell: echo "{{ item }}"
+      loop:
+        - one
+        - two
+      changed_when: _task.result.stdout != "one"
+
+To access the full loop result list during iteration, the ``loop_results`` property of the ``_task`` implicit variable may be used.
+
+.. code-block:: yaml+jinja
+
+    - name: Run a loop and access individual item output
+      ansible.builtin.shell: "{{ item }}"
+      register:
+        foo_output: _task.loop_results[0].stdout
+        bar_output: _task.loop_results[1].stdout | default(0)  # using default here is necessary as when the loop is on the first item, it will still try and access `loop_results[1]` which doesn't exist yet
+      loop:
+        - /usr/bin/foo
+        - /usr/bin/bar
+
 .. _do_until_loops:
 
 Retrying a task until a condition is met

--- a/docs/docsite/rst/playbook_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_loops.rst
@@ -335,11 +335,15 @@ You can use the implicit ``_task`` variable to access the current result in ``un
 
 .. code-block:: yaml
 
-    - name: Retry until attempt count reaches expected value
-      ansible.builtin.shell: /usr/bin/foo
-      retries: 3
-      delay: 1
-      until: _task.result.attempts == 2
+    - name: Wait for each service to be ready
+      ansible.builtin.command: systemctl is-active {{ item }}
+      loop:
+        - nginx
+	- postgresql
+	- redis
+      retries: 5
+      delay: 2
+      until: _task.result.rc == 0
 
 When combining ``until`` with a loop, you can use ``_task.loop_result`` to access accumulated results:
 

--- a/docs/docsite/rst/playbook_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_loops.rst
@@ -339,21 +339,11 @@ You can use the implicit ``_task`` variable to access the current result in ``un
       ansible.builtin.command: systemctl is-active {{ item }}
       loop:
         - nginx
-	- postgresql
-	- redis
+        - postgresql
+        - redis
       retries: 5
       delay: 2
       until: _task.result.rc == 0
-
-When combining ``until`` with a loop, you can use ``_task.loop_result`` to access accumulated results:
-
-.. code-block:: yaml
-
-    - name: Retry each item based on loop progress
-      ansible.builtin.shell: /usr/bin/process {{ item }}
-      loop: [1, 2, 3]
-      retries: 3
-      until: _task.result.attempts == _task.loop_result.results | length
 
 .. _loop_over_inventory:
 

--- a/docs/docsite/rst/playbook_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_loops.rst
@@ -239,7 +239,7 @@ During iteration, the result of the current item will be placed in the variable.
       register: echo
       changed_when: echo.stdout != "one"
 
-The result of the current item during iteration is also accessible in the ``result`` property of the implicit variable ``_task``. This allows for accessing loop item results without first registering a variable
+When registering multiple variables, the result of the current item during iteration is also accessible in the ``result`` property of the implicit variable ``_task``. This allows for accessing loop item results without first registering a variable.
 
 .. code-block:: yaml+jinja
 
@@ -250,18 +250,38 @@ The result of the current item during iteration is also accessible in the ``resu
         - two
       changed_when: _task.result.stdout != "one"
 
-To access the full loop result list during iteration, the ``loop_results`` property of the ``_task`` implicit variable may be used.
+To access the full, accumulated loop result list during iteration, the ``loop_result`` property of the ``_task`` implicit variable may be used.
 
 .. code-block:: yaml+jinja
 
     - name: Run a loop and access individual item output
       ansible.builtin.shell: "{{ item }}"
       register:
-        foo_output: _task.loop_results[0].stdout
-        bar_output: _task.loop_results[1].stdout | default(0)  # using default here is necessary as when the loop is on the first item, it will still try and access `loop_results[1]` which doesn't exist yet
+        foo_output: _task.loop_result[0].stdout
+        bar_output: _task.loop_result[1].stdout | default(0)  # using default here is necessary as when the loop is on the first item, it will still try and access `loop_result[1]` which doesn't exist yet
       loop:
         - /usr/bin/foo
         - /usr/bin/bar
+
+To access the same functionality as name-only variable registration when registering multiple variables, the ``polymorphic_result`` property of the ``_task`` implicit variable can be used. During iteration, it will be contain the result of the most recent loop iteration, and afterwards it will contain the full task result. This makes these two tasks equivalent:
+
+.. code-block:: yaml
+
+    - name: Run a loop and register a single variable
+      ansible.builtin.shell: "{{ item }}"
+      register: foo_bar_result
+      loop:
+        - /usr/bin/foo
+        - /usr/bin/bar
+
+    - name: Register the same variable in the multi-variable register format
+      ansible.builtin.shell: "{{ item }}"
+      register:
+        foo_bar_result: _task.polymorphic_result
+      loop:
+        - /usr/bin/foo
+        - /usr/bin/bar
+
 
 .. _do_until_loops:
 

--- a/docs/docsite/rst/playbook_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_loops.rst
@@ -257,13 +257,13 @@ To access the full, accumulated loop result list during iteration, the ``loop_re
     - name: Run a loop and access individual item output
       ansible.builtin.shell: "{{ item }}"
       register:
-        foo_output: _task.loop_result[0].stdout
-        bar_output: _task.loop_result[1].stdout | default(0)  # using default here is necessary as when the loop is on the first item, it will still try and access `loop_result[1]` which doesn't exist yet
+        foo_output: _task.loop_result.results[0].stdout
+        bar_output: _task.loop_result.results[1].stdout | default(0)  # using default here is necessary as when the loop is on the first item, it will still try and access `loop_result.results[1]` which doesn't exist yet
       loop:
         - /usr/bin/foo
         - /usr/bin/bar
 
-To access the same functionality as name-only variable registration when registering multiple variables, the ``polymorphic_result`` property of the ``_task`` implicit variable can be used. During iteration, it will be contain the result of the most recent loop iteration, and afterwards it will contain the full task result. This makes these two tasks equivalent:
+To access the same functionality as name-only variable registration when registering multiple variables, the ``polymorphic_result`` property of the ``_task`` implicit variable can be used. During iteration, it will contain the result of the most recent loop iteration, and afterwards it will contain the full task result. This makes these two tasks equivalent:
 
 .. code-block:: yaml
 
@@ -330,6 +330,26 @@ You can combine the ``until`` keyword with ``loop`` or ``with_<lookup>``. The re
 .. note::
 
    When you use the ``timeout`` keyword in a loop, it applies to each attempt of the task action. See :ref:`TASK_TIMEOUT <TASK_TIMEOUT>` for more details.
+
+You can use the implicit ``_task`` variable to access the current result in ``until`` without registering a variable:
+
+.. code-block:: yaml
+
+    - name: Retry until attempt count reaches expected value
+      ansible.builtin.shell: /usr/bin/foo
+      retries: 3
+      delay: 1
+      until: _task.result.attempts == 2
+
+When combining ``until`` with a loop, you can use ``_task.loop_result`` to access accumulated results:
+
+.. code-block:: yaml
+
+    - name: Retry each item based on loop progress
+      ansible.builtin.shell: /usr/bin/process {{ item }}
+      loop: [1, 2, 3]
+      retries: 3
+      until: _task.result.attempts == _task.loop_result.results | length
 
 .. _loop_over_inventory:
 
@@ -466,6 +486,19 @@ Use the ``break_when`` directive with ``loop_control`` to exit a loop after any 
        - fail:
            msg: "Maximum attempts to generate a valid password exceeded"
          when: password is not match(password_policy)
+
+When using register projections, you can reference the registered variables in ``break_when``:
+
+.. code-block:: yaml
+
+    - name: Break after processing two items
+      ansible.builtin.debug:
+        msg: "Processing {{ item }}"
+      loop: [1, 2, 3, 4, 5]
+      loop_control:
+        break_when: items_processed == 2
+      register:
+        items_processed: _task.loop_result.results | length
 
 Tracking progress through a loop with ``index_var``
 ---------------------------------------------------

--- a/docs/docsite/rst/playbook_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_variables.rst
@@ -248,6 +248,8 @@ You can create variables from the output of an Ansible task with the task keywor
 
 For more examples of using registered variables in conditions on later tasks, see :ref:`playbooks_conditionals`. Registered variables may be simple variables, list variables, dictionary variables, or complex nested data structures. The documentation for each module includes a ``RETURN`` section that describes the return values for that module. To see the values for a particular task, run your playbook with ``-v``.
 
+.. versionadded:: 2.21
+
 You can also use ``register`` to register multiple variables and manipulate task output with jinja expressions with a dictionary of ``variable: expression`` pairs. Ansible provides an implicit task variable ``_task`` for accessing task output via its ``result`` property.
 
 .. note::

--- a/docs/docsite/rst/playbook_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_variables.rst
@@ -250,7 +250,7 @@ For more examples of using registered variables in conditions on later tasks, se
 
 You can also use ``register`` to register multiple variables and manipulate task output with jinja expressions with a dictionary of ``variable: expression`` pairs. Ansible provides an implicit task variable ``_task`` for accessing task output via its ``result`` property.
 
-.. code-block:: yaml
+.. code-block:: yaml+jinja
 
     - hosts: web_servers
 
@@ -263,6 +263,18 @@ You can also use ``register`` to register multiple variables and manipulate task
             capitalized_command_output: _task.result.stdout | capitalize
 
 Because this form of ``register`` is always a jinja expression, template delimiters ``{{}}`` are not required.
+
+Variable registered in this way allow for chained access to other variables defined in the same ``register`` map. This means you can define variables based on other variables created in the same step, and the order of definition does not matter.
+
+.. code-block:: yaml
+    - hosts: web_servers
+
+      tasks:
+        - name: Run a shell command and register multiple variables
+          ansible.builtin.shell: /usr/bin/foo
+          register:
+            capitalized_command_output: command_result.stdout | capitalize  # This works even though command_result is defined after capitalized_command_output
+            command_result: _task.result  # this is equivalent to register: command_result
 
 Registered variables are stored in memory. You cannot cache registered variables for use in future playbook runs. A registered variable is valid only on the host for the rest of the current playbook run, including subsequent plays within the same playbook run.
 

--- a/docs/docsite/rst/playbook_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_variables.rst
@@ -229,7 +229,7 @@ For more details and example usage, refer to the `community.general.merge_variab
 Registering variables
 =====================
 
-You can create a variable from the output of an Ansible task with the task keyword ``register``. You can use the registered variable in any later task in your play. For example:
+You can create variables from the output of an Ansible task with the task keyword ``register``. You can use the registered variables in any later task in your play. For example:
 
 .. code-block:: yaml
 
@@ -247,6 +247,22 @@ You can create a variable from the output of an Ansible task with the task keywo
           when: foo_result.rc == 5
 
 For more examples of using registered variables in conditions on later tasks, see :ref:`playbooks_conditionals`. Registered variables may be simple variables, list variables, dictionary variables, or complex nested data structures. The documentation for each module includes a ``RETURN`` section that describes the return values for that module. To see the values for a particular task, run your playbook with ``-v``.
+
+You can also use ``register`` to register multiple variables and manipulate task output with jinja expressions with a dictionary of ``variable: expression`` pairs. Ansible provides an implicit task variable ``_task`` for accessing task output via its ``result`` property.
+
+.. code-block:: yaml
+
+    - hosts: web_servers
+
+      tasks:
+        - name: Run a shell command and register multiple variables
+          ansible.builtin.shell: /usr/bin/foo
+          register:
+            command_result: _task.result  # this is equivalent to register: command_result
+            command_duration: _task.result.dt
+            capitalized_command_output: _task.result.stdout | capitalize
+
+Because this form of ``register`` is always a jinja expression, template delimiters ``{{}}`` are not required.
 
 Registered variables are stored in memory. You cannot cache registered variables for use in future playbook runs. A registered variable is valid only on the host for the rest of the current playbook run, including subsequent plays within the same playbook run.
 

--- a/docs/docsite/rst/playbook_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_variables.rst
@@ -267,6 +267,7 @@ Because this form of ``register`` is always a jinja expression, template delimit
 Variable registered in this way allow for chained access to other variables defined in the same ``register`` map. This means you can define variables based on other variables created in the same step, and the order of definition does not matter.
 
 .. code-block:: yaml
+
     - hosts: web_servers
 
       tasks:

--- a/docs/docsite/rst/playbook_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_variables.rst
@@ -250,6 +250,10 @@ For more examples of using registered variables in conditions on later tasks, se
 
 You can also use ``register`` to register multiple variables and manipulate task output with jinja expressions with a dictionary of ``variable: expression`` pairs. Ansible provides an implicit task variable ``_task`` for accessing task output via its ``result`` property.
 
+.. note::
+
+   ``_task`` is a reserved name and used for internal purposes. Do not use this name to register task results.
+
 .. code-block:: yaml+jinja
 
     - hosts: web_servers
@@ -264,7 +268,7 @@ You can also use ``register`` to register multiple variables and manipulate task
 
 Because this form of ``register`` is always a jinja expression, template delimiters ``{{}}`` are not required.
 
-Variable registered in this way allow for chained access to other variables defined in the same ``register`` map. This means you can define variables based on other variables created in the same step, and the order of definition does not matter.
+Variables registered in this way allow for chained access to other variables defined in the same ``register`` map. You can define variables based on other variables created in the same step, **and the order of definition does not matter**.
 
 .. code-block:: yaml
 
@@ -276,6 +280,8 @@ Variable registered in this way allow for chained access to other variables defi
           register:
             capitalized_command_output: command_result.stdout | capitalize  # This works even though command_result is defined after capitalized_command_output
             command_result: _task.result  # this is equivalent to register: command_result
+
+Register projections are evaluated after the task completes, not during task execution. This means variables defined in a ``register`` map are not available within the task itself, and references to ``_task.result`` or other projected variables will reflect the final task state. This lazy evaluation enables order-independent variable definitions.
 
 Registered variables are stored in memory. You cannot cache registered variables for use in future playbook runs. A registered variable is valid only on the host for the rest of the current playbook run, including subsequent plays within the same playbook run.
 

--- a/docs/docsite/rst/reference_appendices/glossary.rst
+++ b/docs/docsite/rst/reference_appendices/glossary.rst
@@ -399,8 +399,8 @@ when a term comes up on the :ref:`Ansible Forum<ansible_forum>`.
 
     Register Variable
         The result of running any :term:`task <tasks>` in Ansible can be
-        stored in a variable for use in a template or a conditional statement.
-        The keyword used to define the variable is called ``register``, taking
+        stored in variables for use in a template or a conditional statement.
+        The keyword used to define the variables is called ``register``, taking
         its name from the idea of registers in assembly programming (though
         Ansible will never feel like assembly programming).  There are an
         infinite number of variable names you can use for registration.


### PR DESCRIPTION
This PR documents the new functionality of the `register` keyword introduced by https://github.com/ansible/ansible/pull/86241. I am confident that this is incomplete and needs adjustments/examples, but these seemed to be the most obvious places that `register` functionality needed updating.

I was torn on including a separate page/section by the name of 'register projections' but I opted to instead disperse the various pieces of `register` across the existing documentation points.

One candidate for getting its own section is the implicit variable `_task` for documenting the accessible properties, but I'm unsure where this should be placed (maybe here? docs/docsite/rst/reference_appendices/common_return_values.rst). 

---
Forgot to add it to commit 4dce38add680de01504672b2c7625bd2eee3884c
Co-authored-by: claude code