### PR TITLE
Add Ansible AI Policy

### DIFF
--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -35,7 +35,7 @@ For the purposes of this document, "contribution submission" includes, but is no
       iii. Assisted-by: Claude Code (Opus 4.6)
       iv. Assisted-by: Cursor (Opus 4.6)
 
-5. All contributions assisted by AI tools MUST meet a specific project’s or platform’s standards including code of conduct and license compliance.
+5. All contributions assisted by AI tools MUST meet a specific project’s or platform’s standards, conventions and contributing guidelines, including code of conduct and license compliance.
 6. AI MUST NOT be used as the sole arbiter to make final judgments and decisions on people or their contributions, for example, Code of Conduct matters, project board elections, package content acceptance.
 7. This policy does not apply to major AI-driven changes to a specific project’s direction, workflows, codebase, or high-volume automated contributions. Such changes require separate discussion and approval by the leadership of the affected project. Unsolicited mass submissions of AI-generated contributions may be rejected without consideration of their content, and the accounts responsible may be banned.
 

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -4,7 +4,7 @@
 Ansible Community Policy for AI-Assisted Contributions
 ******************************************************
 
-This policy uses the term "AI" to apply to any assistive tools, as well as autonomous and semi-autonomous tooling, that is generally built using the machine learning approach. Examples of such AI tools include large language models (LLMs), text or image generators, and agentic systems that are available as a service or trained locally.
+This policy uses the term "AI" to apply to any assistive tools, as well as autonomous and semi-autonomous tooling, that is generally built using the machine learning approach. Examples of such tools include large language models (LLMs), text or image generators, and agentic systems that are available as a service or trained locally.
 
 This policy applies to the following projects and resources:
 

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -42,4 +42,4 @@ This AI policy was adapted from AI policies of other open source projects, inclu
 * The Fedora Project
 * The Linux Foundation
 
-.. [1] For the purposes of this document, "contribution submission" includes, but is not limited to, opening issues, creating pull requests with code or documentation changes, participating in discussions, making comments, creating posts in the forum, and other related activities.
+.. [1] For the purposes of this document, contributions include, but are not limited to, opening issues, creating pull requests with code or documentation changes, participating in discussions, making comments, creating posts in the forum, and other related activities.

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -15,7 +15,7 @@ This policy applies to the following projects and resources:
 
 For the purposes of this document, "contribution submission" includes, but is not limited to, opening issues, pull requests with code or documentation changes, discussion, making comments, posts and alike.
 
-1. Contributors MUST be real humans and MAY use assistance of AI tools for contributing to the above projects and resources, as long as they take full responsibility for their contributions and follow the principles described in this policy.
+1. Contributors MUST be human and MAY use assistance of AI tools for contributing to the above projects and resources, provided that they take full responsibility for their contributions and follow the principles described in this policy.
 
 2. All contributions assisted by AI tools MUST meet a specific project’s or platform’s standards, conventions and contributing guidelines, including code of conduct and license compliance. This document seeks to clarify tool-specific considerations but in no way replaces the governing documents and good contributing practices.
 

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -10,7 +10,7 @@ This policy applies to the following projects and resources:
 2. All projects which are hosted in third-party organizations and are part of Ansible-related distributions. For example, Ansible collections which are part of the Ansible community package.
 3. Communication platforms and channels listed in the :ref:`Ansible communication guide<communication>` such as Ansible Forum, official Matrix channels, and GitHub discussions.
 
-The above projects and resources **MAY have their own AI policies** which MAY expand or be more restrictive, but not contradicting this policy.
+The above projects and resources **MAY have their own AI policies** which MAY expand or be more restrictive, but not contradict this policy.
 
 For the purposes of this document, "contribution submission" includes, but is not limited to, opening issues, pull requests with code or documentation changes, discussion, making comments, posts and alike.
 

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -33,7 +33,7 @@ This policy applies to the following projects and resources:
       ii. Assisted-by: Opus 4.6
       iii. Assisted-by: locally trained model
 
-Possible policy violations should be reported via ``ansible-community@redhat.com``.
+Policy violations should be reported via ``ansible-community@redhat.com``.
 
 The key words "MAY", "MUST", "MUST NOT", and "SHOULD" in this document are to be interpreted as described in :rfc:`2119`.
 

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -11,11 +11,9 @@ This policy applies to the following projects and resources:
 1. All public projects under Ansible organizations on code version control platforms such as GitHub. For example, the `ansible <https://github.com/ansible>`_, `ansible-community <https://github.com/ansible-community>`_, `ansible-collections <https://github.com/ansible-collections>`_ organizations.
 2. Public communication platforms and channels listed in the :ref:`Ansible communication guide<communication>` such as Ansible Forum, official Matrix channels, and GitHub discussions.
 
-..note:: The above projects and resources **MAY have their own AI policies** which MAY expand or be more restrictive than this policy.
+.. note:: The above projects and resources **MAY have their own AI policies** which MAY expand or be more restrictive than this policy.
 
-For the purposes of this document, "contribution submission" includes, but is not limited to, opening issues, creating pull requests with code or documentation changes, participating in discussions, making comments, creating posts in the forum, and other related activities.
-
-1. Contributors MUST be human and MAY use assistance of AI tools for contributing to the above projects and resources, provided that they take full responsibility for their contributions and follow the principles described in this policy.
+1. Contributors MUST be human and MAY use assistance of AI tools for contributing [1]_ to the above projects and resources, provided that they take full responsibility for their contributions and follow the principles described in this policy.
 
 2. All contributions assisted by AI tools MUST adhere to any specific project or platform standards, conventions and contributing guidelines, including code of conduct and license compliance. This document seeks to clarify tool-specific considerations but in no way replaces the governing documents and good contributing practices.
 
@@ -43,3 +41,5 @@ This AI policy was adapted from AI policies of other open source projects, inclu
 
 * The Fedora Project
 * The Linux Foundation
+
+.. [1] For the purposes of this document, "contribution submission" includes, but is not limited to, opening issues, creating pull requests with code or documentation changes, participating in discussions, making comments, creating posts in the forum, and other related activities.

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -4,7 +4,7 @@
 Ansible Community Policy for AI-Assisted Contributions
 ******************************************************
 
-This policy uses the term "AI" to apply to any assistive technology as well as autonomous and semi-autonomous tooling that is generally built using the machine learning approach. Examples of such AI include large language models (LLMs), text or image generators, and agentic systems that are available as a service or trained locally.
+This policy uses the term "AI" to apply to any assistive tools, as well as autonomous and semi-autonomous tooling, that is generally built using the machine learning approach. Examples of such AI tools include large language models (LLMs), text or image generators, and agentic systems that are available as a service or trained locally.
 
 This policy applies to the following projects and resources:
 

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -33,13 +33,16 @@ This policy applies to the following projects and resources:
       ii. Assisted-by: Opus 4.6
       iii. Assisted-by: locally trained model
 
-Policy violations should be reported via ``ansible-community@redhat.com``.
-
 The key words "MAY", "MUST", "MUST NOT", and "SHOULD" in this document are to be interpreted as described in :rfc:`2119`.
 
 This AI policy was adapted from AI policies of other open source projects, including:
 
 * The Fedora Project
 * The Linux Foundation
+
+Reporting policy violations
+===========================
+
+Policy violations should be reported via ``ansible-community@redhat.com``.
 
 .. [1] For the purposes of this document, contributions include, but are not limited to, opening issues, creating pull requests with code or documentation changes, participating in discussions, making comments, creating posts in the forum, and other related activities.

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -4,6 +4,8 @@
 Ansible Community Policy for AI-Assisted Contributions
 ******************************************************
 
+While this policy uses the "AI" marketing term, it applies to any assisting, autonomous and semi-autotomous tooling that is generally built using the machine learning approach used to interact with the Ansible ecosystem projects, such as LLMs, text/image generators and agentic systems available as a public service or trained locally by the contributors.
+
 This policy applies to the following projects and resources:
 
 1. All public projects under Ansible organizations on code version control platforms such as GitHub. For example, the `ansible <https://github.com/ansible>`_, `ansible-community <https://github.com/ansible-community>`_, `ansible-collections <https://github.com/ansible-collections>`_ organizations.

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -1,0 +1,47 @@
+.. _ai_policy:
+
+******************************************************
+Ansible Community Policy for AI-Assisted Contributions
+******************************************************
+
+This policy applies to the following projects and resources:
+
+1. All projects under Ansible organizations on code version control platforms such as GitHub. For example, the `ansible <https://github.com/ansible>`_, `ansible-community <https://github.com/ansible-community>`_, `ansible-collections <https://github.com/ansible-collections>`_ organizations.
+2. All projects which are hosted in third-party organizations and are part of Ansible-related distributions. For example, Ansible collections which are part of the Ansible community package.
+3. Communication platforms and channels listed in the :ref:`Ansible communication guide<communication>` such as Ansible Forum, official Matrix channels, and GitHub discussions.
+
+The above projects and resources **MAY have their own AI policies** which MAY expand or be more restrictive, but not contradicting this policy.
+
+For the purposes of this document, "contribution submission" includes, but is not limited to, opening issues, pull requests with code or documentation changes, discussion, making comments, posts and alike.
+
+1. Contributors MUST be real humans and MAY use assistance of AI tools for contributing to the above projects and resources, as long as they take full responsibility for their contributions and follow the principles described in this policy.
+2. Contributors are always authors and are fully accountable for the contributions they make with or without AI assistance.
+
+   a. A contributor, including a person who authorized an action initiated by an AI tool, MUST take responsibility for their contributions assisted by AI and AI-initiated actions.
+3. Contributions MUST NOT be submitted by AI agents.
+
+   a. All autonomous contributions submitted by AI tools MAY be rejected by resource maintainers as violating this policy.
+   b. An exception to this rule is AI tools usage by the resource maintainers for validation and automation purposes, for example, automatic releasing, testing, spam filtering, AI contribution detection. Such actions MUST be reviewed and manually authorized by resource maintainers.
+4. The use of AI tools MUST be explicitly disclosed by the author when a significant part of the contribution is taken from the AI tools output without significant changes. Grammar, spelling, and stylistic corrections do not require disclosure.
+
+   a. For code contributions, the contributor MUST use a commit message trailer.
+   b. For other contributions, disclosure MUST include a preamble.
+   c. The commit message trailers and preamble SHOULD use the following statement as a disclosure: ``Assisted-by:`` followed by the model name, its version, and tool name (optional), for example:
+
+      i. Assisted-by: gpt-5.4
+      ii. Assisted-by: Opus 4.6
+      iii. Assisted-by: Claude Code (Opus 4.6)
+      iv. Assisted-by: Cursor (Opus 4.6)
+
+5. All contributions assisted by AI tools MUST meet a specific project’s or platform’s standards including code of conduct and license compliance.
+6. AI MUST NOT be used as the sole arbiter to make final judgments and decisions on people or their contributions, for example, Code of Conduct matters, project board elections, package content acceptance.
+7. This policy does not apply to major AI-driven changes to a specific project’s direction, workflows, codebase, or high-volume automated contributions. Such changes require separate discussion and approval by the leadership of the affected project.
+
+Possible policy violations should be reported via ``ansible-community@redhat.com``.
+
+The key words "MAY", "MUST", "MUST NOT", and "SHOULD" in this document are to be interpreted as described in `RFC 2119 <https://datatracker.ietf.org/doc/html/rfc2119>`_.
+
+This AI policy was adapted from AI policies of other open source projects, including:
+
+* The Fedora Project
+* The Linux Foundation

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -17,7 +17,7 @@ For the purposes of this document, "contribution submission" includes, but is no
 
 1. Contributors MUST be human and MAY use assistance of AI tools for contributing to the above projects and resources, provided that they take full responsibility for their contributions and follow the principles described in this policy.
 
-2. All contributions assisted by AI tools MUST meet a specific project’s or platform’s standards, conventions and contributing guidelines, including code of conduct and license compliance. This document seeks to clarify tool-specific considerations but in no way replaces the governing documents and good contributing practices.
+2. All contributions assisted by AI tools MUST adhere to any specific project or platform standards, conventions and contributing guidelines, including code of conduct and license compliance. This document seeks to clarify tool-specific considerations but in no way replaces the governing documents and good contributing practices.
 
 3. Contributors are fully accountable for the contributions they make with or without AI assistance. This also applies to persons who authorize actions initiated by AI tools.
 

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -29,8 +29,8 @@ For the purposes of this document, "contribution submission" includes, but is no
 
 5. The use of AI tools MUST be explicitly disclosed by the author when a significant part of the contribution is taken from the AI tools output without significant changes. Grammar, spelling, and stylistic corrections do not require disclosure.
 
-   a. For code contributions, the contributor MUST use a commit message trailer.
-   b. For other contributions, disclosure MUST include a preamble.
+   a. For code contributions, the contributor MUST use a short commit message trailer (see the recommended format in p. "c").
+   b. For other contributions, disclosure MUST include a short preamble (see the recommended format in p. "c").
    c. The commit message trailers and preamble SHOULD use the following statement as a disclosure: ``Assisted-by:`` followed by the model name, its version, and tool name (optional), for example:
 
       i. Assisted-by: gpt-5.4

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -4,7 +4,7 @@
 Ansible Community Policy for AI-Assisted Contributions
 ******************************************************
 
-This policy uses the term "AI tool" to refer to any assistive tools, as well as autonomous and semi-autonomous tools, that are generally built using the machine learning approach; examples include large language models (LLMs), text or image generators, and agentic systems that are available as a service or trained locally.
+This policy uses the term "AI" as a widely understood shorthand. In practice, "AI" refers to any assistive tools, as well as autonomous and semi-autonomous tools, that are generally built using the machine learning approach; examples include large language models (LLMs), text or image generators, and agentic systems that are available as a service or trained locally.
 
 This policy applies to the following projects and resources:
 

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -13,7 +13,7 @@ This policy applies to the following projects and resources:
 
 ..note:: The above projects and resources **MAY have their own AI policies** which MAY expand or be more restrictive than this policy.
 
-For the purposes of this document, "contribution submission" includes, but is not limited to, opening issues, pull requests with code or documentation changes, discussion, making comments, posts and alike.
+For the purposes of this document, "contribution submission" includes, but is not limited to, opening issues, creating pull requests with code or documentation changes, participating in discussions, making comments, creating posts in the forum, and other related activities.
 
 1. Contributors MUST be human and MAY use assistance of AI tools for contributing to the above projects and resources, provided that they take full responsibility for their contributions and follow the principles described in this policy.
 

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -15,16 +15,17 @@ The above projects and resources **MAY have their own AI policies** which MAY ex
 For the purposes of this document, "contribution submission" includes, but is not limited to, opening issues, pull requests with code or documentation changes, discussion, making comments, posts and alike.
 
 1. Contributors MUST be real humans and MAY use assistance of AI tools for contributing to the above projects and resources, as long as they take full responsibility for their contributions and follow the principles described in this policy.
-2. Contributors are always authors and are fully accountable for the contributions they make with or without AI assistance.
+2. All contributions assisted by AI tools MUST meet a specific project’s or platform’s standards, conventions and contributing guidelines, including code of conduct and license compliance.
+3. Contributors are always authors and are fully accountable for the contributions they make with or without AI assistance.
 
    a. A contributor, including a person who authorized an action initiated by an AI tool, MUST take responsibility for their contributions assisted by AI and AI-initiated actions.
 
-3. Contributions MUST NOT be submitted by AI agents.
+4. Contributions MUST NOT be submitted by AI agents.
 
    a. All autonomous contributions submitted by AI tools MAY be rejected by resource maintainers as violating this policy.
    b. An exception to this rule is AI tools usage by the resource maintainers for validation and automation purposes, for example, automatic releasing, testing, spam filtering, AI contribution detection. Such actions MUST be reviewed and manually authorized by resource maintainers.
 
-4. The use of AI tools MUST be explicitly disclosed by the author when a significant part of the contribution is taken from the AI tools output without significant changes. Grammar, spelling, and stylistic corrections do not require disclosure.
+5. The use of AI tools MUST be explicitly disclosed by the author when a significant part of the contribution is taken from the AI tools output without significant changes. Grammar, spelling, and stylistic corrections do not require disclosure.
 
    a. For code contributions, the contributor MUST use a commit message trailer.
    b. For other contributions, disclosure MUST include a preamble.
@@ -35,7 +36,6 @@ For the purposes of this document, "contribution submission" includes, but is no
       iii. Assisted-by: Claude Code (Opus 4.6)
       iv. Assisted-by: Cursor (Opus 4.6)
 
-5. All contributions assisted by AI tools MUST meet a specific project’s or platform’s standards, conventions and contributing guidelines, including code of conduct and license compliance.
 6. AI MUST NOT be used as the sole arbiter to make final judgments and decisions on people or their contributions, for example, Code of Conduct matters, project board elections, package content acceptance.
 7. This policy does not apply to major AI-driven changes to a specific project’s direction, workflows, codebase, or high-volume automated contributions. Such changes require separate discussion and approval by the leadership of the affected project. Unsolicited mass submissions of AI-generated contributions may be rejected without consideration of their content, and the accounts responsible may be banned.
 

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -37,7 +37,7 @@ For the purposes of this document, "contribution submission" includes, but is no
 
 5. All contributions assisted by AI tools MUST meet a specific project’s or platform’s standards including code of conduct and license compliance.
 6. AI MUST NOT be used as the sole arbiter to make final judgments and decisions on people or their contributions, for example, Code of Conduct matters, project board elections, package content acceptance.
-7. This policy does not apply to major AI-driven changes to a specific project’s direction, workflows, codebase, or high-volume automated contributions. Such changes require separate discussion and approval by the leadership of the affected project.
+7. This policy does not apply to major AI-driven changes to a specific project’s direction, workflows, codebase, or high-volume automated contributions. Such changes require separate discussion and approval by the leadership of the affected project. Unsolicited mass submissions of AI-generated contributions may be rejected without consideration of their content, and the accounts responsible may be banned.
 
 Possible policy violations should be reported via ``ansible-community@redhat.com``.
 

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -39,7 +39,7 @@ For the purposes of this document, "contribution submission" includes, but is no
 
 Possible policy violations should be reported via ``ansible-community@redhat.com``.
 
-The key words "MAY", "MUST", "MUST NOT", and "SHOULD" in this document are to be interpreted as described in `RFC 2119 <https://datatracker.ietf.org/doc/html/rfc2119>`_.
+The key words "MAY", "MUST", "MUST NOT", and "SHOULD" in this document are to be interpreted as described in :rfc:`2119`.
 
 This AI policy was adapted from AI policies of other open source projects, including:
 

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -19,7 +19,7 @@ For the purposes of this document, "contribution submission" includes, but is no
 
 2. All contributions assisted by AI tools MUST meet a specific project’s or platform’s standards, conventions and contributing guidelines, including code of conduct and license compliance. This document seeks to clarify tool-specific considerations but in no way replaces the governing documents and good contributing practices.
 
-3. Contributors are fully accountable for the contributions they make with or without AI assistance. This also applies to persons who authorized an action initiated by AI tools.
+3. Contributors are fully accountable for the contributions they make with or without AI assistance. This also applies to persons who authorize actions initiated by AI tools.
 
 4. All autonomous contributions submitted by AI tools MAY be rejected by resource maintainers without any justification.
 

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -29,7 +29,7 @@ For the purposes of this document, "contribution submission" includes, but is no
 
    a. For code contributions, the contributor MAY use a short commit message trailer.
    b. For other contributions, disclosure MAY include a short preamble.
-   c. We recommend using the following statement as a disclosure: Assisted-by: followed by any information about the contributor’s use of AI tools that they consider useful to disclose, for example:
+   c. We recommend using the following statement as a disclosure: Assisted-by: followed by any information about the contributor’s use of AI tools that they consider relevant, for example:
 
       i. Assisted-by: gpt-5.4
       ii. Assisted-by: Opus 4.6

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -11,7 +11,7 @@ This policy applies to the following projects and resources:
 1. All public projects under Ansible organizations on code version control platforms such as GitHub. For example, the `ansible <https://github.com/ansible>`_, `ansible-community <https://github.com/ansible-community>`_, `ansible-collections <https://github.com/ansible-collections>`_ organizations.
 2. Public communication platforms and channels listed in the :ref:`Ansible communication guide<communication>` such as Ansible Forum, official Matrix channels, and GitHub discussions.
 
-The above projects and resources **MAY have their own AI policies** which MAY expand or be more restrictive than this policy.
+..note:: The above projects and resources **MAY have their own AI policies** which MAY expand or be more restrictive than this policy.
 
 For the purposes of this document, "contribution submission" includes, but is not limited to, opening issues, pull requests with code or documentation changes, discussion, making comments, posts and alike.
 

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -18,10 +18,12 @@ For the purposes of this document, "contribution submission" includes, but is no
 2. Contributors are always authors and are fully accountable for the contributions they make with or without AI assistance.
 
    a. A contributor, including a person who authorized an action initiated by an AI tool, MUST take responsibility for their contributions assisted by AI and AI-initiated actions.
-3. Contributions MUST NOT be submitted by AI agents.
+
+   3. Contributions MUST NOT be submitted by AI agents.
 
    a. All autonomous contributions submitted by AI tools MAY be rejected by resource maintainers as violating this policy.
    b. An exception to this rule is AI tools usage by the resource maintainers for validation and automation purposes, for example, automatic releasing, testing, spam filtering, AI contribution detection. Such actions MUST be reviewed and manually authorized by resource maintainers.
+
 4. The use of AI tools MUST be explicitly disclosed by the author when a significant part of the contribution is taken from the AI tools output without significant changes. Grammar, spelling, and stylistic corrections do not require disclosure.
 
    a. For code contributions, the contributor MUST use a commit message trailer.

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -4,7 +4,7 @@
 Ansible Community Policy for AI-Assisted Contributions
 ******************************************************
 
-While this policy uses the "AI" marketing term, it applies to any assisting, autonomous and semi-autotomous tooling that is generally built using the machine learning approach used to interact with the Ansible ecosystem projects, such as LLMs, text/image generators and agentic systems available as a public service or trained locally by the contributors.
+This policy uses the term "AI" to apply to any assistive technology as well as autonomous and semi-autonomous tooling that is generally built using the machine learning approach. Examples of such AI include large language models (LLMs), text or image generators, and agentic systems that are available as a service or trained locally.
 
 This policy applies to the following projects and resources:
 

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -6,7 +6,7 @@ Ansible Community Policy for AI-Assisted Contributions
 
 This policy applies to the following projects and resources:
 
-1. All projects under Ansible organizations on code version control platforms such as GitHub. For example, the `ansible <https://github.com/ansible>`_, `ansible-community <https://github.com/ansible-community>`_, `ansible-collections <https://github.com/ansible-collections>`_ organizations.
+1. All public projects under Ansible organizations on code version control platforms such as GitHub. For example, the `ansible <https://github.com/ansible>`_, `ansible-community <https://github.com/ansible-community>`_, `ansible-collections <https://github.com/ansible-collections>`_ organizations.
 2. All projects which are hosted in third-party organizations and are part of Ansible-related distributions. For example, Ansible collections which are part of the Ansible community package.
 3. Communication platforms and channels listed in the :ref:`Ansible communication guide<communication>` such as Ansible Forum, official Matrix channels, and GitHub discussions.
 

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -19,7 +19,7 @@ For the purposes of this document, "contribution submission" includes, but is no
 
    a. A contributor, including a person who authorized an action initiated by an AI tool, MUST take responsibility for their contributions assisted by AI and AI-initiated actions.
 
-   3. Contributions MUST NOT be submitted by AI agents.
+3. Contributions MUST NOT be submitted by AI agents.
 
    a. All autonomous contributions submitted by AI tools MAY be rejected by resource maintainers as violating this policy.
    b. An exception to this rule is AI tools usage by the resource maintainers for validation and automation purposes, for example, automatic releasing, testing, spam filtering, AI contribution detection. Such actions MUST be reviewed and manually authorized by resource maintainers.

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -4,7 +4,7 @@
 Ansible Community Policy for AI-Assisted Contributions
 ******************************************************
 
-This policy uses the term "AI" as a widely understood shorthand. In practice, "AI" refers to any assistive tools, as well as autonomous and semi-autonomous tools, that are generally built using the machine learning approach; examples include large language models (LLMs), text or image generators, and agentic systems that are available as a service or trained locally.
+This policy uses the term "AI" as shorthand for technology that is generally built using the machine learning approach. In this sense the term "AI" can refer to any assistive tools, including those considered as autonomous and semi-autonomous, such as large language models (LLMs), text or image generators, and agentic systems that are available as a service or trained locally.
 
 This policy applies to the following projects and resources:
 

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -9,10 +9,9 @@ This policy uses the term "AI" to apply to any assistive technology as well as a
 This policy applies to the following projects and resources:
 
 1. All public projects under Ansible organizations on code version control platforms such as GitHub. For example, the `ansible <https://github.com/ansible>`_, `ansible-community <https://github.com/ansible-community>`_, `ansible-collections <https://github.com/ansible-collections>`_ organizations.
-2. All projects which are hosted in third-party organizations and are part of Ansible-related distributions. For example, Ansible collections which are part of the Ansible community package.
-3. Communication platforms and channels listed in the :ref:`Ansible communication guide<communication>` such as Ansible Forum, official Matrix channels, and GitHub discussions.
+2. Public communication platforms and channels listed in the :ref:`Ansible communication guide<communication>` such as Ansible Forum, official Matrix channels, and GitHub discussions.
 
-The above projects and resources **MAY have their own AI policies** which MAY expand or be more restrictive, but not contradict this policy.
+The above projects and resources **MAY have their own AI policies** which MAY expand or be more restrictive than this policy.
 
 For the purposes of this document, "contribution submission" includes, but is not limited to, opening issues, pull requests with code or documentation changes, discussion, making comments, posts and alike.
 
@@ -20,28 +19,21 @@ For the purposes of this document, "contribution submission" includes, but is no
 
 2. All contributions assisted by AI tools MUST meet a specific project’s or platform’s standards, conventions and contributing guidelines, including code of conduct and license compliance. This document seeks to clarify tool-specific considerations but in no way replaces the governing documents and good contributing practices.
 
-3. Contributors are always authors and are fully accountable for the contributions they make with or without AI assistance.
+3. Contributors are fully accountable for the contributions they make with or without AI assistance. This also applies to persons who authorized an action initiated by AI tools.
 
-   a. A contributor, including a person who authorized an action initiated by an AI tool, MUST take responsibility for their contributions assisted by AI and AI-initiated actions.
+4. All autonomous contributions submitted by AI tools MAY be rejected by resource maintainers without any justification.
 
-4. Contributions MUST NOT be submitted by AI agents.
+   a. Autonomous actions performed by AI tools used by resource maintainers for validation and automation purposes (for example, automatic releasing, testing, spam filtering, and AI contribution detection) SHOULD be reviewed and manually authorized by the maintainers.
 
-   a. All autonomous contributions submitted by AI tools MAY be rejected by resource maintainers as violating this policy.
-   b. An exception to this rule is AI tools usage by the resource maintainers for validation and automation purposes, for example, automatic releasing, testing, spam filtering, AI contribution detection. Such actions MUST be reviewed and manually authorized by resource maintainers.
+5. The use of AI tools SHOULD be explicitly disclosed by the author when a significant part of the contribution is taken from the AI tools output without significant changes. Grammar, spelling, and stylistic corrections do not need disclosure.
 
-5. The use of AI tools MUST be explicitly disclosed by the author when a significant part of the contribution is taken from the AI tools output without significant changes. Grammar, spelling, and stylistic corrections do not require disclosure.
-
-   a. For code contributions, the contributor MUST use a short commit message trailer (see the recommended format in p. "c").
-   b. For other contributions, disclosure MUST include a short preamble (see the recommended format in p. "c").
-   c. The commit message trailers and preamble SHOULD use the following statement as a disclosure: ``Assisted-by:`` followed by the model name, its version, and tool name (optional), for example:
+   a. For code contributions, the contributor MAY use a short commit message trailer.
+   b. For other contributions, disclosure MAY include a short preamble.
+   c. We recommend using the following statement as a disclosure: Assisted-by: followed by any information about the contributor’s use of AI tools that they consider useful to disclose, for example:
 
       i. Assisted-by: gpt-5.4
       ii. Assisted-by: Opus 4.6
-      iii. Assisted-by: Claude Code (Opus 4.6)
-      iv. Assisted-by: Cursor (Opus 4.6)
-
-6. AI MUST NOT be used as the sole arbiter to make final judgments and decisions on people or their contributions, for example, Code of Conduct matters, project board elections, package content acceptance.
-7. This policy does not apply to major AI-driven changes to a specific project’s direction, workflows, codebase, or high-volume automated contributions. Such changes require separate discussion and approval by the leadership of the affected project. Unsolicited mass submissions of AI-generated contributions may be rejected without consideration of their content, and the accounts responsible may be banned.
+      iii. Assisted-by: locally trained model
 
 Possible policy violations should be reported via ``ansible-community@redhat.com``.
 

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -4,7 +4,7 @@
 Ansible Community Policy for AI-Assisted Contributions
 ******************************************************
 
-This policy uses the term "AI" to apply to any assistive tools, as well as autonomous and semi-autonomous tooling, that is generally built using the machine learning approach. Examples of such tools include large language models (LLMs), text or image generators, and agentic systems that are available as a service or trained locally.
+This policy uses the term "AI tool" to refer to any assistive tools, as well as autonomous and semi-autonomous tools, that are generally built using the machine learning approach; examples include large language models (LLMs), text or image generators, and agentic systems that are available as a service or trained locally.
 
 This policy applies to the following projects and resources:
 

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -15,7 +15,9 @@ The above projects and resources **MAY have their own AI policies** which MAY ex
 For the purposes of this document, "contribution submission" includes, but is not limited to, opening issues, pull requests with code or documentation changes, discussion, making comments, posts and alike.
 
 1. Contributors MUST be real humans and MAY use assistance of AI tools for contributing to the above projects and resources, as long as they take full responsibility for their contributions and follow the principles described in this policy.
-2. All contributions assisted by AI tools MUST meet a specific project’s or platform’s standards, conventions and contributing guidelines, including code of conduct and license compliance.
+
+2. All contributions assisted by AI tools MUST meet a specific project’s or platform’s standards, conventions and contributing guidelines, including code of conduct and license compliance. This document seeks to clarify tool-specific considerations but in no way replaces the governing documents and good contributing practices.
+
 3. Contributors are always authors and are fully accountable for the contributions they make with or without AI assistance.
 
    a. A contributor, including a person who authorized an action initiated by an AI tool, MUST take responsibility for their contributions assisted by AI and AI-initiated actions.

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -13,7 +13,7 @@ This policy applies to the following projects and resources:
 
 .. note:: The above projects and resources **MAY have their own AI policies** which MAY expand or be more restrictive than this policy.
 
-1. Contributors MUST be human and MAY use assistance of AI tools for contributing [1]_ to the above projects and resources, provided that they take full responsibility for their contributions and follow the principles described in this policy.
+1. Contributors MAY use assistance of AI tools for contributing [1]_ to the above projects and resources, provided that they take full responsibility for their contributions and follow the principles described in this policy.
 
 2. All contributions assisted by AI tools MUST adhere to any specific project or platform standards, conventions and contributing guidelines, including code of conduct and license compliance. This document seeks to clarify tool-specific considerations but in no way replaces the governing documents and good contributing practices.
 

--- a/docs/docsite/rst/community/ai_policy.rst
+++ b/docs/docsite/rst/community/ai_policy.rst
@@ -21,7 +21,7 @@ For the purposes of this document, "contribution submission" includes, but is no
 
 3. Contributors are fully accountable for the contributions they make with or without AI assistance. This also applies to persons who authorize actions initiated by AI tools.
 
-4. All autonomous contributions submitted by AI tools MAY be rejected by resource maintainers without any justification.
+4. Any autonomous contributions submitted by AI tools MAY be rejected by resource maintainers without prior justification.
 
    a. Autonomous actions performed by AI tools used by resource maintainers for validation and automation purposes (for example, automatic releasing, testing, spam filtering, and AI contribution detection) SHOULD be reviewed and manually authorized by the maintainers.
 

--- a/docs/docsite/rst/community/index.rst
+++ b/docs/docsite/rst/community/index.rst
@@ -26,5 +26,6 @@ The purpose of this guide is to teach you everything you need to know about bein
 .. toctree::
    :maxdepth: 2
 
+   ai_policy
    getting_started
    contributor_path

--- a/docs/docsite/rst/community/index.rst
+++ b/docs/docsite/rst/community/index.rst
@@ -27,5 +27,5 @@ The purpose of this guide is to teach you everything you need to know about bein
    :maxdepth: 2
 
    getting_started
-   ai_policy
    contributor_path
+   ai_policy

--- a/docs/docsite/rst/community/index.rst
+++ b/docs/docsite/rst/community/index.rst
@@ -26,6 +26,6 @@ The purpose of this guide is to teach you everything you need to know about bein
 .. toctree::
    :maxdepth: 2
 
-   ai_policy
    getting_started
+   ai_policy
    contributor_path


### PR DESCRIPTION
Add Ansible AI Policy.

Must be approved by the community and Red Hat legal before merging.

See the [forum post](https://forum.ansible.com/t/ansible-community-ai-policy-proposal/45655) for more context