### PR TITLE
Document expected --start-at-task behavior

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_startnstep.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_startnstep.rst
@@ -17,7 +17,7 @@ To start executing your playbook at a particular task (usually the task that fai
 
     ansible-playbook playbook.yml --start-at-task="install packages"
 
-In this example, Ansible starts executing your playbook at a task named "install packages". If the play containing the task has play-level fact gathering or argument validation, the implicit play-level tasks execute first.
+In this example, Ansible executes your playbook starting at a task named "install packages". If the play containing the task has play-level fact gathering or argument validation, the implicit play-level tasks execute first.
 
 .. warning::
 

--- a/docs/docsite/rst/playbook_guide/playbooks_startnstep.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_startnstep.rst
@@ -17,7 +17,11 @@ To start executing your playbook at a particular task (usually the task that fai
 
     ansible-playbook playbook.yml --start-at-task="install packages"
 
-In this example, Ansible starts executing your playbook at a task named "install packages". This feature does not work with tasks inside dynamically reused roles or tasks (``include_*``), see :ref:`dynamic_vs_static`.
+In this example, Ansible starts executing your playbook at a task named "install packages". If the play containing the task has play-level fact gathering or argument validation, the implicit play-level tasks execute first.
+
+.. warning::
+
+   This feature does not work with tasks inside dynamically reused roles or tasks (``include_*``), see :ref:`dynamic_vs_static` or use ref:`step` to skip tasks and ref:`playbook_debugger` to redo tasks.
 
 .. _step:
 


### PR DESCRIPTION
While getting reviews for https://github.com/ansible/ansible/pull/86345, it was pointed out that the documentation does not mention that play-level tasks corresponding to the gather_facts and validate_argspec play keywords run before the task identified with `--start-at-task`, so this adds that.

I've also changed the mention about the lack of support for dynamic includes into a warning with suggested alternatives.