### PR TITLE
skip readthedocs builds for automatic backports

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,3 +21,10 @@ build:
       -C docs/docsite
       BUILDDIR="${READTHEDOCS_OUTPUT}"
       PYTHON="${READTHEDOCS_VIRTUALENV_PATH}"/bin/python
+  jobs:
+    post_checkout:
+      # Skip builds for backport branches.
+      - |
+        if echo "$READTHEDOCS_GIT_IDENTIFIER" | grep -qE "^(patchback/backports)/"; then
+          exit 183;
+        fi

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,6 +11,11 @@ build:
       3.12
   # Build with make coredocs
   commands:
+      # Skip builds for backport branches.
+    - |
+      if echo "$READTHEDOCS_GIT_IDENTIFIER" | grep -qE "^(patchback/backports)/"; then
+        exit 183;
+      fi
     - python -m venv "${READTHEDOCS_VIRTUALENV_PATH}"
     - >-
       "${READTHEDOCS_VIRTUALENV_PATH}"/bin/python -m pip install --exists-action=w -r tests/requirements.in -c tests/requirements.txt
@@ -23,8 +28,3 @@ build:
       PYTHON="${READTHEDOCS_VIRTUALENV_PATH}"/bin/python
   jobs:
     post_checkout:
-      # Skip builds for backport branches.
-      - |
-        if echo "$READTHEDOCS_GIT_IDENTIFIER" | grep -qE "^(patchback/backports)/"; then
-          exit 183;
-        fi

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,6 +11,7 @@ build:
       3.12
   # Build with make coredocs
   commands:
+    - env  # env debug
       # Skip builds for backport branches.
     - |
       if  [ "${READTHEDOCS_VERSION_TYPE}" != "external" ] && echo "${READTHEDOCS_GIT_IDENTIFIER}" | grep -qE "^(patchback/backports|pip-compile)/"; then

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -26,5 +26,3 @@ build:
       -C docs/docsite
       BUILDDIR="${READTHEDOCS_OUTPUT}"
       PYTHON="${READTHEDOCS_VIRTUALENV_PATH}"/bin/python
-  jobs:
-    post_checkout:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
   commands:
       # Skip builds for backport branches.
     - |
-      if echo "$READTHEDOCS_GIT_IDENTIFIER" | grep -qE "^(patchback/backports)/"; then
+      if  [ "${READTHEDOCS_VERSION_TYPE}" != "external" ] && echo "${READTHEDOCS_GIT_IDENTIFIER}" | grep -qE "^(patchback/backports|pip-compile)/"; then
         exit 183;
       fi
     - python -m venv "${READTHEDOCS_VIRTUALENV_PATH}"


### PR DESCRIPTION
Do not build RTD preview builds for patchback backport PRs to conserve resources and stop running over allowed build limits

What do folks think? We could skip the pip-compile dep updates builds too, I suppose. Although having PR preview builds on those PRs gives us another net to catch breaks. They're also scheduled at a time that doesn't really impact the limit on concurrent builds.