### PR TITLE
Workflows: app-id is apparently deprecated, use client-id instead

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -49,7 +49,7 @@ jobs:
         id: create_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_KEY }}
       - name: Checkout parent repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release-porting-guide.yml
+++ b/.github/workflows/release-porting-guide.yml
@@ -35,7 +35,7 @@ jobs:
         id: create_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.BOT_APP_ID }} # From github-bot environment
+          client-id: ${{ secrets.BOT_APP_ID }} # From github-bot environment
           private-key: ${{ secrets.BOT_APP_KEY }} # From github-bot environment
 
       - name: Check out this repo src

--- a/.github/workflows/reusable-pip-compile.yml
+++ b/.github/workflows/reusable-pip-compile.yml
@@ -90,7 +90,7 @@ jobs:
         id: create_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_KEY }}
       # We could rely on the checkout action to persist the token in the
       # repository config, but this way, we can prevent the previous steps

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -25,7 +25,7 @@ jobs:
         id: create_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_KEY }}
       - name: Check out us
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/noxfile.py
+++ b/noxfile.py
@@ -137,6 +137,9 @@ def actionlint(session: nox.Session) -> None:
         "--workdir", "/pwd",
         # fmt: on
         ACTIONLINT_IMAGE,
+        # https://github.com/rhysd/actionlint/issues/648#issuecomment-4289144208
+        "-ignore=app-id.*create-github-app-token",
+        "-ignore=client-id.*create-github-app-token",
         *session.posargs,
         external=True,
     )


### PR DESCRIPTION
See the warnings in https://github.com/ansible/ansible-documentation/actions/runs/24737520753 for example.

Ref: https://github.com/actions/create-github-app-token/releases/tag/v3.1.0