### PR TITLE
code_of_conduct: add reference to AI policy, add the license section

### DIFF
--- a/docs/docsite/rst/community/code_of_conduct.rst
+++ b/docs/docsite/rst/community/code_of_conduct.rst
@@ -133,6 +133,9 @@ offline.
 We expect all participants, organizers, speakers, and attendees to follow these policies at
 all of our event venues and event-related social events.
 
+License
+=======
+
 The Ansible Community Code of Conduct is licensed under the Creative Commons
 Attribution-Share Alike 3.0 license. Our Code of Conduct was adapted from Codes of Conduct
 of other open source projects, including:
@@ -143,3 +146,8 @@ of other open source projects, including:
 * OpenStack
 * Puppet Labs
 * Ubuntu
+
+Related policies
+================
+
+* :ref:`ai_policy` - Ansible Community Policy for AI-Assisted Contributions

--- a/docs/docsite/rst/community/code_of_conduct.rst
+++ b/docs/docsite/rst/community/code_of_conduct.rst
@@ -148,6 +148,6 @@ of other open source projects, including:
 * Ubuntu
 
 Policy for AI-Assisted Contributions
-=============================
+====================================
 
 * :ref:`ai_policy`

--- a/docs/docsite/rst/community/code_of_conduct.rst
+++ b/docs/docsite/rst/community/code_of_conduct.rst
@@ -150,4 +150,4 @@ of other open source projects, including:
 Policy for AI-Assisted Contributions
 ================
 
-* :ref:`ai_policy` - Ansible Community Policy for AI-Assisted Contributions
+* :ref:`ai_policy`

--- a/docs/docsite/rst/community/code_of_conduct.rst
+++ b/docs/docsite/rst/community/code_of_conduct.rst
@@ -147,7 +147,7 @@ of other open source projects, including:
 * Puppet Labs
 * Ubuntu
 
-Related policies
+Policy for AI-Assisted Contributions
 ================
 
 * :ref:`ai_policy` - Ansible Community Policy for AI-Assisted Contributions

--- a/docs/docsite/rst/community/code_of_conduct.rst
+++ b/docs/docsite/rst/community/code_of_conduct.rst
@@ -148,6 +148,6 @@ of other open source projects, including:
 * Ubuntu
 
 Policy for AI-Assisted Contributions
-================
+=============================
 
 * :ref:`ai_policy`


### PR DESCRIPTION
Update code_of_conduct:
- add reference to AI policy in a dedicated section
- separate license-related content to the License section (I could remove it if it's something extra for this PR, let me know)