### PR TITLE
Add note to roadmap index pointing to devel branch for upcoming releases

### DIFF
--- a/docs/docsite/rst/roadmap/ansible_core_roadmap_index.rst
+++ b/docs/docsite/rst/roadmap/ansible_core_roadmap_index.rst
@@ -15,7 +15,7 @@ You can submit feedback on the current roadmap by creating a topic on the :ref:`
 
 .. note::
 
-   This roadmap index is for the current stable release.
+   To find the roadmap for upcoming releases, refer to the `devel` version of the Ansible documentation.
    For the latest upcoming release roadmap, see the `devel branch roadmap <https://docs.ansible.com/projects/ansible/devel/roadmap/>`_.
 
 .. toctree::

--- a/docs/docsite/rst/roadmap/ansible_core_roadmap_index.rst
+++ b/docs/docsite/rst/roadmap/ansible_core_roadmap_index.rst
@@ -16,7 +16,7 @@ You can submit feedback on the current roadmap by creating a topic on the :ref:`
 .. note::
 
    This roadmap index is for the current stable release.
-   For the latest upcoming release roadmap, see the `devel branch roadmap <https://docs.ansible.com/ansible/devel/roadmap/>`_.
+   For the latest upcoming release roadmap, see the `devel branch roadmap <https://docs.ansible.com/projects/ansible/devel/roadmap/>`_.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/docsite/rst/roadmap/ansible_core_roadmap_index.rst
+++ b/docs/docsite/rst/roadmap/ansible_core_roadmap_index.rst
@@ -16,7 +16,6 @@ You can submit feedback on the current roadmap by creating a topic on the :ref:`
 .. note::
 
    To find the roadmap for upcoming releases, refer to the `devel` version of the Ansible documentation.
-   For the latest upcoming release roadmap, see the `devel branch roadmap <https://docs.ansible.com/projects/ansible/devel/roadmap/>`_.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/docsite/rst/roadmap/ansible_core_roadmap_index.rst
+++ b/docs/docsite/rst/roadmap/ansible_core_roadmap_index.rst
@@ -13,6 +13,11 @@ Each roadmap is published both as an idea of what is upcoming in ``ansible-core`
 
 You can submit feedback on the current roadmap by creating a topic on the :ref:`Ansible Forum<ansible_forum>` tagged with ``ansible-core``.
 
+.. note::
+
+   This roadmap index is for the current stable release.
+   For the latest upcoming release roadmap, see the `devel branch roadmap <https://docs.ansible.com/ansible/devel/roadmap/>`_.
+
 .. toctree::
    :maxdepth: 1
    :glob:
@@ -30,3 +35,4 @@ You can submit feedback on the current roadmap by creating a topic on the :ref:`
    ROADMAP_2_12
    ROADMAP_2_11
    ROADMAP_2_10
+

--- a/docs/docsite/rst/roadmap/ansible_roadmap_index.rst
+++ b/docs/docsite/rst/roadmap/ansible_roadmap_index.rst
@@ -18,7 +18,7 @@ Visit the :ref:`Ansible communication guide<communication>` for details on how t
 .. note::
 
    This roadmap index is for the current stable release.
-   For the latest upcoming release roadmap, see the `devel branch roadmap <https://docs.ansible.com/ansible/devel/roadmap/>`_.
+   For the latest upcoming release roadmap, see the `devel branch roadmap <https://docs.ansible.com/projects/ansible/devel/roadmap/>`_.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/docsite/rst/roadmap/ansible_roadmap_index.rst
+++ b/docs/docsite/rst/roadmap/ansible_roadmap_index.rst
@@ -17,7 +17,7 @@ Visit the :ref:`Ansible communication guide<communication>` for details on how t
 
 .. note::
 
-   This roadmap index is for the current stable release.
+   To find the roadmap for upcoming releases, refer to the `devel` version of the Ansible documentation.
    For the latest upcoming release roadmap, see the `devel branch roadmap <https://docs.ansible.com/projects/ansible/devel/roadmap/>`_.
 
 .. toctree::

--- a/docs/docsite/rst/roadmap/ansible_roadmap_index.rst
+++ b/docs/docsite/rst/roadmap/ansible_roadmap_index.rst
@@ -15,6 +15,11 @@ You can submit feedback on the current roadmap by creating a :ref:`community top
 
 Visit the :ref:`Ansible communication guide<communication>` for details on how to join and use Ansible communication platforms.
 
+.. note::
+
+   This roadmap index is for the current stable release.
+   For the latest upcoming release roadmap, see the `devel branch roadmap <https://docs.ansible.com/ansible/devel/roadmap/>`_.
+
 .. toctree::
    :maxdepth: 1
    :glob:
@@ -34,3 +39,4 @@ Visit the :ref:`Ansible communication guide<communication>` for details on how t
    COLLECTIONS_3_0
    COLLECTIONS_2_10
    old_roadmap_index
+

--- a/docs/docsite/rst/roadmap/ansible_roadmap_index.rst
+++ b/docs/docsite/rst/roadmap/ansible_roadmap_index.rst
@@ -18,7 +18,6 @@ Visit the :ref:`Ansible communication guide<communication>` for details on how t
 .. note::
 
    To find the roadmap for upcoming releases, refer to the `devel` version of the Ansible documentation.
-   For the latest upcoming release roadmap, see the `devel branch roadmap <https://docs.ansible.com/projects/ansible/devel/roadmap/>`_.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/docsite/rst/roadmap/index.rst
+++ b/docs/docsite/rst/roadmap/index.rst
@@ -6,7 +6,7 @@ Roadmaps
 .. note::
 
    This roadmap index is for the current stable release.
-   For the latest upcoming release roadmap, see the `devel branch roadmap <https://docs.ansible.com/ansible/devel/roadmap/>`_.
+   For the latest upcoming release roadmap, see the `devel branch roadmap <https://docs.ansible.com/projects/ansible/devel/roadmap/>`_.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/docsite/rst/roadmap/index.rst
+++ b/docs/docsite/rst/roadmap/index.rst
@@ -3,6 +3,11 @@
 Roadmaps
 ===============
 
+.. note::
+
+   This roadmap index is for the current stable release.
+   For the latest upcoming release roadmap, see the `devel branch roadmap <https://docs.ansible.com/ansible/devel/roadmap/>`_.
+
 .. toctree::
    :maxdepth: 1
    :glob:

--- a/docs/docsite/rst/roadmap/index.rst
+++ b/docs/docsite/rst/roadmap/index.rst
@@ -5,7 +5,7 @@ Roadmaps
 
 .. note::
 
-   This roadmap index is for the current stable release.
+   To find the roadmap for upcoming releases, refer to the `devel` version of the Ansible documentation.
    For the latest upcoming release roadmap, see the `devel branch roadmap <https://docs.ansible.com/projects/ansible/devel/roadmap/>`_.
 
 .. toctree::

--- a/docs/docsite/rst/roadmap/index.rst
+++ b/docs/docsite/rst/roadmap/index.rst
@@ -6,7 +6,6 @@ Roadmaps
 .. note::
 
    To find the roadmap for upcoming releases, refer to the `devel` version of the Ansible documentation.
-   For the latest upcoming release roadmap, see the `devel branch roadmap <https://docs.ansible.com/projects/ansible/devel/roadmap/>`_.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Fixes #1865

Add a note to the roadmap index page pointing users to the devel branch roadmap for information about upcoming releases. Users landing on stable branch docs may not be aware that upcoming release roadmaps are only available in devel.