### PR TITLE
Update variable source reference in ansible_tips_tricks

### DIFF
--- a/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
+++ b/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
@@ -192,7 +192,7 @@ You can use the same setup with ``include_vars`` when you only need OS-specific 
 .. literalinclude:: yaml/tip_include_vars.yaml
       :language: yaml
 
-This pulls in variables from the `group_vars/os_CentOS.yml` file.
+This pulls in variables from the `os_CentOS.yml` or `vars/os_CentOS.yml` file.
 
 .. seealso::
 


### PR DESCRIPTION
In the example code, the path does not specify group_vars, Ansible will only look for the file in the same level or inside ./vars.