### PR TITLE
[stable-2.21] Fix version in Sphinx config

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -50,9 +50,9 @@ assert applied_tags_count == 1, (
 
 VERSION = (
      # Controls branch version for core releases
-    'devel' if tags.has('core_lang') or tags.has('core') else
+    '2.21' if tags.has('core_lang') or tags.has('core') else
     # Controls branch version for Ansible package releases
-    'devel' if tags.has('ansible') or tags.has('all')
+    '14' if tags.has('ansible') or tags.has('all')
     else '<UNKNOWN>'
 )
 AUTHOR = 'Ansible, Inc'


### PR DESCRIPTION
The other stable-2.x branches have explicit version numbers here. Is this no longer necessary, or did this got forgotten?