### PR TITLE
docs: add Ansible Security Policy

### DIFF
--- a/docs/docsite/rst/community/index.rst
+++ b/docs/docsite/rst/community/index.rst
@@ -29,4 +29,5 @@ The purpose of this guide is to teach you everything you need to know about bein
    getting_started
    contributor_path
    ai_policy
+   security_policy
    vulnerability_management_policy

--- a/docs/docsite/rst/community/index.rst
+++ b/docs/docsite/rst/community/index.rst
@@ -29,3 +29,4 @@ The purpose of this guide is to teach you everything you need to know about bein
    getting_started
    contributor_path
    ai_policy
+   security_policy

--- a/docs/docsite/rst/community/security_policy.rst
+++ b/docs/docsite/rst/community/security_policy.rst
@@ -189,6 +189,78 @@ We thank security researchers who help improve Ansible. Contributors are acknowl
 - CONTRIBUTORS.md
 - Ansible forum badge
 
+The ``SECURITY.md`` File
+========================
+
+What is ``SECURITY.md``?
+------------------------
+
+``SECURITY.md`` is the place where users, developers, security researchers, and the community at large can find information on how to communicate and report a potential vulnerability about a particular repository and the overall Ansible project. The file serves as the first point of reference for security-related inquiries, ensuring that the community has a clear, standardized path for disclosure. By providing transparent contact methods and expectations, it upholds the security ethos and procedural standards defined in this Vulnerability Management Policy.
+
+Where to host ``SECURITY.md``
+------------------------------
+
+Host the ``SECURITY.md`` file in the root directory of the GitHub repository, alongside other essential project files like ``README.md`` and ``LICENSE``. This ensures high visibility and automatic integration with GitHub's security features.
+
+Contents of ``SECURITY.md``
+-----------------------------
+
+The file **must** contain the following:
+
+- Contact information
+- Timeline
+- Link to the Vulnerability Management Policy on ``docs.ansible.com``
+- What to include in the report
+
+``SECURITY.md`` Template
+-------------------------
+
+Use the following template for the ``SECURITY.md`` file in your repository:
+
+.. code-block:: markdown
+
+   # Reporting a Security Vulnerability or Incident
+
+   Please do not report security vulnerabilities or security incidents via public GitHub issues.
+   To ensure a coordinated disclosure, submit your findings via email to: `security@ansible.com`
+
+   ## Submission Guidelines
+
+   To help us triage and resolve the issue efficiently, please include the following in your report:
+
+   - **Title**: A concise, descriptive summary of the issue.
+   - **Reporter Details**: Your name/handle and affiliation (optional).
+   - **Technical Description**: Detailed information regarding the vulnerability.
+   - **Affected Versions**: The specific version(s) or range(s) of software tested.
+   - **Reproduction Steps**: A minimal, functional example to reproduce the issue.
+   - **Impact Assessment**: Potential exploit scenarios and perceived severity.
+   - **Suggested Fix**: Any proposed patches or mitigations (optional).
+   - **Disclosure Status**: Whether this has been shared with other parties or published and your plan for future sharing (e.g., at a conference).
+
+   ## Response Timeline
+
+   We aim to provide an initial acknowledgment of your report within one business day.
+
+   ## Resolution Timeline
+
+   Our goal is to assess the report, coordinate fix and disclosure as quickly as possible.
+   All confirmed security vulnerabilities and incidents will be addressed according to
+   severity level and impact on the Ansible Project.
+
+   ## Contact Information
+
+   Direct all security questions and vulnerability reports to:
+
+   - **Email**: security@ansible.com
+   - **Ansible Security Policy**: [https://www.ansible.com/security](https://www.ansible.com/security)
+
+   ## EU Cyber Resilience Act — Open-Source Steward Statement
+
+   This project is stewarded by Red Hat, Inc., an open source software steward as defined
+   in Article 3(14) of the EU Cyber Resilience Act (Regulation 2024/2847).
+
+   - **Contact**: cra-steward@redhat.com
+
 Policy Updates
 ==============
 

--- a/docs/docsite/rst/community/security_policy.rst
+++ b/docs/docsite/rst/community/security_policy.rst
@@ -22,7 +22,7 @@ This policy applies to all Ansible projects that Red Hat hosts.
 GitHub
 ------
 
-Code contained in the following GitHub Orgs:
+Code contained in the following GitHub organizations:
 
 * `ansible <https://github.com/ansible>`_
 * `ansible-collections <https://github.com/ansible-collections>`_
@@ -30,13 +30,13 @@ Code contained in the following GitHub Orgs:
 * `ansible-network <https://github.com/ansible-network>`_
 * `ansible-security <https://github.com/ansible-security>`_
 * `network-automation <https://github.com/network-automation>`_
-* Any other Ansible related GitHub Orgs, that are managed by Red Hat
+* Any other Ansible related GitHub organizations that are managed by Red Hat
 
 Release artifacts
 -----------------
 
-* Any Ansible collections from the above GitHub repos.
-* Any Ansible releases from the above GitHub repos.
+* Any Ansible collections from the preceding GitHub repositories.
+* Any Ansible releases from the preceding GitHub repositories.
 * `Ansible Community PyPI releases <https://pypi.org/org/ansible-community/>`_
 * Ansible Community Package.
 * Community execution environments.
@@ -52,13 +52,13 @@ Infrastructure
 .. note::
 
    Third-party collections or plugins hosted outside the listed organizations are out of scope but are encouraged to adopt compatible practices.
-   Red Hat works with maintainers of the repos under the above GitHub Orgs, that is, Red Hat helps triage and provide fixes for third-party collections in the ansible-collections GitHub Org.
+   Red Hat works with maintainers of the repositories under the preceding GitHub organizations. Specifically, Red Hat helps triage and provide fixes for third-party collections in the ``ansible-collections`` GitHub organization.
 
 Maintained versions
 ====================
 
 Generally, only the latest release of an upstream project receives updates, including security patches.
-Earlier versions may receive critical fixes on a best-effort basis, but back-porting to unsupported versions is not guaranteed.
+Earlier versions may receive critical fixes on a best-effort basis but back-porting to unsupported versions is not guaranteed.
 End-of-Life versions receive no backports unless extraordinary circumstances warrant an exception approved by the Security Team.
 
 Some projects, such as Ansible Core, may backport security fixes into multiple supported versions depending on severity.
@@ -67,7 +67,7 @@ See :ref:`development_and_stable_version_maintenance_workflow` for details.
 Reporting a vulnerability
 =========================
 
-How to report
+How to report vulnerabilities
 -------------
 
 All reports MUST be submitted by email to: `security@ansible.com <mailto:security@ansible.com>`_
@@ -80,16 +80,16 @@ Security vulnerabilities MUST NOT be reported through any public (or insecure) m
 * Ansible Matrix.
 * Public forums or social media.
 
-What to include
+What to include in vulnerability reports
 ---------------
 
-When submitting a report, provide the following details:
+When submitting a vulnerability report, provide the following details:
 
 * **Title** (required): Clear, descriptive summary.
 * **Reporter details** (optional): Your name/handle and affiliation.
 * **Impacted project** (required): Ideally link to the GitHub project.
 * **Vulnerability description** (required): Technical details of the issue.
-* **Affected versions** (required): Known affected version(s), and ideally all affected versions.
+* **Affected versions** (required): All known affected version(s).
 * **Reproduction steps** (required): Minimal example to reproduce the issue.
 * **Impact assessment** (required): Potential exploit scenarios and severity.
 * **Suggested fix** (optional): Proposed remediation, if any.
@@ -110,7 +110,7 @@ What NOT to report
 The following do not qualify as security vulnerabilities:
 
 * Automated scanner output without analysis or reproduction steps.
-* General support or usage questions, use the `Ansible Community Forum <https://forum.ansible.com>`__.
+* General support or usage questions. Use the `Ansible Community Forum <https://forum.ansible.com>`_ instead.
 * Requests for help updating to newer versions.
 * Bugs without security implications.
 
@@ -165,10 +165,10 @@ Use the `SECURITY.md template <https://github.com/ansible-community/project-temp
 Recognition
 ===========
 
-The Ansible project may thank security researchers who help improve Ansible, through recognition in:
+The Ansible project may thank security researchers who help improve Ansible through recognition in:
 
 * Security advisories.
-* `Ansible Community Forum <https://forum.ansible.com>`__.
+* `Ansible Community Forum <https://forum.ansible.com>`_.
 
 Policy updates
 ==============

--- a/docs/docsite/rst/community/security_policy.rst
+++ b/docs/docsite/rst/community/security_policy.rst
@@ -29,7 +29,7 @@ Code contained in the following GitHub Orgs:
 * `ansible-collections <https://github.com/ansible-collections>`_
 * Any other Ansible related GitHub Orgs
 
-Release artefacts
+Release artifacts
 -----------------
 
 * Any Ansible collections from the above GitHub repos.
@@ -66,7 +66,7 @@ How to report
 
 All reports MUST be submitted by email to: `security@ansible.com <mailto:security@ansible.com>`_
 
-Security vulnerabilities MUST NOT be reported through any public (or unsecure) method, including, but not limited to:
+Security vulnerabilities MUST NOT be reported through any public (or insecure) method, including, but not limited to:
 
 * Public GitHub issues.
 * Pull requests.
@@ -104,7 +104,7 @@ What NOT to report
 The following do not qualify as security vulnerabilities:
 
 * Automated scanner output without analysis or reproduction steps.
-* General support or usage questions, use the `Ansible Community Forum <https://forum.ansible.com>`_.
+* General support or usage questions, use the `Ansible Community Forum <https://forum.ansible.com>`__.
 * Requests for help updating to newer versions.
 * Bugs without security implications.
 
@@ -162,7 +162,7 @@ Recognition
 The Ansible project may thank security researchers who help improve Ansible, through recognition in:
 
 * Security advisories.
-* `Ansible Community Forum <https://forum.ansible.com>`_.
+* `Ansible Community Forum <https://forum.ansible.com>`__.
 
 Policy updates
 ==============

--- a/docs/docsite/rst/community/security_policy.rst
+++ b/docs/docsite/rst/community/security_policy.rst
@@ -54,6 +54,7 @@ Supported versions
 
 Generally, only the latest release of an upstream project receives updates, including security patches.
 Earlier versions may receive critical fixes on a best-effort basis, but back-porting to unsupported versions is not guaranteed.
+End-of-life versions receive no backports unless extraordinary circumstances warrant an exception approved by the Security Team.
 
 Some projects, such as Ansible Core, may backport security fixes into multiple supported versions depending on severity.
 See :ref:`development_and_stable_version_maintenance_workflow` for details.

--- a/docs/docsite/rst/community/security_policy.rst
+++ b/docs/docsite/rst/community/security_policy.rst
@@ -10,7 +10,6 @@ Ansible security policy
 Commitment
 ==========
 
-Red Hat takes security seriously.
 Red Hat is committed to maintaining the highest level of security and trust for all users.
 Red Hat appreciates the Ansible community and security researchers' efforts in helping identify and address vulnerabilities responsibly.
 
@@ -57,9 +56,9 @@ Infrastructure
 Maintained versions
 ====================
 
-Generally, only the latest release of an upstream project receives updates, including security patches.
+Generally, only the latest release of a community project receives updates, including security patches.
 Earlier versions may receive critical fixes on a best-effort basis but back-porting to unsupported versions is not guaranteed.
-End-of-Life versions receive no backports unless extraordinary circumstances warrant an exception approved by the Security Team.
+End-of-Life versions receive no backports unless extraordinary circumstances warrant an exception approved by the Ansible Security Team.
 
 Some projects, such as Ansible Core, may backport security fixes into multiple supported versions depending on severity.
 See :ref:`development_and_stable_version_maintenance_workflow` for details.
@@ -72,7 +71,7 @@ How to report vulnerabilities
 
 All reports MUST be submitted by email to: `security@ansible.com <mailto:security@ansible.com>`_
 
-Security vulnerabilities MUST NOT be reported through any public (or insecure) method, including, but not limited to:
+Security vulnerabilities and security incidents MUST NOT be reported through any public method, including, but not limited to:
 
 * Public GitHub issues.
 * Pull requests.
@@ -131,12 +130,12 @@ The Ansible Security Team follows this process:
 Severity classification
 ========================
 
-The Ansible project follows the `Red Hat severity ratings <https://access.redhat.com/security/updates/classification>`_.
+The Ansible Security Team follows the `Red Hat severity ratings <https://access.redhat.com/security/updates/classification>`_.
 
 Disclosure policy
 =================
 
-* The Ansible project follows coordinated disclosure practices.
+* The Ansible Security Team follows coordinated disclosure practices.
 * Fixes are typically included in the next planned release.
 * Critical vulnerabilities may warrant out-of-band releases.
 * Public disclosure occurs through GitHub Security Advisories.
@@ -150,7 +149,7 @@ Security advisories
 Security advisories are published through:
 
 * `Ansible Community Forum <https://forum.ansible.com/tag/security>`_.
-* Official Ansible security page (docs.ansible.com/security).
+* Official Ansible security page (`ansible.com/security <https://ansible.com/security>`__).
 * CVE databases (NVD, OSV).
 
 The ``SECURITY.md`` file
@@ -165,7 +164,7 @@ Use the `SECURITY.md template <https://github.com/ansible-community/project-temp
 Recognition
 ===========
 
-The Ansible project may thank security researchers who help improve Ansible through recognition in:
+The Ansible Security Team may thank security researchers who help improve projects in the Ansible ecosystem through recognition in:
 
 * Security advisories.
 * `Ansible Community Forum <https://forum.ansible.com>`_.

--- a/docs/docsite/rst/community/security_policy.rst
+++ b/docs/docsite/rst/community/security_policy.rst
@@ -9,12 +9,15 @@ Ansible Security Policy
 Our Commitment
 ==============
 
-Ansible takes security seriously. We are committed to maintaining the highest level of security and trust for our users. We appreciate the security research community's efforts in helping us identify and address vulnerabilities responsibly.
+Ansible takes security seriously.
+We are committed to maintaining the highest level of security and trust for our users.
+We appreciate the security research community's efforts in helping us identify and address vulnerabilities responsibly.
 
 Supported Versions
 ==================
 
-Only the latest release receives regular security patches. Earlier versions may receive critical fixes on a best-effort basis, but we cannot guarantee back-porting to unsupported versions.
+Only the latest release receives regular security patches.
+Earlier versions may receive critical fixes on a best-effort basis, but we cannot guarantee back-porting to unsupported versions.
 
 Security Model
 ==============
@@ -22,7 +25,8 @@ Security Model
 Security assumptions and threat model
 --------------------------------------
 
-Ansible is designed to [describe intended use]. Users should be aware:
+Ansible is designed to [describe intended use].
+Users should be aware:
 
 - **Untrusted inputs**: [Describe which inputs are safe/unsafe]
 - **Trust boundaries**: [Define what the project does/does not protect against]
@@ -183,7 +187,8 @@ Out of Scope
 Recognition
 ===========
 
-We thank security researchers who help improve Ansible. Contributors are acknowledged in:
+We thank security researchers who help improve Ansible.
+Contributors are acknowledged in:
 
 - Security advisories
 - CONTRIBUTORS.md
@@ -195,12 +200,15 @@ The ``SECURITY.md`` File
 What is ``SECURITY.md``?
 ------------------------
 
-``SECURITY.md`` is the place where users, developers, security researchers, and the community at large can find information on how to communicate and report a potential vulnerability about a particular repository and the overall Ansible project. The file serves as the first point of reference for security-related inquiries, ensuring that the community has a clear, standardized path for disclosure. By providing transparent contact methods and expectations, it upholds the security ethos and procedural standards defined in this Vulnerability Management Policy.
+``SECURITY.md`` is the place where users, developers, security researchers, and the community at large can find information on how to communicate and report a potential vulnerability about a particular repository and the overall Ansible project.
+The file serves as the first point of reference for security-related inquiries, ensuring that the community has a clear, standardized path for disclosure.
+By providing transparent contact methods and expectations, it upholds the security ethos and procedural standards defined in this Vulnerability Management Policy.
 
 Where to host ``SECURITY.md``
 ------------------------------
 
-Host the ``SECURITY.md`` file in the root directory of the GitHub repository, alongside other essential project files like ``README.md`` and ``LICENSE``. This ensures high visibility and automatic integration with GitHub's security features.
+Host the ``SECURITY.md`` file in the root directory of the GitHub repository, alongside other essential project files like ``README.md`` and ``LICENSE``.
+This ensures high visibility and automatic integration with GitHub's security features.
 
 Contents of ``SECURITY.md``
 -----------------------------
@@ -220,4 +228,5 @@ Use the `SECURITY.md template <https://github.com/ansible-community/project-temp
 Policy Updates
 ==============
 
-This policy may be updated periodically. Suggestions for improvement can be submitted via issues or pull requests.
+This policy may be updated periodically.
+Suggestions for improvement can be submitted via issues or pull requests.

--- a/docs/docsite/rst/community/security_policy.rst
+++ b/docs/docsite/rst/community/security_policy.rst
@@ -94,25 +94,6 @@ The following do not qualify as security vulnerabilities:
 Response Process
 ================
 
-Timeline
---------
-
-.. list-table::
-   :header-rows: 1
-   :widths: auto
-
-   * - Stage
-     - Timeframe
-   * - Acknowledgment
-     - Within 1 business days
-   * - Initial assessment
-     - Within 60 business days(max)
-   * - Resolution target
-     - Within 90 business days(max)
-
-Our Process
------------
-
 1. **Acknowledgment** -- We confirm receipt of your report
 2. **Triage** -- We assess validity and severity
 3. **Investigation** -- We reproduce and analyze the issue

--- a/docs/docsite/rst/community/security_policy.rst
+++ b/docs/docsite/rst/community/security_policy.rst
@@ -16,7 +16,7 @@ We appreciate the security research community's efforts in helping us identify a
 Supported Versions
 ==================
 
-Only the latest release receives regular security patches.
+Only the latest release of the Ansible community package, Ansible community execution environments, and Ansible content receives regular security patches.
 Earlier versions may receive critical fixes on a best-effort basis, but we cannot guarantee back-porting to unsupported versions.
 
 Security Model

--- a/docs/docsite/rst/community/security_policy.rst
+++ b/docs/docsite/rst/community/security_policy.rst
@@ -67,7 +67,7 @@ Reporting a vulnerability
 =========================
 
 How to report vulnerabilities
--------------
+-----------------------------
 
 All reports MUST be submitted by email to: `security@ansible.com <mailto:security@ansible.com>`_
 

--- a/docs/docsite/rst/community/security_policy.rst
+++ b/docs/docsite/rst/community/security_policy.rst
@@ -1,213 +1,176 @@
 .. _security_policy:
 
 ***********************
-Ansible Security Policy
+Ansible security policy
 ***********************
 
-.. contents:: Topics
+.. contents::
+   :local:
 
-Our Commitment
-==============
+Commitment
+==========
 
-Ansible takes security seriously.
-We are committed to maintaining the highest level of security and trust for our users.
-We appreciate the security research community's efforts in helping us identify and address vulnerabilities responsibly.
-
-Supported Versions
-==================
-
-Only the latest release of the Ansible community package, Ansible community execution environments, and Ansible content receives regular security patches.
-Earlier versions may receive critical fixes on a best-effort basis, but we cannot guarantee back-porting to unsupported versions.
-
-Security Model
-==============
-
-Security assumptions and threat model
---------------------------------------
-
-Ansible is designed to [describe intended use].
-Users should be aware:
-
-- **Untrusted inputs**: [Describe which inputs are safe/unsafe]
-- **Trust boundaries**: [Define what the project does/does not protect against]
-- **Safe data formats**: [List formats with strong security track records]
-- **Unsafe operations**: [List operations requiring sandboxing or caution]
-
-Reporting a Vulnerability
-=========================
-
-How to Report
--------------
-
-Please report security vulnerabilities privately through one of these channels:
-
-**Email**
-
-- Send to: `security@ansible.com <mailto:security@ansible.com>`_
-
-Do **NOT** report security vulnerabilities through:
-
-- Public GitHub issues
-- Pull requests
-- Ansible Forum
-- Ansible Matrix
-- Public forums or social media
-
-What to Include
----------------
-
-Please provide the following information:
-
-- **Title**: Clear, descriptive summary
-- **Reporter details**: Your name/handle and affiliation (optional)
-- **Vulnerability description**: Technical details of the issue
-- **Affected versions**:
-
-  - Mandatory: known, affected version
-  - Good to have: identification of all affected versions
-
-- **Reproduction steps**: Minimal example to reproduce the issue
-- **Impact assessment**: Potential exploit scenarios and severity
-- **Suggested fix**: If you have recommendations (optional)
-- **Disclosure status**: Whether this has been shared elsewhere
-
-What to Report
---------------
-
-Please report if you have:
-
-- Discovered a potential security vulnerability
-- Found an issue but are uncertain about its security impact
-- Identified vulnerabilities in dependencies not yet addressed
-
-What NOT to Report
-------------------
-
-The following do not qualify as security vulnerabilities:
-
-- Automated scanner output without analysis or reproduction steps
-- General support or usage questions
-- Requests for help updating to newer versions
-- Bugs without security implications
-- Issues outside our documented threat model
-
-Response Process
-================
-
-1. **Acknowledgment** -- We confirm receipt of your report
-2. **Triage** -- We assess validity and severity
-3. **Investigation** -- We reproduce and analyze the issue
-4. **Fix Development** -- We develop and test a patch
-5. **Coordinated Disclosure** -- We coordinate release timing with you
-6. **Public Disclosure** -- We publish advisory and credits
-
-Severity Classification
-========================
-
-.. list-table::
-   :header-rows: 1
-   :widths: auto
-
-   * - Level
-     - Description
-   * - Critical
-     - Immediate threat, easy exploitation
-   * - High
-     - Significant impact
-   * - Medium
-     - Moderate impact, harder to exploit
-   * - Low
-     - Limited impact
-
-Disclosure Policy
-=================
-
-- We follow coordinated disclosure practices
-- Fixes are typically included in the next planned release
-- Critical vulnerabilities may warrant out-of-band releases
-- Public disclosure occurs via GitHub Security Advisories
-- Reporters are credited unless they prefer anonymity
-
-Security Advisories
-===================
-
-Published advisories are available at: [link]
-
-- GitHub Security Advisories: [link]
-- Ansible Security Page: [link]
-
-Safe Usage Guidelines
-=====================
-
-To use Ansible securely:
-
-1. **Keep updated**: Always use supported versions
-2. **Validate inputs**: [Specific input validation guidance]
-3. **Sandbox untrusted data**: [When sandboxing is needed]
-4. **Follow best practices**: [Link to security documentation]
+Red Hat takes security seriously.
+Red Hat is committed to maintaining the highest level of security and trust for all users.
+Red Hat appreciates the Ansible community and security researchers' efforts in helping identify and address vulnerabilities responsibly.
 
 Scope
 =====
 
-In Scope
---------
+This policy applies to all Ansible projects that Red Hat hosts.
 
-- Core Ansible codebase
-- Official packages and distributions
-- Documentation that could lead to insecure usage
+GitHub
+------
 
-Out of Scope
-------------
+Code contained in the following GitHub Orgs:
 
-- Third-party plugins or extensions
-- User-implemented code
-- Issues requiring physical access
-- Social engineering attacks
-- Denial of service through resource exhaustion
+* `ansible <https://github.com/ansible>`_
+* `ansible-community <https://github.com/ansible-community>`_
+* `ansible-collections <https://github.com/ansible-collections>`_
+* Any other Ansible related GitHub Orgs
+
+Release artefacts
+-----------------
+
+* Any Ansible collections from the above GitHub repos.
+* Any Ansible releases (such as PyPI) from the above GitHub repos.
+* Ansible Community Package.
+* Community execution environments.
+
+Infrastructure
+--------------
+
+* ansible.com
+* docs.ansible.com
+* forum.ansible.com
+
+.. note::
+
+   Third-party collections or plugins hosted outside the listed organizations are out of scope but are encouraged to adopt compatible practices.
+   Red Hat works with maintainers of the repos under the above GitHub Orgs, that is, Red Hat helps triage and provide fixes for third-party collections in the ansible-collections GitHub Org.
+
+Supported versions
+==================
+
+Generally, only the latest release of an upstream project receives updates, including security patches.
+Earlier versions may receive critical fixes on a best-effort basis, but back-porting to unsupported versions is not guaranteed.
+
+Some projects, such as Ansible Core, may backport security fixes into multiple supported versions depending on severity.
+See :ref:`development_and_stable_version_maintenance_workflow` for details.
+
+Reporting a vulnerability
+=========================
+
+How to report
+-------------
+
+All reports MUST be submitted by email to: `security@ansible.com <mailto:security@ansible.com>`_
+
+Security vulnerabilities MUST NOT be reported through any public (or unsecure) method, including, but not limited to:
+
+* Public GitHub issues.
+* Pull requests.
+* Ansible Forum.
+* Ansible Matrix.
+* Public forums or social media.
+
+What to include
+---------------
+
+When submitting a report, provide the following details:
+
+* **Title** (required): Clear, descriptive summary.
+* **Reporter details** (optional): Your name/handle and affiliation.
+* **Impacted project** (required): Ideally link to the GitHub project.
+* **Vulnerability description** (required): Technical details of the issue.
+* **Affected versions** (required): Known affected version(s), and ideally all affected versions.
+* **Reproduction steps** (required): Minimal example to reproduce the issue.
+* **Impact assessment** (required): Potential exploit scenarios and severity.
+* **Suggested fix** (optional): Proposed remediation, if any.
+* **Disclosure status** (required): Whether this has been shared elsewhere.
+
+What to report
+--------------
+
+Report if you have:
+
+* Discovered a potential security vulnerability.
+* Found an issue but are uncertain about its security impact.
+* Identified vulnerabilities in dependencies not yet addressed.
+
+What NOT to report
+------------------
+
+The following do not qualify as security vulnerabilities:
+
+* Automated scanner output without analysis or reproduction steps.
+* General support or usage questions, use the `Ansible Community Forum <https://forum.ansible.com>`_.
+* Requests for help updating to newer versions.
+* Bugs without security implications.
+
+Bugs that have no security impact should be filed through the public issues tracker of the respective GitHub project.
+
+Response process
+================
+
+The Ansible Security Team follows this process:
+
+1. **Acknowledgment:** Confirms receipt of the report within one (1) business day.
+2. **Triage:** Assesses validity and severity.
+3. **Investigation:** Reproduces and analyzes the issue.
+4. **Fix development:** Develops and tests a patch.
+5. **Coordinated disclosure:** Coordinates release timing with the reporter.
+6. **Public disclosure:** Publishes advisory and credits.
+
+Severity classification
+========================
+
+The Ansible project follows the `Red Hat severity ratings <https://access.redhat.com/security/updates/classification>`_.
+
+Disclosure policy
+=================
+
+* The Ansible project follows coordinated disclosure practices.
+* Fixes are typically included in the next planned release.
+* Critical vulnerabilities may warrant out-of-band releases.
+* Public disclosure occurs through GitHub Security Advisories.
+* Reporters are credited unless they prefer anonymity.
+
+For detailed information on disclosure types, embargo periods, and researcher coordination, see the :ref:`vulnerability_management_policy`.
+
+Security advisories
+===================
+
+Security advisories are published through:
+
+* `Ansible Community Forum <https://forum.ansible.com/tag/security>`_.
+* Official Ansible security page (docs.ansible.com/security).
+* CVE databases (NVD, OSV).
+
+The ``SECURITY.md`` file
+========================
+
+``SECURITY.md`` is the standard location where users, developers, and security researchers can find information on how to report a potential vulnerability for a particular repository.
+Projects SHOULD host a ``SECURITY.md`` file in the root directory of their GitHub repository, alongside ``README.md`` and ``LICENSE``.
+This ensures high visibility and automatic integration with GitHub's security features.
+
+Use the `SECURITY.md template <https://github.com/ansible-community/project-template/blob/main/SECURITY.md>`__ from the `ansible-community/project-template <https://github.com/ansible-community/project-template>`__ repository as a starting point for your project.
 
 Recognition
 ===========
 
-We thank security researchers who help improve Ansible.
-Contributors are acknowledged in:
+The Ansible project may thank security researchers who help improve Ansible, through recognition in:
 
-- Security advisories
-- CONTRIBUTORS.md
-- Ansible forum badge
+* Security advisories.
+* `Ansible Community Forum <https://forum.ansible.com>`_.
 
-The ``SECURITY.md`` File
-========================
-
-What is ``SECURITY.md``?
-------------------------
-
-``SECURITY.md`` is the place where users, developers, security researchers, and the community at large can find information on how to communicate and report a potential vulnerability about a particular repository and the overall Ansible project.
-The file serves as the first point of reference for security-related inquiries, ensuring that the community has a clear, standardized path for disclosure.
-By providing transparent contact methods and expectations, it upholds the security ethos and procedural standards defined in this Vulnerability Management Policy.
-
-Where to host ``SECURITY.md``
-------------------------------
-
-Host the ``SECURITY.md`` file in the root directory of the GitHub repository, alongside other essential project files like ``README.md`` and ``LICENSE``.
-This ensures high visibility and automatic integration with GitHub's security features.
-
-Contents of ``SECURITY.md``
------------------------------
-
-The file **must** contain the following:
-
-- Contact information
-- Timeline
-- Link to the Vulnerability Management Policy on ``docs.ansible.com``
-- What to include in the report
-
-``SECURITY.md`` Template
--------------------------
-
-Use the `SECURITY.md template <https://github.com/ansible-community/project-template/blob/main/SECURITY.md>`__ from the `ansible-community/project-template <https://github.com/ansible-community/project-template>`__ repository as a starting point for your project.
-
-Policy Updates
+Policy updates
 ==============
 
 This policy may be updated periodically.
-Suggestions for improvement can be submitted via issues or pull requests.
+Suggestions for improvement can be submitted through issues or pull requests to the `ansible-documentation <https://github.com/ansible/ansible-documentation>`_ repository.
+
+Notes
+=====
+
+The key words "MUST", "MUST NOT", and "SHOULD" in this document are to be interpreted as described in :rfc:`2119`.

--- a/docs/docsite/rst/community/security_policy.rst
+++ b/docs/docsite/rst/community/security_policy.rst
@@ -1,0 +1,195 @@
+.. _security_policy:
+
+***********************
+Ansible Security Policy
+***********************
+
+.. contents:: Topics
+
+Our Commitment
+==============
+
+Ansible takes security seriously. We are committed to maintaining the highest level of security and trust for our users. We appreciate the security research community's efforts in helping us identify and address vulnerabilities responsibly.
+
+Supported Versions
+==================
+
+Only the latest release receives regular security patches. Earlier versions may receive critical fixes on a best-effort basis, but we cannot guarantee back-porting to unsupported versions.
+
+Security Model
+==============
+
+Security assumptions and threat model
+--------------------------------------
+
+Ansible is designed to [describe intended use]. Users should be aware:
+
+- **Untrusted inputs**: [Describe which inputs are safe/unsafe]
+- **Trust boundaries**: [Define what the project does/does not protect against]
+- **Safe data formats**: [List formats with strong security track records]
+- **Unsafe operations**: [List operations requiring sandboxing or caution]
+
+Reporting a Vulnerability
+=========================
+
+How to Report
+-------------
+
+Please report security vulnerabilities privately through one of these channels:
+
+**Email**
+
+- Send to: `security@ansible.com <mailto:security@ansible.com>`_
+
+Do **NOT** report security vulnerabilities through:
+
+- Public GitHub issues
+- Pull requests
+- Ansible Forum
+- Ansible Matrix
+- Public forums or social media
+
+What to Include
+---------------
+
+Please provide the following information:
+
+- **Title**: Clear, descriptive summary
+- **Reporter details**: Your name/handle and affiliation (optional)
+- **Vulnerability description**: Technical details of the issue
+- **Affected versions**:
+
+  - Mandatory: known, affected version
+  - Good to have: identification of all affected versions
+
+- **Reproduction steps**: Minimal example to reproduce the issue
+- **Impact assessment**: Potential exploit scenarios and severity
+- **Suggested fix**: If you have recommendations (optional)
+- **Disclosure status**: Whether this has been shared elsewhere
+
+What to Report
+--------------
+
+Please report if you have:
+
+- Discovered a potential security vulnerability
+- Found an issue but are uncertain about its security impact
+- Identified vulnerabilities in dependencies not yet addressed
+
+What NOT to Report
+------------------
+
+The following do not qualify as security vulnerabilities:
+
+- Automated scanner output without analysis or reproduction steps
+- General support or usage questions
+- Requests for help updating to newer versions
+- Bugs without security implications
+- Issues outside our documented threat model
+
+Response Process
+================
+
+Timeline
+--------
+
+.. list-table::
+   :header-rows: 1
+   :widths: auto
+
+   * - Stage
+     - Timeframe
+   * - Acknowledgment
+     - Within 1 business days
+   * - Initial assessment
+     - Within 60 business days(max)
+   * - Resolution target
+     - Within 90 business days(max)
+
+Our Process
+-----------
+
+1. **Acknowledgment** -- We confirm receipt of your report
+2. **Triage** -- We assess validity and severity
+3. **Investigation** -- We reproduce and analyze the issue
+4. **Fix Development** -- We develop and test a patch
+5. **Coordinated Disclosure** -- We coordinate release timing with you
+6. **Public Disclosure** -- We publish advisory and credits
+
+Severity Classification
+========================
+
+.. list-table::
+   :header-rows: 1
+   :widths: auto
+
+   * - Level
+     - Description
+   * - Critical
+     - Immediate threat, easy exploitation
+   * - High
+     - Significant impact
+   * - Medium
+     - Moderate impact, harder to exploit
+   * - Low
+     - Limited impact
+
+Disclosure Policy
+=================
+
+- We follow coordinated disclosure practices
+- Fixes are typically included in the next planned release
+- Critical vulnerabilities may warrant out-of-band releases
+- Public disclosure occurs via GitHub Security Advisories
+- Reporters are credited unless they prefer anonymity
+
+Security Advisories
+===================
+
+Published advisories are available at: [link]
+
+- GitHub Security Advisories: [link]
+- Ansible Security Page: [link]
+
+Safe Usage Guidelines
+=====================
+
+To use Ansible securely:
+
+1. **Keep updated**: Always use supported versions
+2. **Validate inputs**: [Specific input validation guidance]
+3. **Sandbox untrusted data**: [When sandboxing is needed]
+4. **Follow best practices**: [Link to security documentation]
+
+Scope
+=====
+
+In Scope
+--------
+
+- Core Ansible codebase
+- Official packages and distributions
+- Documentation that could lead to insecure usage
+
+Out of Scope
+------------
+
+- Third-party plugins or extensions
+- User-implemented code
+- Issues requiring physical access
+- Social engineering attacks
+- Denial of service through resource exhaustion
+
+Recognition
+===========
+
+We thank security researchers who help improve Ansible. Contributors are acknowledged in:
+
+- Security advisories
+- CONTRIBUTORS.md
+- Ansible forum badge
+
+Policy Updates
+==============
+
+This policy may be updated periodically. Suggestions for improvement can be submitted via issues or pull requests.

--- a/docs/docsite/rst/community/security_policy.rst
+++ b/docs/docsite/rst/community/security_policy.rst
@@ -59,7 +59,7 @@ Maintained versions
 
 Generally, only the latest release of an upstream project receives updates, including security patches.
 Earlier versions may receive critical fixes on a best-effort basis, but back-porting to unsupported versions is not guaranteed.
-End-of-life versions receive no backports unless extraordinary circumstances warrant an exception approved by the Security Team.
+End-of-Life versions receive no backports unless extraordinary circumstances warrant an exception approved by the Security Team.
 
 Some projects, such as Ansible Core, may backport security fixes into multiple supported versions depending on severity.
 See :ref:`development_and_stable_version_maintenance_workflow` for details.

--- a/docs/docsite/rst/community/security_policy.rst
+++ b/docs/docsite/rst/community/security_policy.rst
@@ -215,51 +215,7 @@ The file **must** contain the following:
 ``SECURITY.md`` Template
 -------------------------
 
-Use the following template for the ``SECURITY.md`` file in your repository:
-
-.. code-block:: markdown
-
-   # Reporting a Security Vulnerability or Incident
-
-   Please do not report security vulnerabilities or security incidents via public GitHub issues.
-   To ensure a coordinated disclosure, submit your findings via email to: `security@ansible.com`
-
-   ## Submission Guidelines
-
-   To help us triage and resolve the issue efficiently, please include the following in your report:
-
-   - **Title**: A concise, descriptive summary of the issue.
-   - **Reporter Details**: Your name/handle and affiliation (optional).
-   - **Technical Description**: Detailed information regarding the vulnerability.
-   - **Affected Versions**: The specific version(s) or range(s) of software tested.
-   - **Reproduction Steps**: A minimal, functional example to reproduce the issue.
-   - **Impact Assessment**: Potential exploit scenarios and perceived severity.
-   - **Suggested Fix**: Any proposed patches or mitigations (optional).
-   - **Disclosure Status**: Whether this has been shared with other parties or published and your plan for future sharing (e.g., at a conference).
-
-   ## Response Timeline
-
-   We aim to provide an initial acknowledgment of your report within one business day.
-
-   ## Resolution Timeline
-
-   Our goal is to assess the report, coordinate fix and disclosure as quickly as possible.
-   All confirmed security vulnerabilities and incidents will be addressed according to
-   severity level and impact on the Ansible Project.
-
-   ## Contact Information
-
-   Direct all security questions and vulnerability reports to:
-
-   - **Email**: security@ansible.com
-   - **Ansible Security Policy**: [https://www.ansible.com/security](https://www.ansible.com/security)
-
-   ## EU Cyber Resilience Act — Open-Source Steward Statement
-
-   This project is stewarded by Red Hat, Inc., an open source software steward as defined
-   in Article 3(14) of the EU Cyber Resilience Act (Regulation 2024/2847).
-
-   - **Contact**: cra-steward@redhat.com
+Use the `SECURITY.md template <https://github.com/ansible-community/project-template/blob/main/SECURITY.md>`__ from the `ansible-community/project-template <https://github.com/ansible-community/project-template>`__ repository as a starting point for your project.
 
 Policy Updates
 ==============

--- a/docs/docsite/rst/community/security_policy.rst
+++ b/docs/docsite/rst/community/security_policy.rst
@@ -80,7 +80,7 @@ Security vulnerabilities and security incidents MUST NOT be reported through any
 * Public forums or social media.
 
 What to include in vulnerability reports
----------------
+----------------------------------------
 
 When submitting a vulnerability report, provide the following details:
 

--- a/docs/docsite/rst/community/security_policy.rst
+++ b/docs/docsite/rst/community/security_policy.rst
@@ -25,31 +25,36 @@ GitHub
 Code contained in the following GitHub Orgs:
 
 * `ansible <https://github.com/ansible>`_
-* `ansible-community <https://github.com/ansible-community>`_
 * `ansible-collections <https://github.com/ansible-collections>`_
-* Any other Ansible related GitHub Orgs
+* `ansible-community <https://github.com/ansible-community>`_
+* `ansible-network <https://github.com/ansible-network>`_
+* `ansible-security <https://github.com/ansible-security>`_
+* `network-automation <https://github.com/network-automation>`_
+* Any other Ansible related GitHub Orgs, that are managed by Red Hat
 
 Release artifacts
 -----------------
 
 * Any Ansible collections from the above GitHub repos.
-* Any Ansible releases (such as PyPI) from the above GitHub repos.
+* Any Ansible releases from the above GitHub repos.
+* `Ansible Community PyPI releases <https://pypi.org/org/ansible-community/>`_
 * Ansible Community Package.
 * Community execution environments.
 
 Infrastructure
 --------------
 
-* ansible.com
-* docs.ansible.com
-* forum.ansible.com
+* `ansible.com`
+* `docs.ansible.com`
+* `forum.ansible.com`
+* `*.ansible.com`
 
 .. note::
 
    Third-party collections or plugins hosted outside the listed organizations are out of scope but are encouraged to adopt compatible practices.
    Red Hat works with maintainers of the repos under the above GitHub Orgs, that is, Red Hat helps triage and provide fixes for third-party collections in the ansible-collections GitHub Org.
 
-Supported versions
+Maintained versions
 ==================
 
 Generally, only the latest release of an upstream project receives updates, including security patches.

--- a/docs/docsite/rst/community/security_policy.rst
+++ b/docs/docsite/rst/community/security_policy.rst
@@ -55,7 +55,7 @@ Infrastructure
    Red Hat works with maintainers of the repos under the above GitHub Orgs, that is, Red Hat helps triage and provide fixes for third-party collections in the ansible-collections GitHub Org.
 
 Maintained versions
-==================
+====================
 
 Generally, only the latest release of an upstream project receives updates, including security patches.
 Earlier versions may receive critical fixes on a best-effort basis, but back-porting to unsupported versions is not guaranteed.

--- a/docs/docsite/rst/community/vulnerability_management_policy.rst
+++ b/docs/docsite/rst/community/vulnerability_management_policy.rst
@@ -16,7 +16,7 @@ It ensures that confirmed vulnerabilities are addressed according to severity an
 Scope
 =====
 
-This policy applies to the same projects and resources covered by the `Ansible security policy <https://ansible.com/security>`_.
+This policy applies to the same projects and resources covered by the :ref:`security_policy`.
 In addition, this policy covers the processes and workflows for the Ansible Security Team's handling of vulnerability reports, triage, remediation, and disclosure.
 
 Third-party collections or plugins hosted outside the GitHub organizations listed in the security policy are out of scope but are encouraged to adopt compatible practices.
@@ -44,7 +44,7 @@ Roles and responsibilities
 Vulnerability reporting
 =======================
 
-For complete details on how to report a vulnerability, what to include in a report, and what qualifies as a reportable vulnerability, see the `Ansible security policy <https://ansible.com/security>`_.
+For complete details on how to report a vulnerability, what to include in a report, and what qualifies as a reportable vulnerability, see the :ref:`security_policy`.
 
 All reports MUST be submitted by email to: `security@ansible.com <mailto:security@ansible.com>`_
 
@@ -58,7 +58,7 @@ Triage process
 
 Upon receipt of a vulnerability report, the Ansible Security Team will:
 
-1. **Acknowledge** the report according to the response timeline in the `Ansible security policy <https://ansible.com/security>`_.
+1. **Acknowledge** the report according to the response timeline in the :ref:`security_policy`.
 2. **Validate** the report by reproducing the issue or confirming the technical basis.
 3. **Classify** severity using the framework below.
 4. **Assign** the issue to the appropriate project maintainers for resolution.
@@ -102,7 +102,7 @@ Release and distribution
 Backporting
 ------------
 
-Backports are made according to the `Ansible security policy <https://ansible.com/security>`_.
+Backports are made according to the :ref:`security_policy`.
 
 Coordinated vulnerability disclosure
 =====================================
@@ -136,7 +136,7 @@ Disclosure types
 Researcher coordination
 -----------------------
 
-* Reporter recognition is described in the `Ansible security policy <https://ansible.com/security>`_.
+* Reporter recognition is described in the :ref:`security_policy`.
 * The Ansible Security Team coordinates disclosure timing with the reporter.
 * Reporters are asked to **refrain from public disclosure** until the agreed-upon date.
 
@@ -191,7 +191,7 @@ Communication
 Advisory distribution
 ---------------------
 
-Security advisories are published through the channels listed in the `Ansible security policy <https://ansible.com/security>`_.
+Security advisories are published through the channels listed in the :ref:`security_policy`.
 
 Policy governance
 =================


### PR DESCRIPTION
Adds the initial Ansible Security Policy file.

Introduces a security policy documenting how the Ansible project
handles vulnerability reporting, response timelines, severity 
classification, and coordinated disclosure. Provide guidance on 
hosting and maintaining a SECURITY.md file in project repositories,
referencing the canonical template in ansible-community/project-template.

As discussed in the community forum, the CRA encourages treating security
as a default practice, not an afterthought. These guidelines help the 
Ansible community strengthen its security posture while Red Hat, as the 
open source software steward, shields contributors from regulatory liability.

This is part of the community effort to embed security into everyday 
development practices as encouraged by the EU Cyber Resilience Act (CRA):

- https://forum.ansible.com/t/eu-cyber-resilience-act-cra-and-what-it-means-for-ansible/45716
- https://forum.ansible.com/t/security-as-default-not-an-afterthought-the-cras-real-message/45795