### PR TITLE
 "parmiko " connection type deprecation

### DIFF
--- a/docs/docsite/rst/network/dev_guide/developing_plugins_network.rst
+++ b/docs/docsite/rst/network/dev_guide/developing_plugins_network.rst
@@ -152,6 +152,10 @@ Developing network_cli plugins
 ==============================
 
 The :ref:`network_cli <network_cli_connection>` connection type uses ``paramiko_ssh`` under the hood which creates a pseudo terminal to send commands and receive responses.
+
+.. note::
+
+   The Paramiko-based connection plugin is deprecated. Use the libssh connection plugin instead. For details on migrating from Paramiko to libssh, see `Migrating to ssh_type libssh for ansible.netcommon.network_cli across Ansible networking collections <https://forum.ansible.com/t/migrating-to-ssh-type-libssh-for-ansible-netcommon-network-cli-across-ansible-networking-collections/45780>`_.
 ``network_cli`` loads two platform specific plugins based on the value of ``ansible_network_os``:
 
 * Terminal plugin (for example ``plugins/terminal/ios.py``) - Controls the parameters related to terminal, such as setting terminal length and width, page disabling and privilege escalation. Also defines regex to identify the command prompt and error prompts.

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -661,6 +661,10 @@ file to specify the proxy host.
     ansible_paramiko_proxy_command='-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
+.. note::
+
+   The ``ansible_paramiko_proxy_command`` variable is deprecated because the Paramiko-based connection plugin is deprecated. Use ``ansible_libssh_proxy_command`` instead with the libssh connection plugin. For details on migrating from Paramiko to libssh, see `Migrating to ssh_type libssh for ansible.netcommon.network_cli across Ansible networking collections <https://forum.ansible.com/t/migrating-to-ssh-type-libssh-for-ansible-netcommon-network-cli-across-ansible-networking-collections/45780>`_.
+
 With the configuration above, simply build and run the playbook as normal with
 no additional changes necessary.  The network module will now connect to the
 network device by first connecting to the host specified in

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -663,7 +663,7 @@ file to specify the proxy host.
 
 .. note::
 
-   The ``ansible_paramiko_proxy_command`` variable is deprecated because the Paramiko-based connection plugin is deprecated. Use ``ansible_libssh_proxy_command`` instead with the libssh connection plugin. For details on migrating from Paramiko to libssh, see `Migrating to ssh_type libssh for ansible.netcommon.network_cli across Ansible networking collections <https://forum.ansible.com/t/migrating-to-ssh-type-libssh-for-ansible-netcommon-network-cli-across-ansible-networking-collections/45780>`_.
+   The ``ansible_paramiko_proxy_command`` variable is deprecated along with the Paramiko-based connection plugin. Use ``ansible_libssh_proxy_command`` instead with the libssh connection plugin. For details on migrating from Paramiko to libssh, see `Migrating to ssh_type libssh for ansible.netcommon.network_cli across Ansible networking collections <https://forum.ansible.com/t/migrating-to-ssh-type-libssh-for-ansible-netcommon-network-cli-across-ansible-networking-collections/45780>`_.
 
 With the configuration above, simply build and run the playbook as normal with
 no additional changes necessary.  The network module will now connect to the

--- a/docs/docsite/rst/network/user_guide/platform_eos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_eos.rst
@@ -64,7 +64,7 @@ Example CLI ``group_vars/eos.yml``
 
 .. note::
 
-   The ``ansible_paramiko_proxy_command`` variable is deprecated because the Paramiko-based connection plugin is deprecated. Use ``ansible_libssh_proxy_command`` instead with the libssh connection plugin. For details on migrating from Paramiko to libssh, see `Migrating to ssh_type libssh for ansible.netcommon.network_cli across Ansible networking collections <https://forum.ansible.com/t/migrating-to-ssh-type-libssh-for-ansible-netcommon-network-cli-across-ansible-networking-collections/45780>`_.
+   The ``ansible_paramiko_proxy_command`` variable is deprecated along with the Paramiko-based connection plugin. Use ``ansible_libssh_proxy_command`` instead with the libssh connection plugin. For details on migrating from Paramiko to libssh, see `Migrating to ssh_type libssh for ansible.netcommon.network_cli across Ansible networking collections <https://forum.ansible.com/t/migrating-to-ssh-type-libssh-for-ansible-netcommon-network-cli-across-ansible-networking-collections/45780>`_.
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
 - If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.

--- a/docs/docsite/rst/network/user_guide/platform_eos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_eos.rst
@@ -62,6 +62,10 @@ Example CLI ``group_vars/eos.yml``
    ansible_paramiko_proxy_command: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
+.. note::
+
+   The ``ansible_paramiko_proxy_command`` variable is deprecated because the Paramiko-based connection plugin is deprecated. Use ``ansible_libssh_proxy_command`` instead with the libssh connection plugin. For details on migrating from Paramiko to libssh, see `Migrating to ssh_type libssh for ansible.netcommon.network_cli across Ansible networking collections <https://forum.ansible.com/t/migrating-to-ssh-type-libssh-for-ansible-netcommon-network-cli-across-ansible-networking-collections/45780>`_.
+
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
 - If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.

--- a/docs/docsite/rst/network/user_guide/platform_ios.rst
+++ b/docs/docsite/rst/network/user_guide/platform_ios.rst
@@ -57,6 +57,10 @@ Example CLI ``group_vars/ios.yml``
    ansible_paramiko_proxy_command: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
+.. note::
+
+   The ``ansible_paramiko_proxy_command`` variable is deprecated because the Paramiko-based connection plugin is deprecated. Use ``ansible_libssh_proxy_command`` instead with the libssh connection plugin. For details on migrating from Paramiko to libssh, see `Migrating to ssh_type libssh for ansible.netcommon.network_cli across Ansible networking collections <https://forum.ansible.com/t/migrating-to-ssh-type-libssh-for-ansible-netcommon-network-cli-across-ansible-networking-collections/45780>`_.
+
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
 - If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.

--- a/docs/docsite/rst/network/user_guide/platform_ios.rst
+++ b/docs/docsite/rst/network/user_guide/platform_ios.rst
@@ -59,7 +59,7 @@ Example CLI ``group_vars/ios.yml``
 
 .. note::
 
-   The ``ansible_paramiko_proxy_command`` variable is deprecated because the Paramiko-based connection plugin is deprecated. Use ``ansible_libssh_proxy_command`` instead with the libssh connection plugin. For details on migrating from Paramiko to libssh, see `Migrating to ssh_type libssh for ansible.netcommon.network_cli across Ansible networking collections <https://forum.ansible.com/t/migrating-to-ssh-type-libssh-for-ansible-netcommon-network-cli-across-ansible-networking-collections/45780>`_.
+   The ``ansible_paramiko_proxy_command`` variable is deprecated along with the Paramiko-based connection plugin. Use ``ansible_libssh_proxy_command`` instead with the libssh connection plugin. For details on migrating from Paramiko to libssh, see `Migrating to ssh_type libssh for ansible.netcommon.network_cli across Ansible networking collections <https://forum.ansible.com/t/migrating-to-ssh-type-libssh-for-ansible-netcommon-network-cli-across-ansible-networking-collections/45780>`_.
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
 - If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.

--- a/docs/docsite/rst/network/user_guide/platform_iosxr.rst
+++ b/docs/docsite/rst/network/user_guide/platform_iosxr.rst
@@ -59,6 +59,10 @@ Example CLI inventory ``[iosxr:vars]``
    ansible_paramiko_proxy_command='-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
+.. note::
+
+   The ``ansible_paramiko_proxy_command`` variable is deprecated because the Paramiko-based connection plugin is deprecated. Use ``ansible_libssh_proxy_command`` instead with the libssh connection plugin. For details on migrating from Paramiko to libssh, see `Migrating to ssh_type libssh for ansible.netcommon.network_cli across Ansible networking collections <https://forum.ansible.com/t/migrating-to-ssh-type-libssh-for-ansible-netcommon-network-cli-across-ansible-networking-collections/45780>`_.
+
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
 - If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.

--- a/docs/docsite/rst/network/user_guide/platform_iosxr.rst
+++ b/docs/docsite/rst/network/user_guide/platform_iosxr.rst
@@ -61,7 +61,7 @@ Example CLI inventory ``[iosxr:vars]``
 
 .. note::
 
-   The ``ansible_paramiko_proxy_command`` variable is deprecated because the Paramiko-based connection plugin is deprecated. Use ``ansible_libssh_proxy_command`` instead with the libssh connection plugin. For details on migrating from Paramiko to libssh, see `Migrating to ssh_type libssh for ansible.netcommon.network_cli across Ansible networking collections <https://forum.ansible.com/t/migrating-to-ssh-type-libssh-for-ansible-netcommon-network-cli-across-ansible-networking-collections/45780>`_.
+   The ``ansible_paramiko_proxy_command`` variable is deprecated along with the Paramiko-based connection plugin. Use ``ansible_libssh_proxy_command`` instead with the libssh connection plugin. For details on migrating from Paramiko to libssh, see `Migrating to ssh_type libssh for ansible.netcommon.network_cli across Ansible networking collections <https://forum.ansible.com/t/migrating-to-ssh-type-libssh-for-ansible-netcommon-network-cli-across-ansible-networking-collections/45780>`_.
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
 - If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.

--- a/docs/docsite/rst/network/user_guide/platform_junos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_junos.rst
@@ -62,7 +62,7 @@ Example CLI inventory ``[junos:vars]``
 
 .. note::
 
-   The ``ansible_paramiko_proxy_command`` variable is deprecated because the Paramiko-based connection plugin is deprecated. Use ``ansible_libssh_proxy_command`` instead with the libssh connection plugin. For details on migrating from Paramiko to libssh, see `Migrating to ssh_type libssh for ansible.netcommon.network_cli across Ansible networking collections <https://forum.ansible.com/t/migrating-to-ssh-type-libssh-for-ansible-netcommon-network-cli-across-ansible-networking-collections/45780>`_.
+   The ``ansible_paramiko_proxy_command`` variable is deprecated along with the Paramiko-based connection plugin. Use ``ansible_libssh_proxy_command`` instead with the libssh connection plugin. For details on migrating from Paramiko to libssh, see `Migrating to ssh_type libssh for ansible.netcommon.network_cli across Ansible networking collections <https://forum.ansible.com/t/migrating-to-ssh-type-libssh-for-ansible-netcommon-network-cli-across-ansible-networking-collections/45780>`_.
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
 - If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.

--- a/docs/docsite/rst/network/user_guide/platform_junos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_junos.rst
@@ -60,6 +60,10 @@ Example CLI inventory ``[junos:vars]``
    ansible_paramiko_proxy_command='-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
+.. note::
+
+   The ``ansible_paramiko_proxy_command`` variable is deprecated because the Paramiko-based connection plugin is deprecated. Use ``ansible_libssh_proxy_command`` instead with the libssh connection plugin. For details on migrating from Paramiko to libssh, see `Migrating to ssh_type libssh for ansible.netcommon.network_cli across Ansible networking collections <https://forum.ansible.com/t/migrating-to-ssh-type-libssh-for-ansible-netcommon-network-cli-across-ansible-networking-collections/45780>`_.
+
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
 - If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.

--- a/docs/docsite/rst/network/user_guide/platform_nxos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_nxos.rst
@@ -59,6 +59,10 @@ Example CLI ``group_vars/nxos.yml``
    ansible_paramiko_proxy_command: '-o ProxyCommand="ssh -W %h:%p -q bastion01"'
 
 
+.. note::
+
+   The ``ansible_paramiko_proxy_command`` variable is deprecated because the Paramiko-based connection plugin is deprecated. Use ``ansible_libssh_proxy_command`` instead with the libssh connection plugin. For details on migrating from Paramiko to libssh, see `Migrating to ssh_type libssh for ansible.netcommon.network_cli across Ansible networking collections <https://forum.ansible.com/t/migrating-to-ssh-type-libssh-for-ansible-netcommon-network-cli-across-ansible-networking-collections/45780>`_.
+
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
 - If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.
 - If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords through environment variables.

--- a/docs/docsite/rst/network/user_guide/platform_nxos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_nxos.rst
@@ -61,7 +61,7 @@ Example CLI ``group_vars/nxos.yml``
 
 .. note::
 
-   The ``ansible_paramiko_proxy_command`` variable is deprecated because the Paramiko-based connection plugin is deprecated. Use ``ansible_libssh_proxy_command`` instead with the libssh connection plugin. For details on migrating from Paramiko to libssh, see `Migrating to ssh_type libssh for ansible.netcommon.network_cli across Ansible networking collections <https://forum.ansible.com/t/migrating-to-ssh-type-libssh-for-ansible-netcommon-network-cli-across-ansible-networking-collections/45780>`_.
+   The ``ansible_paramiko_proxy_command`` variable is deprecated along with the Paramiko-based connection plugin. Use ``ansible_libssh_proxy_command`` instead with the libssh connection plugin. For details on migrating from Paramiko to libssh, see `Migrating to ssh_type libssh for ansible.netcommon.network_cli across Ansible networking collections <https://forum.ansible.com/t/migrating-to-ssh-type-libssh-for-ansible-netcommon-network-cli-across-ansible-networking-collections/45780>`_.
 
 - If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
 - If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_paramiko_proxy_command`` configuration.


### PR DESCRIPTION
This PR adds note about "parmiko " connection type deprecation inside user_guide for ansible supported network collections , the note shares link for detailed migration process , it also suggest what should be used instesd paramiko related commands