### PR TITLE
fix(getting_started_ee): remove unnecessary become from EE examples

### DIFF
--- a/docs/docsite/rst/getting_started_ee/run_execution_environment.rst
+++ b/docs/docsite/rst/getting_started_ee/run_execution_environment.rst
@@ -22,7 +22,7 @@ Run against localhost
 
    .. code-block:: bash
 
-      ansible-navigator run test_localhost.yml --execution-environment-image postgresql_ee --mode stdout --pull-policy missing --container-options='--user=0'
+      ansible-navigator run test_localhost.yml --execution-environment-image postgresql_ee --mode stdout --pull-policy missing
 
 You may notice the facts being gathered are about the container and not the developer machine.
 This is because the ansible playbook was run inside the container.

--- a/docs/docsite/rst/getting_started_ee/yaml/test_localhost.yml
+++ b/docs/docsite/rst/getting_started_ee/yaml/test_localhost.yml
@@ -1,6 +1,5 @@
 - name: Gather and print local facts
   hosts: localhost
-  become: true
   gather_facts: true
   tasks:
 


### PR DESCRIPTION
The getting started EE playbooks used become: true for tasks that only gather facts and print debug output, which do not require privilege escalation.

Inspired by https://github.com/ansible/ansible-documentation/pull/3653