### PR TITLE
fix: remove pings from build failure notifications

### DIFF
--- a/.github/workflows/reusable-build-docs.yaml
+++ b/.github/workflows/reusable-build-docs.yaml
@@ -105,7 +105,6 @@ jobs:
           Oh no! A community package docs build has failed.
           Check this workflow run to see what went wrong:
           https://github.com/ansible/ansible-documentation/actions/runs/${{ github.run_id }}
-          @orandon @samccann
     steps:
     - name: Set a transaction ID
       run: echo "TX_ID=$(date +%s)" >> "${GITHUB_ENV}"


### PR DESCRIPTION
Removes direct pings in the docs matrix channel when scheduled doc builds fail.