### PR TITLE
fix: reduce fetch depth for deploy checkout to shallow clone

### DIFF
--- a/.github/workflows/reusable-deploy-docs.yaml
+++ b/.github/workflows/reusable-deploy-docs.yaml
@@ -91,7 +91,7 @@ jobs:
         repository: ${{ env.DEST_REPO }}
         ref: ${{ env.BRANCH }}
         path: deploy-directory
-        fetch-depth: 0
+        fetch-depth: 1
         ssh-key: ${{ secrets.DEPLOY_DOC_BUILD }}
         persist-credentials: true
 


### PR DESCRIPTION
Noticed in this run: https://github.com/ansible/ansible-documentation/actions/runs/27784219557/job/82223586237 that the step to checkout the deploy directory takes >25 minutes. The workflow should just need the current tree state to rsync the generated docs into. Full history isn't required for that step.