### PR TITLE
Add note about role argument_specs coercion

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
@@ -618,10 +618,6 @@ This section will discuss the behavioral attributes for arguments:
 
   The ``raw`` type, performs no type validation or type casting, and maintains the type of the passed value.
 
-  .. note::
-
-     Type validation is coercive, so any value that can be converted to the desired type will pass type validation. For example, the int ``1``, when passed as an argument expecting a ``str``, will be coerced to the str ``"1"`` and pass type validation.
-
 :elements:
 
   ``elements`` works in combination with ``type`` when ``type='list'``. ``elements`` can then be defined as ``elements='int'`` or any other type, indicating that each element of the specified list should be of that type.

--- a/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
@@ -618,6 +618,10 @@ This section will discuss the behavioral attributes for arguments:
 
   The ``raw`` type, performs no type validation or type casting, and maintains the type of the passed value.
 
+  .. note::
+
+     Type validation is coercive, so any value that can be converted to the desired type will pass type validation. For example, the int ``1``, when passed as an argument expecting a ``str``, will be coerced to the str ``"1"`` and pass type validation.
+
 :elements:
 
   ``elements`` works in combination with ``type`` when ``type='list'``. ``elements`` can then be defined as ``elements='int'`` or any other type, indicating that each element of the specified list should be of that type.

--- a/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
@@ -383,7 +383,11 @@ role ``meta/argument_specs.yml`` file. All fields are lowercase.
 
             .. note::
 
-               Type validation is coercive, so values that can be converted to the expected ``type`` will pass type validation. However, at runtime the role will receive the original uncoerced value. For example, passing the ``int`` ``1`` as a value expecting a ``str`` will pass validation and the role will receive the ``int`` ``1`` and not the coerced ``str`` ``"1"``. Use filters such as ``| string`` or ``| bool`` to coerce values as needed.
+               Type validation is coercive so values that can be converted to the expected ``type`` pass validation.
+               However, at runtime roles receive the original uncoerced values.
+               For example, passing the ``int`` ``1`` as a value expecting a ``str`` passes validation.
+               In this case the role receives the ``int`` ``1`` instead of the coerced ``str`` ``"1"``.
+               Use filters such as ``| string`` or ``| bool`` to coerce values as needed.
 
         :required:
 

--- a/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
@@ -383,7 +383,7 @@ role ``meta/argument_specs.yml`` file. All fields are lowercase.
 
             .. note::
 
-               Type validation is coercive so values that can be converted to the expected ``type`` pass validation.
+               Type validation is coercive, so values that can be converted to the expected ``type`` pass validation.
                However, at runtime roles receive the original uncoerced values.
                For example, passing the ``int`` ``1`` as a value expecting a ``str`` passes validation.
                In this case the role receives the ``int`` ``1`` instead of the coerced ``str`` ``"1"``.

--- a/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
@@ -381,6 +381,10 @@ role ``meta/argument_specs.yml`` file. All fields are lowercase.
             * The data type of the option. See :ref:`Argument spec <argument_spec>` for allowed values for ``type``. The default is ``str``.
             * If an option is of type ``list``, ``elements`` should be specified.
 
+            .. note::
+
+               Type validation is coercive, so values that can be converted to the expected ``type`` will pass type validation. However, at runtime the role will receive the original uncoerced value. For example, passing the ``int`` ``1`` as a value expecting a ``str`` will pass validation and the role will receive the ``int`` ``1`` and not the coerced ``str`` ``"1"``. Use filters such as ``| string`` or ``| bool`` to coerce values as needed.
+
         :required:
 
             * Only needed if ``true``.


### PR DESCRIPTION
Given that there have been multiple issues raised around ansible's coercive type validation in role `argument_specs` (https://github.com/ansible/ansible/issues/87217, https://github.com/ansible/ansible/issues/78889), this PR adds a small `..note::` to the docs to flag the behavior.

Closes: https://github.com/ansible/ansible/issues/87217