### PR TITLE
Fix duplicate word in testing_running_locally docs

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_running_locally.rst
+++ b/docs/docsite/rst/dev_guide/testing_running_locally.rst
@@ -187,7 +187,7 @@ Configuration requirements
 """"""""""""""""""""""""""
 
 1. Open Docker Desktop and go to the **Settings** screen.
-2. On the the **General** tab:
+2. On the **General** tab:
 
    a. Uncheck the **Start Docker Desktop when you log in** checkbox.
    b. Check the **Use the WSL 2 based engine** checkbox.


### PR DESCRIPTION
##### SUMMARY
Removes a duplicated word ("the the") in the Docker Desktop
configuration section of the "Testing Ansible and collections" page.

##### ISSUE TYPE
Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/dev_guide/testing_running_locally.rst