### PR TITLE
Fix duplicate word in cli_parsing docs

### DIFF
--- a/docs/docsite/rst/network/user_guide/cli_parsing.rst
+++ b/docs/docsite/rst/network/user_guide/cli_parsing.rst
@@ -334,7 +334,7 @@ Taking a deeper dive into this task:
 	Red Hat Ansible Automation Platform subscription support is limited to the use of the ``ntc_templates`` public APIs as documented.
 
 
-This task and and the predefined template sets the following fact as the ``interfaces`` fact for the host:
+This task and the predefined template sets the following fact as the ``interfaces`` fact for the host:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
##### SUMMARY
Removes a duplicated word ("and and") in the network CLI parsing
guide, in the sentence describing how a task and its predefined
template set the interfaces fact.

##### ISSUE TYPE
Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/network/user_guide/cli_parsing.rst