### PR TITLE
Remove outdated UTF-8 encoding comment recommendation

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -35,8 +35,8 @@ For modules written in languages other than Python, there are two approaches to 
 
 .. _shebang:
 
-Python shebang & UTF-8 coding
-=============================
+Python shebang
+==============
 
 1. Begin your Ansible module with the ``#!/usr/bin/python`` shebang so that ``ansible_python_interpreter`` works.
 
@@ -45,20 +45,19 @@ Python shebang & UTF-8 coding
   * Do NOT use ``#!/usr/bin/env`` because it makes ``env`` the interpreter and bypasses ``ansible_<interpreter>_interpreter`` logic.
   * Passing arguments to the interpreter in the shebang does not work; for example, ``#!/usr/bin/env python``.
 
-2. Follow the shebang immediately with ``# -*- coding: utf-8 -*-`` to clarify that the file is UTF-8 encoded.
+2. Do not add an encoding comment such as ``# -*- coding: utf-8 -*-``. It was required for Python 2 but is unnecessary in Python 3, which treats source files as UTF-8 by default. Since ansible-core 2.17 dropped Python 2 support, existing encoding comments can be removed.
 
 .. _copyright:
 
 Copyright and license
 =====================
 
-* After the shebang and UTF-8 encoding lines, add a `copyright line <https://www.linuxfoundation.org/blog/copyright-notices-in-open-source-software-projects/>`_ with the original copyright holder and a license declaration.
+* After the shebang, add a `copyright line <https://www.linuxfoundation.org/blog/copyright-notices-in-open-source-software-projects/>`_ with the original copyright holder and a license declaration.
 * The license declaration should be one line ONLY, not the full GPL prefix, as follows:
 
 .. code-block:: python
 
     #!/usr/bin/python
-    # -*- coding: utf-8 -*-
 
     # Copyright: Contributors to the Ansible project
     # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
@@ -83,7 +82,7 @@ DOCUMENTATION block
 
 Before committing your module documentation, please test it at the :ref:`command line and as HTML <dev_testing_module_documentation>`.
 
-After the shebang, the UTF-8 encoding, the copyright line, and the license section comes the ``DOCUMENTATION`` block. Ansible's online module documentation is generated from the ``DOCUMENTATION`` blocks in the source code of each module.
+After the shebang, the copyright line, and the license section comes the ``DOCUMENTATION`` block. Ansible's online module documentation is generated from the ``DOCUMENTATION`` blocks in the source code of each module.
 
 The ``DOCUMENTATION`` block must be valid YAML. To make it easier:
 


### PR DESCRIPTION
##### SUMMARY
The dev guide currently recommends adding `# -*- coding: utf-8 -*-` to
Python module files. This was required for Python 2, but is unnecessary
in Python 3, which treats source files as UTF-8 by default. Since
ansible-core 2.17 dropped Python 2 support, this comment can and should
be removed.

This updates the "Python shebang" section (heading, item 2, the copyright
section reference, the code example, and the later DOCUMENTATION block
reference) to reflect that.

Fixes #3469

##### ISSUE TYPE
Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/dev_guide/developing_modules_documenting.rst