### PR TITLE
Clarify role variable directory loading

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
@@ -762,9 +762,9 @@ Read the `Ansible Galaxy documentation <https://ansible.readthedocs.io/projects/
    :ref:`playbooks_variables`
        Variables in playbooks
    :ref:`playbooks_conditionals`
-       Conditionals
+       Conditionals in playbooks
    :ref:`playbooks_loops`
-       Loops
+       Loops in playbooks
    :ref:`tags`
        Using tags to select or skip roles/tasks in long playbooks
    :ref:`list_of_collections`

--- a/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
@@ -79,7 +79,7 @@ Or call those tasks directly when loading the role, which bypasses the ``main.ym
      when: ansible_facts['os_family'] == 'Debian'
 
 
-Directories ``defaults`` and ``vars`` may also include *nested directories*. If your variables file is a directory, Ansible reads all variables files and directories inside in alphabetical order. If a nested directory contains variables files as well as directories, Ansible reads the directories first. Below is an example of a ``vars/main`` directory:
+Ansible automatically loads the ``main`` entry point from ``defaults/`` and ``vars/``. The ``main`` entry point can be a file or a directory. If ``defaults/main`` or ``vars/main`` is a directory, Ansible reads all variables files and directories inside in alphabetical order. If a nested directory contains variables files as well as directories, Ansible reads the directories first. To load a different variables file or directory, select it explicitly with ``defaults_from`` or ``vars_from`` when using ``include_role`` or ``import_role``, as described above. Below is an example of a ``vars/main`` directory:
 
 .. code-block:: text
 

--- a/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
@@ -79,7 +79,7 @@ Or call those tasks directly when loading the role, which bypasses the ``main.ym
      when: ansible_facts['os_family'] == 'Debian'
 
 
-Ansible automatically loads the ``main`` entry point from ``defaults/`` and ``vars/``. The ``main`` entry point can be a file or a directory. If ``defaults/main`` or ``vars/main`` is a directory, Ansible reads all variables files and directories inside in alphabetical order. If a nested directory contains variables files as well as directories, Ansible reads the directories first. To load a different variables file or directory, select it explicitly with ``defaults_from`` or ``vars_from`` when using ``include_role`` or ``import_role``, as described above. Below is an example of a ``vars/main`` directory:
+Variable entry points in ``defaults`` and ``vars`` can also be directories. See the default entry points described at the beginning of :ref:`Role directory structure <role_directory_structure>`. If a variable entry point is a directory, Ansible reads all variables files and directories inside in alphabetical order. If a nested directory contains variables files as well as directories, Ansible reads the directories first. Below is an example of a ``vars/main`` directory:
 
 .. code-block:: text
 
@@ -762,9 +762,9 @@ Read the `Ansible Galaxy documentation <https://ansible.readthedocs.io/projects/
    :ref:`playbooks_variables`
        Variables in playbooks
    :ref:`playbooks_conditionals`
-       Conditionals in playbooks
+       Conditionals
    :ref:`playbooks_loops`
-       Loops in playbooks
+       Loops
    :ref:`tags`
        Using tags to select or skip roles/tasks in long playbooks
    :ref:`list_of_collections`


### PR DESCRIPTION
## Summary

Clarify how Ansible loads variables from role `defaults` and `vars` directories.

The previous wording could imply that any nested directory under `defaults/` or `vars/` is loaded automatically. The updated text explains that:

- Ansible automatically loads the `main` entry point.
- `defaults/main` and `vars/main` may be files or directories.
- Alternative files or directories must be selected explicitly with `defaults_from` or `vars_from`.

Fixes #2994.

## Validation

- `nox -s spelling`
- `nox -s "checkers(rstcheck)"`
- `nox --force-python 3.13 -s "checkers(docs-build)"`

## Scope

Documentation only. No runtime behaviour is changed.
