### PR TITLE
Fix inconsistent playbook file extension in check mode example

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_intro.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_intro.rst
@@ -111,7 +111,7 @@ To run a playbook in check mode, pass the ``-C`` or ``--check`` flag to the ``an
 
 .. code-block:: bash
 
-    ansible-playbook --check playbook.yaml
+    ansible-playbook --check playbook.yml
 
 
 Executing this command runs the playbook normally. Instead of implementing any modifications, Ansible provides a report on the changes it would have made. This report includes details such as file modifications, command execution, and module calls.


### PR DESCRIPTION
Fixes an inconsistency where the check mode example referenced playbook.yaml while the rest of the page uses playbook.yml.