### PR TITLE
chore: fix ruff checks in docs/bin/

### DIFF
--- a/docs/bin/clone-core.py
+++ b/docs/bin/clone-core.py
@@ -82,7 +82,7 @@ def parse_args(args: list[str] | None = None) -> Args:
     return Args(**vars(parser.parse_args(args)))
 
 
-def remove_files(directory: pathlib.Path = pathlib.Path.cwd()) -> list[pathlib.Path]:
+def remove_files(directory: pathlib.Path) -> list[pathlib.Path]:
     removed: list[pathlib.Path] = []
     for file in REMOVE_FILES:
         path = directory / file
@@ -95,7 +95,7 @@ def remove_files(directory: pathlib.Path = pathlib.Path.cwd()) -> list[pathlib.P
 
 def main(args: Args) -> None:
     # Start by removing extra files
-    removed_files = remove_files()
+    removed_files = remove_files(pathlib.Path.cwd())
 
     if (
         # Check is enabled

--- a/docs/bin/find-plugin-refs.py
+++ b/docs/bin/find-plugin-refs.py
@@ -60,11 +60,7 @@ def process_refs(topdir: str | os.PathLike[str], plugin_names: Collection[str]):
                     # the file contains an unported ref
                     if label in plugin_names:
                         print(
-                            ":ref:`{0}` matching plugin {1} was found in {2}".format(
-                                ref_match.group(1),
-                                label,
-                                os.path.join(dirpath, filename),
-                            )
+                            f":ref:`{ref_match.group(1)}` matching plugin {label} was found in {os.path.join(dirpath, filename)}"
                         )
 
 


### PR DESCRIPTION
Related to CI failures in https://github.com/ansible/ansible-documentation/pull/3839

These changes address failures from ruff checks in the `docs/bin/` folder.

- Avoid calling `pathlib.Path.cwd()` in the `remove_files` argument default (B008) in `clone-core.py`
- Replace `.format()` with an f-string in `find-plugin-refs.py` (UP030)