### PR TITLE
chore: bump sphinx to 9.1.0

### DIFF
--- a/tests/constraints.in
+++ b/tests/constraints.in
@@ -2,11 +2,11 @@
 # and antsibull-docs that production builds rely upon.
 # This constraint file also pins other versions for which there are known limitations.
 
-sphinx == 7.2.5
+sphinx == 9.1.0
 antsibull-docs == 2.23.0  # currently approved version
 
 sphinx-rtd-theme >= 2.0.0  # Fix 404 pages with new sphinx -- https://github.com/ansible/ansible-documentation/issues/678
 rstcheck < 6  # rstcheck 6.x has problem with rstcheck.core triggered by include files w/ sphinx directives https://github.com/rstcheck/rstcheck-core/issues/3
-jinja2 >= 3.0.0  # https://github.com/ansible/ansible/blob/devel/requirements.txt
+jinja2 >= 3.1.0  # https://github.com/ansible/ansible/blob/devel/requirements.txt
 pyyaml >= 5.1  # https://github.com/ansible/ansible/blob/devel/requirements.txt
-resolvelib >= 0.5.3, < 2.0.0  # https://github.com/ansible/ansible/blob/devel/requirements.txt
+resolvelib >= 0.8.0, < 2.0.0  # https://github.com/ansible/ansible/blob/devel/requirements.txt

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -69,7 +69,7 @@ colorama==0.4.6 ; os_name == 'nt' or sys_platform == 'win32'
     #   sphinx
 cryptography==48.0.0
     # via -r tests/requirements.in
-docutils==0.18.1
+docutils==0.22.4
     # via
     #   antsibull-changelog
     #   antsibull-docs
@@ -143,7 +143,9 @@ resolvelib==1.2.1
     # via
     #   -c tests/constraints.in
     #   -r tests/requirements.in
-rstcheck==5.0.0
+roman-numerals==4.1.0
+    # via sphinx
+rstcheck==3.5.0
     # via
     #   -c tests/constraints.in
     #   -r tests/requirements.in
@@ -158,7 +160,7 @@ six==1.17.0
     # via twiggy
 snowballstemmer==3.1.1
     # via sphinx
-sphinx==7.2.5
+sphinx==9.1.0
     # via
     #   -c tests/constraints.in
     #   -r tests/requirements.in
@@ -201,13 +203,10 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 twiggy==0.5.1
     # via antsibull-core
-types-docutils==0.18.3
-    # via rstcheck
 typing-extensions==4.15.0
     # via
     #   pydantic
     #   pydantic-core
-    #   rstcheck
     #   typing-inspection
 typing-inspection==0.4.2
     # via pydantic


### PR DESCRIPTION
This change bumps sphinx to the latest version, 9.1.0. I also updated some of the pins to match core reqs at: https://github.com/ansible/ansible/blob/devel/requirements.txt

Tested locally with `nox -P python3.13` and looks good. I'll kick off a run with the package docs as well.