### PR TITLE
Pin actions to hash

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -47,16 +47,16 @@ jobs:
           echo "${event_json}"
       - name: Generate temp GITHUB_TOKEN
         id: create_token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_KEY }}
       - name: Checkout parent repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Install Python 3.13
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
       - name: Set up UV

--- a/.github/workflows/release-porting-guide.yml
+++ b/.github/workflows/release-porting-guide.yml
@@ -33,19 +33,19 @@ jobs:
 
       - name: Generate temp GITHUB_TOKEN
         id: create_token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.BOT_APP_ID }} # From github-bot environment
           private-key: ${{ secrets.BOT_APP_KEY }} # From github-bot environment
 
       - name: Check out this repo src
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ steps.create_token.outputs.token }}
           persist-credentials: true  # Needed to push to the repo
 
       - name: Check out ansible-build-data
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ansible-community/ansible-build-data
           ref: ${{ inputs.ansible-build-data-branch }}

--- a/.github/workflows/reusable-build-docs.yaml
+++ b/.github/workflows/reusable-build-docs.yaml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Ansible documentation
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         repository: >-
           ${{
@@ -55,7 +55,7 @@ jobs:
         persist-credentials: false
 
     - name: Setup nox
-      uses: wntrblm/nox@2026.07.11
+      uses: wntrblm/nox@3284968a16fa5bd7fc0cc64a69a531404ccb4756 # 2026.07.11
       with:
         python-versions: "${{ inputs.python-version }}"
 
@@ -102,7 +102,7 @@ jobs:
       working-directory: build-directory/docs/docsite
 
     - name: Create a downloadable archive that contains the tarball
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: package-docs-build
         path: build-directory/docs/docsite/ansible-package-docs-html-*.tar.gz

--- a/.github/workflows/reusable-deploy-docs.yaml
+++ b/.github/workflows/reusable-deploy-docs.yaml
@@ -58,7 +58,7 @@ jobs:
       USER_NAME: "github-actions[bot]"
     steps:
     - name: Download the build archive
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: package-docs-build
 
@@ -86,7 +86,7 @@ jobs:
         echo "ENV_URL=${TEST_URL}" >> "${GITHUB_ENV}"
 
     - name: Checkout the deploy directory
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         repository: ${{ env.DEST_REPO }}
         ref: ${{ env.BRANCH }}

--- a/.github/workflows/reusable-nox.yml
+++ b/.github/workflows/reusable-nox.yml
@@ -39,11 +39,11 @@ jobs:
     name: "Run nox ${{ matrix.session }} session"
     steps:
       - name: Check out repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Setup nox
-        uses: wntrblm/nox@2026.07.11
+        uses: wntrblm/nox@3284968a16fa5bd7fc0cc64a69a531404ccb4756 # 2026.07.11
         with:
           python-versions: "${{ matrix.python-versions }}"
       - name: Graft ansible-core with Python ${{ matrix.python-versions }}

--- a/.github/workflows/reusable-pip-compile.yml
+++ b/.github/workflows/reusable-pip-compile.yml
@@ -45,7 +45,7 @@ jobs:
     environment: github-bot
     steps:
       - name: Check out repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: "${{ inputs.base-branch }}"
@@ -54,7 +54,7 @@ jobs:
         run: |
           python docs/bin/clone-core.py
       - name: Set up nox
-        uses: wntrblm/nox@2026.07.11
+        uses: wntrblm/nox@3284968a16fa5bd7fc0cc64a69a531404ccb4756 # 2026.07.11
         with:
           python-versions: "${{ inputs.python-versions }}"
       - name: Set up git committer
@@ -88,7 +88,7 @@ jobs:
           nox ${{ inputs.nox-args }}
       - name: Generate temp GITHUB_TOKEN
         id: create_token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_KEY }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -23,26 +23,26 @@ jobs:
     steps:
       - name: Generate temp GITHUB_TOKEN
         id: create_token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_KEY }}
       - name: Check out us
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: ansible-documentation
           fetch-depth: 0
           token: "${{ steps.create_token.outputs.token }}"
           persist-credentials: true
       - name: Check out core
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ansible/ansible
           path: ansible
           fetch-depth: 0
           persist-credentials: false
       - name: Setup nox
-        uses: wntrblm/nox@2026.07.11
+        uses: wntrblm/nox@3284968a16fa5bd7fc0cc64a69a531404ccb4756 # 2026.07.11
         with:
           python-versions: "3.13"
       - name: Set up git committer

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -2,6 +2,6 @@ rules:
   unpinned-uses:
     config:
       policies:
-        "wntrblm/nox": ref-pin
+        "wntrblm/nox": hash-pin
         "re-actors/alls-green": ref-pin
-        "actions/*": ref-pin
+        "actions/*": hash-pin


### PR DESCRIPTION
This change pins actions to hashes instead of tags and updates the zizmor policy to enforce hash pinning.

One exception that I am unsure about is `re-actors/alls-green@release/v1` at: https://github.com/ansible/ansible-documentation/blob/34edd6bf3f298ad2b3862f35b833238afccec855/.github/workflows/ci.yaml#L36

I guess this is fine since @webknjaz is the maintainer so I've left it as-is but wanted to mention.