### PR TITLE
[stable 2.21]: Bump actions and pin to hash

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -47,16 +47,16 @@ jobs:
           echo "${event_json}"
       - name: Generate temp GITHUB_TOKEN
         id: create_token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_KEY }}
       - name: Checkout parent repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Install Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - name: Set up UV

--- a/.github/workflows/reusable-nox.yml
+++ b/.github/workflows/reusable-nox.yml
@@ -39,11 +39,11 @@ jobs:
     name: "Run nox ${{ matrix.session }} session"
     steps:
       - name: Check out repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Setup nox
-        uses: wntrblm/nox@2026.02.09
+        uses: wntrblm/nox@3284968a16fa5bd7fc0cc64a69a531404ccb4756 # 2026.07.11
         with:
           python-versions: "${{ matrix.python-versions }}"
       - name: Graft ansible-core

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -2,6 +2,6 @@ rules:
   unpinned-uses:
     config:
       policies:
-        "wntrblm/nox": ref-pin
+        "wntrblm/nox": hash-pin
         "re-actors/alls-green": ref-pin
-        "actions/*": ref-pin
+        "actions/*": hash-pin


### PR DESCRIPTION
Related to https://github.com/ansible/ansible-documentation/pull/3847

These changes bump action versions and pin to hash. Also updates the zizmor config to enforce hash pinning.