### PR TITLE
chore(tag.py): fix the isort/ruff sorting conflict

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,3 @@
 [isort]
 profile = black
+known_third_party = packaging

--- a/hacking/tagger/tag.py
+++ b/hacking/tagger/tag.py
@@ -23,7 +23,6 @@ from typing import Any, NamedTuple, NoReturn
 import git
 import git.objects.util
 import typer
-
 from packaging.version import Version
 
 MESSAGE = Template("""\


### PR DESCRIPTION
Another CI failure from `ruff check`:

```
I001 [*] Import block is un-sorted or un-formatted
  --> hacking/tagger/tag.py:13:1
   |
11 |   """
12 |
13 | / from __future__ import annotations
14 | |
15 | | import datetime
16 | | from collections.abc import Iterable
17 | | from dataclasses import dataclass
18 | | from pathlib import Path
19 | | from string import Template
20 | | from types import SimpleNamespace
21 | | from typing import Any, NamedTuple, NoReturn
22 | |
23 | | import git
24 | | import git.objects.util
25 | | import typer
26 | |
27 | | from packaging.version import Version
   | |_____________________________________^
28 |
29 |   MESSAGE = Template("""\
   |
help: Organize imports
   |
25 | import typer
   -
26 | from packaging.version import Version
   |
```

My initial commit formatted the tagger but that failed `nox -s formatters_check` because isort complained about the blank line that `ruff --fix` added. So ruff and isort were conflicting with each other.

Adding `packaging` as a [known_third_party](https://isort.readthedocs.io/en/latest/configuration/options.html#known-third-party) in isort config satisfies both tools.