### PR TITLE
chore(noxfile.py): move format comments outside the function call

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -128,18 +128,18 @@ def actionlint(session: nox.Session) -> None:
     """
     engine = _get_container_engine(session)
     session.run_always(engine, "pull", ACTIONLINT_IMAGE, external=True)
+    # fmt: off
     session.run(
         engine,
         "run",
         "--rm",
-        # fmt: off
         "--volume", f"{Path.cwd()}:/pwd:z",
         "--workdir", "/pwd",
-        # fmt: on
         ACTIONLINT_IMAGE,
         *session.posargs,
         external=True,
     )
+    # fmt: on
 
 
 @nox.session


### PR DESCRIPTION
Ruff was complaining about the formatter suppression comments inside the function call with https://docs.astral.sh/ruff/rules/invalid-formatter-suppression-comment/

If we remove those comments, then black formats them. To satisfy ruff, we need to wrap the entire function call.