### PR TITLE
chore: ignore ruff warnings about blind exception handlers

### DIFF
--- a/tests/checkers/rst-yamllint.py
+++ b/tests/checkers/rst-yamllint.py
@@ -160,7 +160,7 @@ def main() -> None:
                                 "message": msg,
                             }
                         )
-                except Exception as exc:
+                except Exception as exc:  # noqa: BLE001
                     error = str(exc).replace("\n", " / ")
                     results.append(
                         {
@@ -173,7 +173,7 @@ def main() -> None:
                             ),
                         }
                     )
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             error = str(exc).replace("\n", " / ")
             results.append(
                 {


### PR DESCRIPTION
Ruff complains about the broad exception handlers in the yamllint checker:

```
BLE001 Do not catch blind exception: `Exception`
   --> tests/checkers/rst-yamllint.py:163:24
    |
161 |                             }
162 |                         )
163 |                 except Exception as exc:
    |                        ^^^^^^^^^
164 |                     error = str(exc).replace("\n", " / ")
165 |                     results.append(
    |

BLE001 Do not catch blind exception: `Exception`
   --> tests/checkers/rst-yamllint.py:176:16
    |
174 |                         }
175 |                     )
176 |         except Exception as exc:
    |                ^^^^^^^^^
177 |             error = str(exc).replace("\n", " / ")
178 |             results.append(
    |
```

I think we want these to stay as-is because it's linting the files and we want a wide net. So I added `noqa` comments to ignore that particular ruff check.