### PR TITLE
[stable-2.19]: chore: update pr_labeler to use type keyword

### DIFF
--- a/hacking/pr_labeler/pr_labeler/actions.py
+++ b/hacking/pr_labeler/pr_labeler/actions.py
@@ -88,7 +88,6 @@ def new_contributor_welcome(ctx: IssueOrPrCtx) -> None:
     if (
         # Contributor has already been welcomed
         NEW_CONTRIBUTOR_LABEL in ctx.previously_labeled
-        #
         or not is_new_contributor(ctx)
     ):
         return

--- a/hacking/pr_labeler/pr_labeler/cli_context.py
+++ b/hacking/pr_labeler/pr_labeler/cli_context.py
@@ -17,11 +17,10 @@ import github.PullRequest
 import github.Repository
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
 
     from .github_utils import IssueOrPr
 
-IssueOrPrCtx: TypeAlias = "IssueLabelerCtx | PRLabelerCtx"
+type IssueOrPrCtx = "IssueLabelerCtx | PRLabelerCtx"
 
 
 @dataclasses.dataclass()

--- a/hacking/pr_labeler/pr_labeler/github_utils.py
+++ b/hacking/pr_labeler/pr_labeler/github_utils.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 import os
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import github
 import github.Auth
@@ -21,11 +21,7 @@ import github.Repository
 from .cli_context import IssueLabelerCtx, IssueOrPrCtx
 from .utils import log
 
-if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
-
-
-IssueOrPr: TypeAlias = "github.Issue.Issue | github.PullRequest.PullRequest"
+type IssueOrPr = "github.Issue.Issue | github.PullRequest.PullRequest"
 
 
 def get_repo(


### PR DESCRIPTION
Backports PR labeler changes from https://github.com/ansible/ansible-documentation/pull/3842