### PR TITLE
[stable-2.19]: chore(pr_labeler): update pr_labeler to import from typing

### DIFF
--- a/hacking/pr_labeler/pr_labeler/actions.py
+++ b/hacking/pr_labeler/pr_labeler/actions.py
@@ -88,7 +88,6 @@ def new_contributor_welcome(ctx: IssueOrPrCtx) -> None:
     if (
         # Contributor has already been welcomed
         NEW_CONTRIBUTOR_LABEL in ctx.previously_labeled
-        #
         or not is_new_contributor(ctx)
     ):
         return

--- a/hacking/pr_labeler/pr_labeler/cli_context.py
+++ b/hacking/pr_labeler/pr_labeler/cli_context.py
@@ -17,7 +17,7 @@ import github.PullRequest
 import github.Repository
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
     from .github_utils import IssueOrPr
 

--- a/hacking/pr_labeler/pr_labeler/github_utils.py
+++ b/hacking/pr_labeler/pr_labeler/github_utils.py
@@ -22,7 +22,7 @@ from .cli_context import IssueLabelerCtx, IssueOrPrCtx
 from .utils import log
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 
 IssueOrPr: TypeAlias = "github.Issue.Issue | github.PullRequest.PullRequest"


### PR DESCRIPTION
Supercedes https://github.com/ansible/ansible-documentation/pull/3860

The `stable-2.19` branch uses Python3.11 and backporting all changes to the PR labeler from devel failed with:

```
invalid-syntax: Cannot use `type` alias statement on Python 3.11
```

This change removes the `type` alias change and imports from `typing` instead of `typing_extensions`.