### PR TITLE
Add basic ruff config to disable problematic rules

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,11 @@
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: Ansible project
+
+[lint]
+# https://docs.astral.sh/ruff/rules/
+
+ignore = [
+    "I001",  # unsorted-imports: we use isort
+    "RUF028",  # invalid-formatter-suppression-comment: we use black
+]

--- a/ruff.toml
+++ b/ruff.toml
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # SPDX-FileCopyrightText: Ansible project
 
+target-version = "py313"
+
 [lint]
 # https://docs.astral.sh/ruff/rules/
 


### PR DESCRIPTION
It would be even better to have an explicit list of rules we want to be checked, but for now stick to disabling the ones we don't want.

Replaces #3855 and #3856.
