### PR TITLE
[stable-2.21]: fix(ruff.toml): specify the correct target python version

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # SPDX-FileCopyrightText: Ansible project
 
-target-version = "py313"
+target-version = "py312"
 
 [lint]
 # https://docs.astral.sh/ruff/rules/


### PR DESCRIPTION
Follows up on https://github.com/ansible/ansible-documentation/pull/3868