### PR TITLE
[stable-2.19]: Pin the alls-green action to hash (#3869)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,6 @@ jobs:
 
     steps:
     - name: Decide whether the needed jobs succeeded or failed
-      uses: re-actors/alls-green@release/v1
+      uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
       with:
         jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
* chore(workflows): pin alls green to hash

(cherry picked from commit 7065b6cca32b4b8eb1bf59199a7ae168cb76817b)

Follows up on https://github.com/ansible/ansible-documentation/pull/3869