### PR TITLE
typo: unit tests are in tests/unit

### DIFF
--- a/docs/docsite/rst/community/collection_contributors/collection_unit_tests.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_unit_tests.rst
@@ -36,11 +36,11 @@ See :ref:`collection_prepare_local` to prepare your environment.
 Determine if unit tests exist
 =============================
 
-Ansible collection unit tests are located in the ``tests/units`` directory.
+Ansible collection unit tests are located in the ``tests/unit`` directory.
 
-The structure of the unit tests matches the structure of the code base, so the tests can reside in the ``tests/units/plugins/modules/`` and ``tests/units/plugins/module_utils`` directories. There can be sub-directories if modules are organized by module groups.
+The structure of the unit tests matches the structure of the code base, so the tests can reside in the ``tests/unit/plugins/modules/`` and ``tests/unit/plugins/module_utils`` directories. There can be sub-directories if modules are organized by module groups.
 
-If you are adding unit tests for ``my_module`` for example, check to see if the tests already exist in the collection source tree with the path ``tests/units/plugins/modules/test_my_module.py``.
+If you are adding unit tests for ``my_module`` for example, check to see if the tests already exist in the collection source tree with the path ``tests/unit/plugins/modules/test_my_module.py``.
 
 Example of unit tests
 =====================
@@ -81,7 +81,7 @@ To write these unit tests in collection is called ``community.mycollection``:
 
     .. code:: bash
 
-      touch tests/units/plugins/modules/test_my_module.py
+      touch tests/unit/plugins/modules/test_my_module.py
 
 3. Add the following code to the file:
 

--- a/docs/docsite/rst/dev_guide/developing_collections_migrating.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_migrating.rst
@@ -53,7 +53,7 @@ Create a PR in the new collection to:
 #. If it is an action plugin, include the corresponding module with documentation.
 #. If it is a module, check if it has a corresponding action plugin that should move with it.
 #. Check ``meta/`` for relevant updates to ``runtime.yml`` if it exists.
-#. Carefully check the moved ``tests/integration`` and ``tests/units`` and update for FQCN.
+#. Carefully check the moved ``tests/integration`` and ``tests/unit`` and update for FQCN.
 #. Review ``tests/sanity/ignore-*.txt`` entries in the old collection.
 #. Update ``meta/runtime.yml`` in the old collection.
 
@@ -67,7 +67,7 @@ Create a PR against the source collection repository to remove the modules, modu
 #. If you are removing a module, remove any corresponding action plugin that should stay with it.
 #. Remove any entries about removed plugins from ``meta/runtime.yml``. Ensure they are added into the new repo.
 #. Remove sanity ignore lines from ``tests/sanity/ignore\*.txt``
-#. Remove associated integration tests from ``tests/integrations/targets/`` and unit tests from ``tests/units/plugins/``.
+#. Remove associated integration tests from ``tests/integrations/targets/`` and unit tests from ``tests/unit/plugins/``.
 #. if you are removing from content from ``community.general`` or ``community.network``, remove entries from ``.github/BOTMETA.yml``.
 #. Carefully review ``meta/runtime.yml`` for any entries you may need to remove or update, in particular deprecated entries.
 #. Update ``meta/runtime.yml`` to contain redirects for EVERY PLUGIN, pointing to the new collection name.


### PR DESCRIPTION
in an ansible module I recently contributed to, a reviewer mentioned that the newly added unit tests belong into the `tests/units` directory according to [the documentation](https://docs.ansible.com/projects/ansible/latest/community/collection_contributors/collection_unit_tests.html#determine-if-unit-tests-exist).

When doing so, I get the following error:

```bash
$ git mv tests/unit tests/units
$ ansible-test units --docker --python 3.12
WARNING: Rename "tests/units/" to "tests/unit/" to run unit tests.
WARNING: All targets skipped.

$ ansible-test --version
ansible-test version 2.21.2
```