### PR TITLE
build(constraints.in): remove constraint for sphinx from devel

### DIFF
--- a/tests/constraints.in
+++ b/tests/constraints.in
@@ -1,8 +1,7 @@
-# This constraints file contains pins for the stable, tested versions of sphinx
-# and antsibull-docs that production builds rely upon.
+# This constraints file contains pins for the stable, tested versions of
+# antsibull-docs that production builds rely upon.
 # This constraint file also pins other versions for which there are known limitations.
 
-sphinx == 9.1.0
 antsibull-docs == 2.23.0  # currently approved version
 
 sphinx-rtd-theme >= 2.0.0  # Fix 404 pages with new sphinx -- https://github.com/ansible/ansible-documentation/issues/678

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -162,7 +162,6 @@ snowballstemmer==3.1.1
     # via sphinx
 sphinx==9.1.0
     # via
-    #   -c tests/constraints.in
     #   -r tests/requirements.in
     #   antsibull-docs
     #   sphinx-ansible-theme


### PR DESCRIPTION
Removes the pin for `sphinx` from the `constraints.in` file. Applies to the `devel` branch only. I'll send a docs PR separately for the maintainers guide.

Discussed in this forum thread: https://forum.ansible.com/t/removing-the-sphinx-constraint-on-devel/46130/3