### PR TITLE
ci: update to use self-repository syntax

### DIFF
--- a/.github/workflows/build-devel-docs.yaml
+++ b/.github/workflows/build-devel-docs.yaml
@@ -11,14 +11,14 @@ permissions:
 jobs:
   build-package-docs:
     name: 📝 Build
-    uses: ./.github/workflows/reusable-build-docs.yaml
+    uses: $/.github/workflows/reusable-build-docs.yaml
     secrets:
       DOCS_BOT_TOKEN: ${{ secrets.DOCS_BOT_TOKEN }}
 
   deploy-package-docs:
     name: 🚀 Deploy
     needs: build-package-docs
-    uses: ./.github/workflows/reusable-deploy-docs.yaml
+    uses: $/.github/workflows/reusable-deploy-docs.yaml
     with:
       deployment-environment: 'production'
     secrets:

--- a/.github/workflows/build-latest-docs.yaml
+++ b/.github/workflows/build-latest-docs.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   build-package-docs:
     name: 📝 Build
-    uses: ./.github/workflows/reusable-build-docs.yaml
+    uses: $/.github/workflows/reusable-build-docs.yaml
     with:
       repository-branch: 'stable-2.21'
       ansible-package-version: '14'
@@ -21,7 +21,7 @@ jobs:
   deploy-package-docs:
     name: 🚀 Deploy
     needs: build-package-docs
-    uses: ./.github/workflows/reusable-deploy-docs.yaml
+    uses: $/.github/workflows/reusable-deploy-docs.yaml
     with:
       ansible-package-version: '14'
       deployment-environment: 'production'

--- a/.github/workflows/build-package-docs.yaml
+++ b/.github/workflows/build-package-docs.yaml
@@ -63,7 +63,7 @@ permissions:
 jobs:
   build-package-docs:
     name: 📝 Build
-    uses: ./.github/workflows/reusable-build-docs.yaml
+    uses: $/.github/workflows/reusable-build-docs.yaml
     with:
       repository-owner: ${{ github.event.inputs.repository-owner || 'ansible' }}
       repository-name:  ${{ github.event.inputs.repository-name || 'ansible-documentation' }}
@@ -80,7 +80,7 @@ jobs:
     name: 🚀 Deploy
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.deploy == 'true'
     needs: build-package-docs
-    uses: ./.github/workflows/reusable-deploy-docs.yaml
+    uses: $/.github/workflows/reusable-deploy-docs.yaml
     with:
       ansible-package-version: ${{ github.event.inputs.ansible-package-version }}
       deployment-environment: ${{ github.event.inputs.deployment-environment }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   nox:
-    uses: ./.github/workflows/reusable-nox.yml
+    uses: $/.github/workflows/reusable-nox.yml
 
   check:
     if: always()

--- a/.github/workflows/pip-compile-dev.yml
+++ b/.github/workflows/pip-compile-dev.yml
@@ -57,7 +57,7 @@ jobs:
               'pip-compile(spelling)'
             python-versions: "3.11"
     name: "Refresh dev dependencies"
-    uses: ./.github/workflows/reusable-pip-compile.yml
+    uses: $/.github/workflows/reusable-pip-compile.yml
     with:
       message: "ci: refresh dev dependencies"
       base-branch: "${{ matrix.base-branch }}"

--- a/.github/workflows/pip-compile-docs.yml
+++ b/.github/workflows/pip-compile-docs.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   refresh:
     name: "Refresh docs build dependencies"
-    uses: ./.github/workflows/reusable-pip-compile.yml
+    uses: $/.github/workflows/reusable-pip-compile.yml
     with:
       message: "ci: refresh docs build dependencies"
       base-branch: "${{ inputs.base-branch || 'devel' }}"


### PR DESCRIPTION
This change updates workflows to use the self-repository syntax as per https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/

Fixes https://github.com/ansible/ansible-documentation/pull/3939

Needs to be merged after https://github.com/ansible/ansible-documentation/pull/3941 