### PR TITLE
[backport stable-2.21] docs: add cross-links and forum references (#3916)

### DIFF
--- a/docs/docsite/rst/community/security_policy.rst
+++ b/docs/docsite/rst/community/security_policy.rst
@@ -169,11 +169,19 @@ The Ansible Security Team may thank security researchers who help improve projec
 * Security advisories.
 * `Ansible Community Forum <https://forum.ansible.com>`__.
 
+Related documents
+=================
+
+* :ref:`vulnerability_management_policy` covers triage, remediation, coordinated disclosure, CVE management, and incident response processes.
+
 Policy updates
 ==============
 
 This policy may be updated periodically.
 Suggestions for improvement can be submitted through issues or pull requests to the `ansible-documentation <https://github.com/ansible/ansible-documentation>`_ repository.
+
+For discussion about the EU Cyber Resilience Act and how it applies to the Ansible ecosystem, see the `CRA tag on the Ansible Forum <https://forum.ansible.com/tag/cra>`__.
+To follow changes and suggest improvements to Ansible security practices, see the `infra-and-security tag on Ansible Forum <https://forum.ansible.com/tag/infra-and-security>`__.
 
 Notes
 =====

--- a/docs/docsite/rst/community/vulnerability_management_policy.rst
+++ b/docs/docsite/rst/community/vulnerability_management_policy.rst
@@ -215,6 +215,9 @@ Any exception to this policy requires written approval from the Ansible Security
 * Compensating controls in place.
 * Expiration date for the exception.
 
+For discussion about the EU Cyber Resilience Act and how it applies to the Ansible ecosystem, see the `CRA tag on the Ansible Forum <https://forum.ansible.com/tag/cra>`__.
+To follow changes and suggest improvements to Ansible security practices, see the `infra-and-security tag on Ansible Forum <https://forum.ansible.com/tag/infra-and-security>`__.
+
 Notes
 =====
 


### PR DESCRIPTION
## Summary

Manual backport of https://github.com/ansible/ansible-documentation/pull/3916 to stable-2.21.

* Add "Related documents" section to security policy linking to VMP.
* Add CRA and infra-and-security Ansible Forum tags to security policy and VMP.

Patchback failed due to cherry-pick conflicts from squash merge.

## Test plan

* CI passes.