### PR TITLE
Fix a typo within the sample spec

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
@@ -464,7 +464,7 @@ Sample specification
               myapp_food_preparation_time: 60
             - myapp_food_kind: "fruits"
               myapp_food_preparation_time: 5
-          description: "A list of dicts with a defined structure and with default a value."
+          description: "A list of dicts with a defined structure and with a default value."
           options:
             myapp_food_kind:
               type: "str"


### PR DESCRIPTION
Hi there,

I guess the description for the list of dicts in the sample specification has a typo.

Cheers