### PR TITLE
Add documentation for secret masking

### DIFF
--- a/docs/docsite/rst/community/secure_development_practices.rst
+++ b/docs/docsite/rst/community/secure_development_practices.rst
@@ -23,6 +23,7 @@ Follow these guidelines when developing Ansible modules and plugins to avoid com
 * :ref:`module_utils` documents secure utilities including ``fetch_url`` for TLS-verified HTTP requests and ``run_command`` for safe shell execution.
 * :ref:`developing_modules_best_practices` covers conventions for error handling, return values, and idempotent operations.
 * :ref:`developing_plugins` covers plugin development guidelines for all plugin types.
+* :ref:`developing_secret_masking` covers registering secrets so they are masked in Ansible output, marking plugin options as ``secret``, and callback plugin responsibilities.
 
 Secure collections
 ==================

--- a/docs/docsite/rst/dev_guide/ansible_index.rst
+++ b/docs/docsite/rst/dev_guide/ansible_index.rst
@@ -89,6 +89,7 @@ If you prefer to read the entire guide, here's a list of the pages in order.
    developing_api
    developing_rebasing
    developing_module_utilities
+   developing_secret_masking
    developing_collections_path
    developing_collections
    migrating_roles

--- a/docs/docsite/rst/dev_guide/core_index.rst
+++ b/docs/docsite/rst/dev_guide/core_index.rst
@@ -86,6 +86,7 @@ If you prefer to read the entire guide, here's a list of the pages in order.
    developing_api
    developing_rebasing
    developing_module_utilities
+   developing_secret_masking
    developing_collections_path
    developing_collections
    migrating_roles

--- a/docs/docsite/rst/dev_guide/developing_module_utilities.rst
+++ b/docs/docsite/rst/dev_guide/developing_module_utilities.rst
@@ -68,6 +68,7 @@ Ansible ships with an extensive library of ``module_utils`` files. You can find 
 - ``json_utils.py`` - Utilities for filtering unrelated output around module JSON output, like leading and trailing lines
 - ``powershell/`` - Directory of definitions and helper functions for Windows PowerShell modules
 - ``pycompat24.py`` - Exception workaround for Python 2.4
+- ``secrets.py`` - Functions for registering secrets so they are masked in Ansible output. See :ref:`developing_secret_masking`
 - ``service.py`` - Utilities to enable modules to work with Linux services (placeholder, not in use)
 - ``six/__init__.py`` - Bundled copy of the `Six Python library <https://pypi.org/project/six/>`_ to aid in writing code compatible with both Python 2 and Python 3
 - ``splitter.py`` - String splitting and manipulation utilities for working with Jinja2 templates

--- a/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
@@ -173,4 +173,4 @@ Module Security
 * If you must use the shell, you must pass ``use_unsafe_shell=True`` to ``module.run_command``.
 * If any variables in your module can come from user input with ``use_unsafe_shell=True``, you must wrap them with ``pipes.quote(x)``.
 * When fetching URLs, use ``fetch_url`` or ``open_url`` from ``ansible.module_utils.urls``. Do not use ``urllib2``, which does not natively verify TLS certificates and so is insecure for https.
-* Sensitive values marked with ``no_log=True`` will automatically have that value stripped from module return values. If your module could return these sensitive values as part of a dictionary key name, you should call the ``ansible.module_utils.basic.sanitize_keys()`` function to strip the values from the keys. See the ``uri`` module for an example.
+* Sensitive values marked with ``no_log=True`` are automatically hidden from Ansible output. On ``ansible-core`` 2.22 the value is preserved in the result and redacted in the output, on earlier versions the value is redacted in the result itself. See :ref:`developing_secret_masking` for details.

--- a/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
@@ -173,4 +173,4 @@ Module Security
 * If you must use the shell, you must pass ``use_unsafe_shell=True`` to ``module.run_command``.
 * If any variables in your module can come from user input with ``use_unsafe_shell=True``, you must wrap them with ``pipes.quote(x)``.
 * When fetching URLs, use ``fetch_url`` or ``open_url`` from ``ansible.module_utils.urls``. Do not use ``urllib2``, which does not natively verify TLS certificates and so is insecure for https.
-* Sensitive values marked with ``no_log=True`` are automatically hidden from Ansible output. On ``ansible-core`` 2.22 the value is preserved in the result and redacted in the output, on earlier versions the value is redacted in the result itself. See :ref:`developing_secret_masking` for details.
+* Sensitive values marked with ``no_log=True`` are automatically hidden from Ansible output. Since ``ansible-core`` 2.22 the value is preserved in the result and redacted in the output, on earlier versions the value is redacted in the result itself. See :ref:`developing_secret_masking` for details.

--- a/docs/docsite/rst/dev_guide/developing_modules_general_windows.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general_windows.rst
@@ -206,7 +206,7 @@ options set:
 - ``default``: The default value for the module option if not set
 - ``deprecated_aliases``: A list of hashtables that define aliases that are deprecated and the versions they will be removed in. Each entry must contain the keys ``name`` and ``collection_name`` with either ``version`` or ``date``
 - ``elements``: When ``type=list``, this sets the type of each list value, the values are the same as ``type``
-- ``no_log``: Will sanitize the input value before being returned in the ``module_invocation`` return value
+- ``no_log``: Hides the input value from Ansible output. On ``ansible-core`` 2.22 and later the value is masked in the Event Log and in output, on earlier versions it is removed from ``module_invocation``. See :ref:`developing_secret_masking`
 - ``removed_in_version``: States when a deprecated module option is to be removed, a warning is displayed to the end user if set
 - ``removed_at_date``: States the date (YYYY-MM-DD) when a deprecated module option will be removed, a warning is displayed to the end user if set
 - ``removed_from_collection``: States from which collection the deprecated module option will be removed; must be specified if one of ``removed_in_version`` and ``removed_at_date`` is specified
@@ -346,7 +346,9 @@ module:
     #AnsibleRequires -CSharpUtil Ansible.Basic
 
 This will import the module_util at ``./lib/ansible/module_utils/csharp/Ansible.Basic.cs``
-and automatically load the types in the executing process. C# module utils can
+and automatically load the types in the executing process. The ``Ansible.Secrets``
+C# module util provides the ``[Ansible.Secrets.SecretMasker]`` class for registering
+secrets and masking strings, see :ref:`developing_secret_masking`. C# module utils can
 reference each other and be loaded together by adding the following line to the
 using statements at the top of the util:
 

--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -72,6 +72,7 @@ To define configurable options for your plugin, describe them in the ``DOCUMENTA
           - name: mycollection_name_of_second_var
             version_added: X.x
         required: True/False
+        secret: True/False
         type: boolean/float/integer/list/none/path/pathlist/pathspec/string/tmppath
         version_added: X.x
 
@@ -85,7 +86,7 @@ The supported configuration fields are:
   The last set environment variable in the list takes precedence if multiple are set.
   This is commonly used for plugins (especially inventory plugins) to allow configuration through environment variables.
   Examples: ``VMWARE_PORT``, ``GRAFANA_PASSWORD``
-  
+
 
 **ini**
   List of configuration file settings that can be used to set this option.
@@ -94,7 +95,7 @@ The supported configuration fields are:
   The last set configuration setting in the list takes precedence if multiple are set.
   This allows plugins to be configured with ansible.cfg.
   Example: ``grafana_password``
-  
+
 
 **vars**
   List of Ansible variables that can be used to set this option.
@@ -105,6 +106,14 @@ The supported configuration fields are:
   Variables follow Ansible's variable precedence rules.
   This allows plugins to be configured with Ansible variables.
   Example: ``ansible_vmware_port``
+
+**secret**
+  New in ansible-core 2.22.
+  Boolean that marks the option as sensitive.
+  When set to ``true``, the resolved value is registered as a secret and is masked in Ansible output regardless of the source that set it.
+  Only supported for options of type ``str``, ``string``, and ``list`` (string elements), and not supported on ``suboptions``.
+  Use it for passwords, tokens, private keys, and similar values.
+  See :ref:`plugin_config_secret` for details.
 
 .. _general_plugin_precedence_rules:
 
@@ -124,10 +133,10 @@ General precedence rules
 Accessing configuration settings
 --------------------------------
 
-To access the configuration settings in your plugin, use ``self.get_option(<option_name>)``. 
+To access the configuration settings in your plugin, use ``self.get_option(<option_name>)``.
 Some plugin types handle this differently:
 
-* Become, callback, connection and shell plugins are guaranteed to have the engine call ``set_options()``. 
+* Become, callback, connection and shell plugins are guaranteed to have the engine call ``set_options()``.
 * Lookup plugins always require you to handle it in the ``run()`` method.
 * Inventory plugins are done automatically if you use the ``base _read_config_file()`` method. If not, you must use ``self.get_option(<option_name>)``.
 * Cache plugins do it on load.
@@ -355,6 +364,8 @@ but with an extra option so you can see how configuration works in Ansible versi
 
 
 Note that the ``CALLBACK_VERSION`` and ``CALLBACK_NAME`` definitions are required for properly functioning plugins for Ansible version 2.0 and later. ``CALLBACK_TYPE`` is mostly needed to distinguish 'stdout' plugins from the rest, since you can only load one plugin that writes to stdout.
+
+New in ansible-core 2.22, callback plugins should also set ``ANSIBLE_SUPPORTS_MASKING = True`` to declare that they mask registered secrets in any output they write outside of ``Display()``. Callbacks that do not set the attribute receive task results with secrets already masked, which is a transitional behavior that is planned for removal. See :ref:`developing_callbacks_masking` for the details and an example.
 
 For example callback plugins, see the source code for the `callback plugins included with Ansible Core <https://github.com/ansible/ansible/tree/devel/lib/ansible/plugins/callback>`_
 

--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -108,12 +108,13 @@ The supported configuration fields are:
   Example: ``ansible_vmware_port``
 
 **secret**
-  New in ansible-core 2.22.
   Boolean that marks the option as sensitive.
   When set to ``true``, the resolved value is registered as a secret and is masked in Ansible output regardless of the source that set it.
   Only supported for options of type ``str``, ``string``, and ``list`` (string elements), and not supported on ``suboptions``.
   Use it for passwords, tokens, private keys, and similar values.
   See :ref:`plugin_config_secret` for details.
+
+  .. versionadded:: 2.22
 
 .. _general_plugin_precedence_rules:
 

--- a/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
@@ -650,6 +650,8 @@ This section will discuss the behavioral attributes for arguments:
 
   ``no_log`` accepts a boolean, either ``True`` or ``False``, that indicates explicitly whether or not the argument value should be masked in logs and output.
 
+  How the value is hidden depends on the ``ansible-core`` version. On ``ansible-core`` 2.22 and later, the value is registered as a secret and masked wherever Ansible writes output, while the module result keeps the real value so later tasks can use it. On earlier versions, the value is removed from the module result and replaced with ``VALUE_SPECIFIED_IN_NO_LOG_PARAMETER``, and is stripped from the module logs. See :ref:`developing_secret_masking` for details of the masking behavior.
+
   .. note::
      In the absence of ``no_log``, if the parameter name appears to indicate that the argument value is a password or passphrase (such as "admin_password"), a warning will be shown and the value will be masked in logs but **not** output. To disable the warning and masking for parameters that do not contain sensitive information, set ``no_log`` to ``False``.
 

--- a/docs/docsite/rst/dev_guide/developing_secret_masking.rst
+++ b/docs/docsite/rst/dev_guide/developing_secret_masking.rst
@@ -1,0 +1,298 @@
+.. _developing_secret_masking:
+
+*******************************************
+Handling secrets in modules and plugins
+*******************************************
+
+.. versionadded:: 2.22
+
+``ansible-core`` 2.22 adds a secret masking API that modules and plugins can use to register sensitive values.
+Any registered value is replaced with ``$REDACTED$`` wherever Ansible writes output, without changing the value itself.
+This page describes the API, how registered secrets move between the controller, its worker processes, and the managed node, and what you must do in callback plugins and plugin configuration to take part in masking.
+
+For the user-facing behavior, including which values Ansible registers automatically and the length rules for secrets, see :ref:`playbooks_secret_masking`.
+
+.. contents::
+   :local:
+
+How masking works
+=================
+
+Ansible keeps a process-wide registry of secret strings. Every place that Ansible writes output, referred to as an *egress boundary*, runs the text through the registry and replaces any registered secret with the placeholder. The boundaries are:
+
+* The ``Display`` object on the controller, which covers the screen, the ``log_path`` log file, warnings, deprecation messages, errors, and tracebacks.
+* Task results handed to callback plugins that do not declare ``ANSIBLE_SUPPORTS_MASKING``.
+* ``AnsibleModule.log()`` in Python modules and the ``Ansible.Basic`` logging in PowerShell modules, which write to syslog and the Windows Event Log on the managed node.
+
+Registration is append-only and non-destructive. Registering a value does not change it, and code that already holds the value keeps working with it. Secrets are never removed from the registry for the life of the process.
+
+.. note::
+   The ``log_path`` log file is a handler on the Python root logger. Only messages that Ansible writes through ``Display`` are masked before they reach it. Messages that a plugin, or a library it imports, emits with the standard ``logging`` module are written to the file unmasked. Pass such messages through ``mask_secrets()`` before logging them, or avoid logging sensitive data with ``logging`` at all.
+
+Secrets registered in a worker process, such as an action, connection, lookup, or filter plugin running inside a forked worker, are sent back to the controller together with the worker's results and registered there. Secrets registered inside a module on the managed node are returned to the controller as part of the module result and registered there as well. In both cases the secret is masked in every later task, not only in the task that registered it.
+
+In the other direction, the controller passes any registered secrets that appear in a module's arguments to the module, so that the module-side masking in ``AnsibleModule.log()`` and ``Ansible.Basic`` also covers them. Secrets that are not present in the module arguments are not sent to the managed node. A module that obtains a sensitive value another way, such as reading it from a file or receiving it from an API, must register the value itself for module-side masking to cover it, even if the controller already knows that value.
+
+Secrets that a module registers during its run are returned inside the module's raw JSON result and are only registered on the controller when that result is processed. Connection plugin authors must audit any code that displays the raw standard output or standard error of a module, since that text contains the new secrets in plain text before the controller knows about them. The connection plugins shipped with ``ansible-core`` only display raw module output when ``ANSIBLE_DEBUG`` is enabled. Gate such output the same way, or do not display it at all.
+
+Propagation from a worker to the controller happens when the worker sends its results, and only workers forked after that point inherit the new secret. Workers that are already running, such as those executing the same task for other hosts, do not see it. If a plugin needs a value masked across every host in the current task, register it on the controller before the task runs, for example in a vars plugin or through the ``register_secret`` filter in an earlier task.
+
+.. note::
+   Masking works by searching output for the exact registered string. See :ref:`playbooks_secret_masking` for the minimum and maximum secret lengths and the word boundary rule that applies to short secrets. Register the secret in every form that could appear in output. A base64 encoded or URL encoded copy of a registered secret is a different string and is not masked.
+
+The ``ansible.module_utils.secrets`` API
+========================================
+
+The ``ansible.module_utils.secrets`` module is the public API for working with secrets. It is available to modules, module utilities, and all controller-side plugins.
+
+.. code-block:: python
+
+    from ansible.module_utils.secrets import register_secret, register_secrets, mask_secrets
+
+``register_secret(value)``
+  Register a single string as a secret and return it unchanged. The return value makes it convenient to wrap an expression in place, for example ``token = register_secret(response['token'])``.
+
+``register_secrets(values)``
+  Register every string in an iterable. Use this when you have several values to register at once.
+
+``mask_secrets(value, *, mask_placeholder='$REDACTED$')``
+  Return a copy of ``value`` with every registered secret replaced by ``mask_placeholder``. Use this when you write text to a destination that is not an Ansible egress boundary, such as a file, an external logging system, or a message queue.
+
+All three functions expect Python ``str`` values. Convert bytes with ``to_text()`` before registering them. Values shorter than the minimum secret length are silently ignored by ``register_secret()`` and ``register_secrets()``.
+
+Registering secrets in a module
+-------------------------------
+
+Values for options declared with ``no_log: True`` in the ``argument_spec`` are registered automatically when ``AnsibleModule`` validates the arguments. Register any other sensitive value that your module discovers at run time, such as a token returned by an API or a password read from a file on the managed node, as soon as you have it:
+
+.. code-block:: python
+
+    from ansible.module_utils.basic import AnsibleModule
+    from ansible.module_utils.secrets import register_secret
+
+
+    def main():
+        module = AnsibleModule(
+            argument_spec=dict(
+                username=dict(type='str', required=True),
+                password=dict(type='str', required=True, no_log=True),  # registered automatically
+            ),
+        )
+
+        session = login(module.params['username'], module.params['password'])
+
+        # The token is a new secret discovered by the module. Register it so it is masked
+        # in the module log, the callback output, and any later task on the controller.
+        token = register_secret(session['token'])
+
+        # The real value is still returned so it can be used by later tasks. It is only
+        # masked when written to output.
+        module.exit_json(changed=False, token=token)
+
+
+    if __name__ == '__main__':
+        main()
+
+There is no need to strip the value from the result. The result keeps the real value, and the controller masks it when a callback or ``Display`` writes it out.
+
+.. note::
+   On ``ansible-core`` versions before 2.22, ``no_log`` values are removed from the module result and replaced with ``VALUE_SPECIFIED_IN_NO_LOG_PARAMETER``, and are stripped from module logs. The secrets API is not available on those versions.
+
+The ``AnsibleModule.log()`` method masks its message and the ``log_args`` values before writing to syslog. The module invocation log entry always replaces ``no_log`` options with ``$REDACTED$``, regardless of the value's length, and masks any other registered secret it contains.
+
+Modules that respawn under a different Python interpreter keep the secrets that were passed in from the controller, and any secret registered in the respawned process is returned to the controller as normal.
+
+Registering secrets in a plugin
+-------------------------------
+
+The same functions work in every controller-side plugin type. This example is a lookup plugin that reads a credential from an external service and registers it before returning it:
+
+.. code-block:: python
+
+    from ansible.module_utils.secrets import register_secret
+    from ansible.plugins.lookup import LookupBase
+    from ansible.utils.display import Display
+
+    display = Display()
+
+
+    class LookupModule(LookupBase):
+
+        def run(self, terms, variables=None, **kwargs):
+            self.set_options(var_options=variables, direct=kwargs)
+
+            results = []
+            for term in terms:
+                value = fetch_credential(term)
+                results.append(register_secret(value))
+
+                # Display output is a masked boundary, so this prints the placeholder.
+                display.vvv(f"fetched credential for {term}: {value}")
+
+            return results
+
+For plugin options that are always sensitive, prefer marking the option with ``secret: true`` in the plugin documentation instead of registering the value by hand. See :ref:`plugin_config_secret`.
+
+Masking output you write yourself
+---------------------------------
+
+Anything you write outside of an egress boundary is not masked. Call ``mask_secrets()`` before writing:
+
+.. code-block:: python
+
+    from ansible.module_utils.secrets import mask_secrets
+
+    with open('/var/log/my_plugin.log', 'a') as fd:
+        fd.write(mask_secrets(f"request completed: {response_text}\n"))
+
+Deprecated helpers
+------------------
+
+The following helpers are replaced by automatic masking and are deprecated:
+
+* ``ansible.module_utils.basic.heuristic_log_sanitize()`` is deprecated and will be removed in ``ansible-core`` 2.25.
+* ``ansible.module_utils.common.parameters.remove_values()`` and ``sanitize_keys()`` are deprecated and will be removed in ``ansible-core`` 2.25.
+* The ``live`` argument of ``ansible.utils.cmd_functions.run_cmd()`` is deprecated and will be removed in ``ansible-core`` 2.25.
+
+Modules that called ``remove_values()`` or ``sanitize_keys()`` on their results, or that strip ``no_log`` values from a result before returning it, no longer need to. Remove those calls and return the real values.
+
+The ``live`` argument of ``run_cmd()`` writes subprocess output directly to standard output, which bypasses masking. Run the subprocess yourself if you need to stream its output, and mask it with ``mask_secrets()``.
+
+The heuristics that these helpers applied are gone as well. ``AnsibleModule.log()`` no longer rewrites password-like text such as ``user:password@host`` in URLs, and ``run_command()`` no longer replaces password-like arguments such as ``--password=...`` with ``********`` in the ``cmd`` value of a failure result. Only registered secrets are masked. If your module passes a secret on the command line or embeds one in a URL and that secret is not a ``no_log`` option, register it with ``register_secret()`` before use.
+
+PowerShell and C# modules
+=========================
+
+The ``Ansible.Secrets`` C# module utility provides the same API for Windows modules. Import it with ``#AnsibleRequires`` and use the static ``Ansible.Secrets.SecretMasker`` class:
+
+.. code-block:: powershell
+
+    #!powershell
+
+    #AnsibleRequires -CSharpUtil Ansible.Basic
+    #AnsibleRequires -CSharpUtil Ansible.Secrets
+
+    $spec = @{
+        options = @{
+            username = @{ type = 'str'; required = $true }
+            password = @{ type = 'str'; required = $true; no_log = $true }  # registered automatically
+        }
+    }
+    $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+    $session = Connect-MyService -Username $module.Params.username -Password $module.Params.password
+
+    # Register the discovered token so it is masked in the Event Log and on the controller.
+    [Ansible.Secrets.SecretMasker]::RegisterSecret($session.Token)
+
+    # Mask a string yourself before writing it somewhere that is not an Ansible boundary.
+    $summary = [Ansible.Secrets.SecretMasker]::MaskString("Connected with token $($session.Token)")
+    Set-Content -Path C:\logs\my_module.log -Value $summary
+
+    $module.Result.token = $session.Token
+    $module.ExitJson()
+
+The ``SecretMasker`` class exposes:
+
+``RegisterSecret(string secret)`` and ``RegisterSecret(SecureString secret)``
+  Register a value. Prefer the ``SecureString`` overload when you already hold the value as a ``SecureString``, so the plain text is not exposed to PowerShell AMSI notifications.
+
+``MaskString(string value)`` and ``MaskString(string value, string maskPlaceholder)``
+  Return a copy of ``value`` with registered secrets replaced by ``$REDACTED$`` or the placeholder you supply.
+
+The length rules match the Python implementation. ``Ansible.Basic`` registers ``no_log`` option values automatically, masks messages written through its event logging, and returns any newly registered secrets to the controller when the module exits.
+
+.. _plugin_config_secret:
+
+Marking plugin configuration options as secret
+==============================================
+
+Plugin configuration options can be marked with ``secret: true``. When a marked option is resolved, its value is registered as a secret regardless of the source that set it: an environment variable, an ``ansible.cfg`` entry, an Ansible variable, a command line option, or a direct argument to the plugin.
+
+.. code-block:: yaml
+
+    options:
+      api_token:
+        description: Token used to authenticate to the service.
+        type: str
+        secret: true
+        env:
+          - name: MYCOLLECTION_API_TOKEN
+        vars:
+          - name: mycollection_api_token
+
+``secret`` is only supported for options of type ``str``, ``string``, and ``list``. For a ``list`` option, each string element is registered and non-string elements are ignored. Declaring ``secret: true`` on an option of any other type is an error when the plugin's configuration is loaded, so the plugin fails to load rather than silently leaving the value unmasked.
+
+``secret`` is not supported on ``suboptions``. Sub-option definitions are documentation only and are not processed by the configuration manager, so there is no point at which their values could be registered. If a sub-option holds a sensitive value, register it in the plugin with ``register_secret()`` after reading the option.
+
+The ``ansible-core`` connection and become plugins use this keyword for their password, private key, and passphrase options. When you write a plugin that accepts a password or token, mark the option as secret instead of relying on callers to add ``no_log`` or use ``register_secret``.
+
+.. _developing_callbacks_masking:
+
+Callback plugins and ``ANSIBLE_SUPPORTS_MASKING``
+=================================================
+
+Callback plugins receive task results that may contain registered secrets. To keep callbacks written before ``ansible-core`` 2.22 safe, the task queue manager masks every string in a result before handing it to a callback plugin, unless the plugin declares that it supports masking:
+
+.. code-block:: python
+
+    from ansible.plugins.callback import CallbackBase
+
+
+    class CallbackModule(CallbackBase):
+        CALLBACK_VERSION = 2.0
+        CALLBACK_TYPE = 'stdout'
+        CALLBACK_NAME = 'namespace.collection_name.my_callback'
+
+        # Opt in to receiving unmasked task results.
+        ANSIBLE_SUPPORTS_MASKING = True
+
+Obtain the ``Display`` instance with ``Display()`` from ``ansible.utils.display``. It is a singleton, so every caller shares the same object and gets the same masking.
+
+The attribute changes what ``CallbackTaskResult.result`` contains:
+
+``ANSIBLE_SUPPORTS_MASKING = False`` (the default)
+  Every string value in ``result.result``, including values nested in lists and dictionaries, is passed through ``mask_secrets()`` before the callback sees it. The callback cannot leak a registered secret through the result, but it also cannot see the real values.
+
+``ANSIBLE_SUPPORTS_MASKING = True``
+  ``result.result`` contains the real values. The callback is responsible for masking. Any output sent through ``Display()`` is masked automatically. Output written anywhere else, such as a file, a socket, or an HTTP request, should be passed through ``mask_secrets()`` first.
+
+A callback that only ever writes through ``Display()`` can set the attribute to ``True`` with no other changes. A callback that serializes results elsewhere should mask them itself. The ``junit`` and ``tree`` callbacks shipped with ``ansible-core`` are examples of callbacks that write to files and call ``mask_secrets()`` on everything they write:
+
+.. code-block:: python
+
+    import json
+
+    from ansible.module_utils.secrets import mask_secrets
+    from ansible.plugins.callback import CallbackBase
+
+
+    class CallbackModule(CallbackBase):
+        CALLBACK_VERSION = 2.0
+        CALLBACK_TYPE = 'notification'
+        CALLBACK_NAME = 'namespace.collection_name.json_file'
+        CALLBACK_NEEDS_ENABLED = True
+
+        ANSIBLE_SUPPORTS_MASKING = True
+
+        def v2_runner_on_ok(self, result):
+            # The result contains real values, so mask the serialized form before writing it.
+            with open('/var/log/ansible-results.jsonl', 'a') as fd:
+                result_json = json.dumps(result.result, default=str)
+                redacted_json = mask_secrets(result_json)
+                fd.write(redacted_json + '\n')
+
+The implicit masking of results for callbacks that do not set the attribute is a compatibility shim, kept only so that existing callback plugins do not break. It is not a complete solution. It masks the task result as a whole before the callback receives it, so it can only redact secrets present in the result at that point, and cannot cover values the callback derives, formats, or combines from elsewhere. Masking at each of the callback's own egress points outside of ``Display()`` means the values are masked at the moment they are written and nothing is missed.
+
+The shim will be deprecated in a future release and then removed. Removal is tentatively planned for ``ansible-core`` 2.27, but that version is subject to change until an official deprecation warning is added. Update your callback plugins to set the attribute and mask their own output now so they keep redacting secrets when the shim is removed.
+
+.. seealso::
+
+   :ref:`playbooks_secret_masking`
+       User guide for secret masking, including the length rules and limitations
+   :ref:`developing_plugins`
+       Developing plugins
+   :ref:`developing_modules_general`
+       Developing modules
+   :ref:`developing_modules_general_windows`
+       Developing Windows modules

--- a/docs/docsite/rst/dev_guide/developing_secret_masking.rst
+++ b/docs/docsite/rst/dev_guide/developing_secret_masking.rst
@@ -252,12 +252,10 @@ Callback plugins receive task results that may contain registered secrets. To ke
 
 The attribute must be set on the class body of the callback itself, it is not inherited from a parent class.
 
-Obtain the ``Display`` instance with ``Display()`` from ``ansible.utils.display``. It is a singleton, so every caller shares the same object and gets the same masking.
-
 The attribute changes what ``CallbackTaskResult.result`` contains:
 
 ``ANSIBLE_SUPPORTS_MASKING = False`` (the default)
-  Every string value in ``result.result``, including values nested in lists and dictionaries, is passed through ``mask_secrets()`` before the callback sees it. The callback cannot leak a registered secret through the result, but it also cannot see the real values.
+  Before the callback sees ``result.result``, Ansible walks the result and passes every ``str`` key and value, at any depth, through ``mask_secrets()``. The callback cannot see the real value of any string in the result. See :ref:`developing_callbacks_masking_shim` for more information.
 
 ``ANSIBLE_SUPPORTS_MASKING = True``
   ``result.result`` contains the real values. The callback is responsible for masking. Any output sent through ``Display()`` is masked automatically. Output written anywhere else, such as a file, a socket, or an HTTP request, should be passed through ``mask_secrets()`` first.
@@ -288,7 +286,43 @@ A callback that only ever writes through ``Display()`` can set the attribute to 
             with open('/var/log/ansible-results.jsonl', 'a') as fd:
                 fd.write(redacted_json + '\n')
 
-The implicit masking of results for callbacks that do not set the attribute is a compatibility shim, kept only so that existing callback plugins do not break. It is not a complete solution. It masks the task result as a whole before the callback receives it, so it can only redact secrets present in the result at that point, and cannot cover values the callback derives, formats, or combines from elsewhere. Masking at each of the callback's own egress points outside of ``Display()`` means the values are masked at the moment they are written and nothing is missed.
+The ``mask_secrets()`` function masks a secret in its literal form and in its JSON-escaped form, so a callback can serialize a result with ``json.dumps()`` first and mask the resulting text, as the example above does. A secret that contains a double quote, a backslash, a control character, or any other character that is written differently when encoded as JSON is still recognized as a secret:
+
+.. code-block:: python
+
+    import json
+
+    from ansible.module_utils.secrets import mask_secrets, register_secret
+
+    register_secret('pa"ss\\wörd!')
+
+    # The literal value is masked.
+    mask_secrets('pa"ss\\wörd!')      # $REDACTED$
+
+    # The JSON-escaped form is masked as well.
+    result = {'password': 'pa"ss\\wörd!'}
+    result_json = json.dumps(result)  # {"password": "pa\"ss\\w\u00f6rd!"}
+    mask_secrets(result_json)         # {"password": "$REDACTED$"}
+
+Masking the serialized text is not always enough, or not what you want. Mask each string in the result before serializing it instead when:
+
+* **The output must stay valid.** A non-string value whose text form is a registered secret is replaced inside the serialized text. If ``12345678`` is registered, ``{"key": 12345678}`` becomes ``{"key": $REDACTED$}``, which is not valid JSON.
+* **The serializer escapes differently from JSON.** XML writes ``My<Secret>`` as ``My&lt;Secret&gt;``, and ``repr()``, YAML, and other formats have their own escaping rules. Only the literal and JSON-escaped forms are registered, so a secret containing an escaped character is not found in that text.
+* **The serializer transforms values.** Base64, URL encoding, compression, or any other transform produces text that does not contain the registered form.
+* **Only some fields are secret.** Masking the whole text can also replace the same string where it is not sensitive, such as a key name or an unrelated field that happens to hold the same value.
+
+.. _developing_callbacks_masking_shim:
+
+What the implicit masking does not cover
+----------------------------------------
+
+The implicit masking of results for callbacks that do not set the attribute is a compatibility shim, kept only so that existing callback plugins do not accidentally leak secrets that older versions removed from the result. It is not a complete solution. A callback that sets the attribute and masks its own output has full control over what is masked and how, for example whether dictionary keys are masked or which placeholder is used, whereas the shim applies one fixed behavior with the following gaps:
+
+* **Only strings are masked.** The shim calls ``mask_secrets()`` on ``str`` values and ``str`` dictionary keys. Integers, floats, booleans, bytes, dates, and any other type pass through unchanged, even when their printed representation is a registered secret. If ``1234567`` is registered, a result containing ``{"pin": "1234567"}`` is masked but one containing ``{"pin": 1234567}`` is not, and a callback that prints the integer reveals it.
+* **Only** ``result.result`` **is masked.** The shim covers the result mapping and nothing else. Data the callback reaches through other attributes or arguments, like warnings and deprecations, anything the callback builds by combining or deriving values, is not masked.
+* **Each string is masked on its own.** A secret that is split across several strings, such as a multi-line value in ``stdout_lines``, is not recognized in its parts. A secret that the callback transforms after receiving the result, for example by base64 encoding it or by serializing the result with ``repr()`` or XML, may not be masked either, for the reasons described above.
+
+Masking at each of the callback's own egress points outside of ``Display()`` means the values are masked at the moment they are written, with the real values still available to the callback for any logic that needs them. All of the :ref:`limitations of secret masking <secret_masking_limitations>` described in the user guide apply to a callback that masks its own output, so read them before designing how your callback handles results.
 
 The shim will be deprecated in a future release and then removed. Removal is tentatively planned for ``ansible-core`` 2.27, but that version is subject to change until an official deprecation warning is added. Update your callback plugins to set the attribute and mask their own output now so they keep redacting secrets when the shim is removed.
 

--- a/docs/docsite/rst/dev_guide/developing_secret_masking.rst
+++ b/docs/docsite/rst/dev_guide/developing_secret_masking.rst
@@ -26,6 +26,9 @@ Ansible keeps a process-wide registry of secret strings. Every place that Ansibl
 
 Registration is append-only and non-destructive. Registering a value does not change it, and code that already holds the value keeps working with it. Secrets are never removed from the registry for the life of the process.
 
+.. warning::
+   Secret masking is best effort and does not guarantee that a secret never reaches output. Modules and plugins must still avoid writing sensitive data where they can, and use ``no_log`` where a whole result is sensitive. The public API on this page is stable, but the matching algorithm, the length rules, and the other behaviors described here are implementation details that may change in future releases.
+
 .. note::
    The ``log_path`` log file is a handler on the Python root logger. Only messages that Ansible writes through ``Display`` are masked before they reach it. Messages that a plugin, or a library it imports, emits with the standard ``logging`` module are written to the file unmasked. Pass such messages through ``mask_secrets()`` before logging them, or avoid logging sensitive data with ``logging`` at all.
 
@@ -38,7 +41,7 @@ Secrets that a module registers during its run are returned inside the module's 
 Propagation from a worker to the controller happens when the worker sends its results, and only workers forked after that point inherit the new secret. Workers that are already running, such as those executing the same task for other hosts, do not see it. If a plugin needs a value masked across every host in the current task, register it on the controller before the task runs, for example in a vars plugin or through the ``register_secret`` filter in an earlier task.
 
 .. note::
-   Masking works by searching output for the exact registered string. See :ref:`playbooks_secret_masking` for the minimum and maximum secret lengths and the word boundary rule that applies to short secrets. Register the secret in every form that could appear in output. A base64 encoded or URL encoded copy of a registered secret is a different string and is not masked.
+   Masking works by searching output for the exact registered string. See :ref:`playbooks_secret_masking` for the minimum and maximum secret lengths and the word boundary rule that applies to short secrets. Register the secret in every form that could appear in output. A base64 encoded or URL encoded copy of a registered secret is a different string and is not masked. The JSON-escaped form of a secret is the one exception. Because most Ansible output and module data is JSON, the registry derives the escaped forms of each secret itself, with and without ``\uXXXX`` escapes for non-ASCII characters, and masks those as well.
 
 The ``ansible.module_utils.secrets`` API
 ========================================
@@ -58,7 +61,7 @@ The ``ansible.module_utils.secrets`` module is the public API for working with s
 ``mask_secrets(value, *, mask_placeholder='$REDACTED$')``
   Return a copy of ``value`` with every registered secret replaced by ``mask_placeholder``. Use this when you write text to a destination that is not an Ansible egress boundary, such as a file, an external logging system, or a message queue.
 
-All three functions expect Python ``str`` values. Convert bytes with ``to_text()`` before registering them. Values shorter than the minimum secret length are silently ignored by ``register_secret()`` and ``register_secrets()``.
+All three functions expect Python ``str`` values. Convert bytes with ``to_text()`` before registering them. Leading and trailing spaces, tabs, carriage returns, and newlines are stripped from a value before it is registered, so there is no need to strip a value read from a file or a subprocess yourself. Values shorter than the minimum secret length after stripping are silently ignored by ``register_secret()`` and ``register_secrets()``. In both cases ``register_secret()`` still returns the value exactly as it was given.
 
 Registering secrets in a module
 -------------------------------
@@ -247,6 +250,8 @@ Callback plugins receive task results that may contain registered secrets. To ke
         # Opt in to receiving unmasked task results.
         ANSIBLE_SUPPORTS_MASKING = True
 
+The attribute must be set on the class body of the callback itself, it is not inherited from a parent class.
+
 Obtain the ``Display`` instance with ``Display()`` from ``ansible.utils.display``. It is a singleton, so every caller shares the same object and gets the same masking.
 
 The attribute changes what ``CallbackTaskResult.result`` contains:
@@ -277,9 +282,10 @@ A callback that only ever writes through ``Display()`` can set the attribute to 
 
         def v2_runner_on_ok(self, result):
             # The result contains real values, so mask the serialized form before writing it.
+            result_json = json.dumps(result.result, default=str)
+            redacted_json = mask_secrets(result_json)
+
             with open('/var/log/ansible-results.jsonl', 'a') as fd:
-                result_json = json.dumps(result.result, default=str)
-                redacted_json = mask_secrets(result_json)
                 fd.write(redacted_json + '\n')
 
 The implicit masking of results for callbacks that do not set the attribute is a compatibility shim, kept only so that existing callback plugins do not break. It is not a complete solution. It masks the task result as a whole before the callback receives it, so it can only redact secrets present in the result at that point, and cannot cover values the callback derives, formats, or combines from elsewhere. Masking at each of the callback's own egress points outside of ``Display()`` means the values are masked at the moment they are written and nothing is missed.

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -151,7 +151,10 @@ globally. If an individual task is failing intermittently this option can be ena
 After Ansible has finished running you can inspect the log file which has been created on the Ansible control node
 
 .. note:: Be sure to fully understand the security implications of enabling this option as it can log sensitive
-          information in log file thus creating security vulnerability.
+          information in log file thus creating security vulnerability. The :ref:`secret masking <playbooks_secret_masking>`
+          added in ``ansible-core`` 2.22 does not apply to these messages, because the persistent connection runs in a
+          separate ``ansible-connection`` process that does not receive the secrets registered by the controller.
+          Passwords and other sensitive configuration sent over the connection are written to the log in plain text.
 
 
 Isolating an error

--- a/docs/docsite/rst/playbook_guide/playbooks.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks.rst
@@ -38,4 +38,5 @@ There are multiple ways to organize playbooks and the files they include, and we
    playbooks_variables
    playbooks_vars_facts
    playbooks_variables_validation
+   playbooks_secret_masking
    guide_rolling_upgrade

--- a/docs/docsite/rst/playbook_guide/playbooks_prompts.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_prompts.rst
@@ -31,6 +31,7 @@ Here is a most basic example:
             msg: 'Logging in as {{ username }}'
 
 The user input is hidden by default but it can be made visible by setting ``private: false``.
+Starting with ``ansible-core`` 2.22, a value entered for a private prompt is also registered as a secret and masked in Ansible output, see :ref:`playbooks_secret_masking`.
 
 .. note::
     Prompts for individual ``vars_prompt`` variables will be skipped for any variable that is already defined through the command line ``--extra-vars`` option, or when running from a non-interactive session (such as cron or Ansible AWX). See :ref:`passing_variables_on_the_command_line`.

--- a/docs/docsite/rst/playbook_guide/playbooks_secret_masking.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_secret_masking.rst
@@ -1,0 +1,238 @@
+.. _playbooks_secret_masking:
+.. _secret_masking:
+
+*********************************
+Masking secrets in Ansible output
+*********************************
+
+.. versionadded:: 2.22
+
+Ansible can register values as secrets and mask them wherever Ansible writes output.
+Once a value is registered, it is replaced with the placeholder ``$REDACTED$`` on the screen, in the ``log_path`` log file, in callback output, and in module logs on the managed node.
+The value itself is not changed. Tasks, templates, and modules keep working with the real value, only the output is masked.
+
+This page explains what masking covers, which values Ansible registers automatically, how to register your own secrets in a playbook, and the limits of the feature.
+If you are writing modules or plugins, see :ref:`developing_secret_masking` for the developer API.
+
+.. contents::
+   :local:
+
+Where masking happens
+=====================
+
+Masking happens at an *egress boundary*: a place where data leaves Ansible and could be seen or stored by something else.
+Data that stays inside Ansible, such as variables, module arguments, and task results, is never altered.
+Ansible masks registered secrets at the following boundaries:
+
+* **Display output**, which covers the screen and the ``log_path`` log file.
+* **Callback plugins**, which receive masked task results unless they mask their own output.
+* **Module logging**, which covers syslog and the Windows Event Log on the managed node.
+
+Display output includes task banners, ``debug`` messages, warnings, deprecation messages, error messages, tracebacks, and verbose (``-v``) module invocation output.
+Everything the ``Display`` object writes is masked, both on the screen and in the file set by the ``log_path`` :ref:`configuration setting <DEFAULT_LOG_PATH>`.
+
+Task results handed to a callback plugin are masked before the plugin sees them, unless the plugin declares that it handles masking itself.
+The callback plugins shipped with ``ansible-core``, such as ``default``, ``minimal``, ``oneline``, ``junit``, and ``tree``, declare this and mask their own output.
+See :ref:`developing_callbacks_masking` for the details.
+
+Module logging covers messages that a module writes through ``AnsibleModule.log()``, including the module invocation entry.
+These are masked on the managed node before they reach syslog or the Event Log.
+
+Because masking is applied at the boundary rather than to the data, a value registered late in a play is still masked in any later output, and the registered value can still be used by its true value in conditionals, templates, and module arguments.
+
+What is registered automatically
+================================
+
+Ansible registers the following values as secrets without any action from you:
+
+* **Vault-encrypted content**, once it is decrypted.
+* **Vault passwords** supplied by prompt, password file, or password script.
+* **Module options marked** ``no_log: true``.
+* **Prompted values**, such as passwords entered for ``vars_prompt`` or ``--ask-pass``.
+* **Plugin options marked** ``secret: true``, such as connection and become passwords.
+* **Generated and decrypted secrets** from the ``password`` and ``unvault`` lookups and the ``vault`` and ``unvault`` filters.
+
+How vault-encrypted content is registered depends on how it is loaded:
+
+* A vault-encrypted file loaded as variables is parsed and each value in it is registered on its own.
+* An inline ``!vault`` value is registered as a single string when it is decrypted.
+* The ``unvault`` lookup registers the entire decrypted content of each file as a single string.
+
+A vault-encrypted file is loaded as variables through ``vars_files``, ``include_vars``, ``host_vars``, and similar mechanisms.
+Ansible walks into lists and dictionaries and registers each nested string, integer, and float value, with numbers registered in their string form.
+Dictionary keys are not registered, only the values.
+
+The difference matters when the decrypted text is structured. With a vaulted vars file, a password inside it is masked wherever that password appears on its own. With ``unvault``, only the complete decrypted text is registered, including any newlines. This means a value inside it is masked only when the whole text appears in output. To mask individual values from an ``unvault`` result, parse it and register the values you need with the ``register_secret`` filter.
+
+The value of any option declared with ``no_log`` in a module's argument spec is registered when the module validates its arguments.
+This includes values that came from a default, a fallback, or a sub-option.
+See :ref:`secret_masking_no_log` for how this changes the ``no_log`` behavior.
+
+Prompted values are registered for a ``vars_prompt`` with ``private: true`` (the default), the ``pause`` module with ``echo: false``, and passwords entered for ``--ask-pass``, ``--ask-become-pass``, and ``--ask-vault-pass``.
+
+Plugin authors can mark configuration options with ``secret: true`` so the resolved value is registered no matter which source set it.
+In ``ansible-core`` this includes the ``ssh``, ``winrm``, and ``psrp`` connection passwords, the ``ssh`` private key and passphrase, the ``sudo``, ``su``, and ``runas`` become passwords, and the ``url`` lookup password.
+
+The ``password`` lookup registers the plaintext password it generates.
+The ``vault`` and ``unvault`` filters register the vault password passed to them, not the data being encrypted or decrypted.
+
+Registering your own secrets
+============================
+
+Use the :ansplugin:`ansible.builtin.register_secret#filter` filter to register any string value from a playbook. The filter returns the value unchanged so you can use it inline:
+
+.. code-block:: yaml+jinja
+
+    - name: Fetch an API token from an external system
+      ansible.builtin.uri:
+        url: https://example.com/token
+        return_content: true
+      register: token_response
+      no_log: true  # Ensures the module response isn't leaked before registration
+
+    - name: Register the token so it is masked from output
+      ansible.builtin.set_fact:
+        api_token: "{{ token_response.json.token | register_secret }}"
+
+    - name: The token is still usable but does not appear in output
+      ansible.builtin.debug:
+        msg: "Using token {{ api_token }}"
+
+The last task prints ``Using token $REDACTED$``.
+
+The filter accepts a single string. To register every string in a list, apply the filter in a loop or with ``map``:
+
+.. code-block:: yaml+jinja
+
+    - name: Register several secrets at once
+      ansible.builtin.set_fact:
+        db_passwords: "{{ raw_passwords | map('register_secret') | list }}"
+
+Use the :ansplugin:`ansible.builtin.mask_secrets#filter` filter to redact registered secrets from a string yourself. This is useful when you write output somewhere Ansible does not control, such as a file on the managed node or a message sent to an external service:
+
+.. code-block:: yaml+jinja
+
+    - name: Write a sanitized copy of a command's output
+      ansible.builtin.copy:
+        content: "{{ command_result.stdout | mask_secrets }}"
+        dest: /var/log/deploy-summary.log
+
+    - name: Use a custom placeholder
+      ansible.builtin.debug:
+        msg: "{{ 'token=' ~ api_token | mask_secrets(mask_placeholder='***') }}"
+
+.. _secret_masking_no_log:
+
+How masking changes ``no_log``
+==============================
+
+Before ``ansible-core`` 2.22, a module option declared with ``no_log: true`` had its value replaced with the string ``VALUE_SPECIFIED_IN_NO_LOG_PARAMETER`` in the module result. This meant that a task could not register the result and use the real value in a later task.
+
+Starting with ``ansible-core`` 2.22, the real value is kept in the module result and is registered as a secret instead.
+The value is masked in callback output and module logs, but a registered result still holds the true value:
+
+.. code-block:: yaml+jinja
+
+    - name: Create a user with a generated password
+      ansible.builtin.user:
+        name: deploy
+        password: "{{ generated_hash }}"
+      register: user_result
+
+    - name: The password option is masked in output but is intact in the registered result
+      ansible.builtin.assert:
+        that:
+          - user_result.invocation.module_args.password == generated_hash
+
+The ``no_log`` task keyword is unchanged. Setting ``no_log: true`` on a task or play still hides the entire task result from callbacks, and is still the right choice when a task's output could contain secrets in a form that masking cannot recognize.
+
+.. _secret_masking_length_rules:
+
+Secret length rules
+===================
+
+Masking works by searching output for the registered strings, so very short values would cause false matches all over the output. Ansible applies the following rules based on the length of the value:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Length
+     - Behavior
+   * - Fewer than 4 characters
+     - Ignored. The value is not registered and is never masked.
+   * - 4 to 6 characters
+     - Registered, but only masked when the match sits on a word boundary. The character before and after the match must be a non-alphanumeric character, or the match must be at the start or end of the text. For example, a secret of ``abcd`` is masked in ``password=abcd`` but not in ``abcdef``.
+   * - 7 to 1024 characters
+     - Registered and masked wherever the value appears.
+   * - More than 1024 characters
+     - Trimmed to the first 1024 characters before registration. Only that leading portion is masked, any remainder of the value is left as is in the output.
+
+Only string values can be registered. Booleans and ``None`` are never registered. Numbers are registered only in the specific cases noted above, such as numeric values in a vault-encrypted file, where they are registered as their string form.
+
+Limitations
+===========
+
+Masking is a safety net for output that Ansible controls, not a replacement for handling secrets carefully. Be aware of the following limits:
+
+* **Only exact matches are masked.**
+* **Short values are silently ignored.**
+* **Output that bypasses Ansible is not masked.**
+* **Log messages from other Python libraries are not masked.**
+* **Persistent connection logging is not masked.**
+* **Callback plugins that opt in to masking are trusted.**
+* **Fact and inventory caches are not masked.**
+* **Modules only know the secrets in their input.**
+* **Secrets are not shared between running workers.**
+* **Connection plugins may show raw module output.**
+
+A transformed copy of a secret, such as a base64 encoded, URL encoded, hashed, or upper-cased version, is a different string.
+It is not masked unless it is registered as well.
+
+Values shorter than 4 characters are never registered, and this happens without any warning or error.
+This applies to values registered implicitly, such as a ``no_log`` module option, a plugin option marked ``secret: true``, or a prompt input, as well as to values passed to the ``register_secret`` filter.
+Ansible stays silent so that existing content which sets short values for these options keeps working, but those values are not treated as secrets and appear in output unmasked.
+See :ref:`secret_masking_length_rules` for the full length rules.
+
+Anything a module writes to a file on the managed node, a plugin prints directly to standard output, or a task sends to an external service does not pass through a masked boundary.
+Use the ``mask_secrets`` filter, or the developer API described in :ref:`developing_secret_masking`, if you need to sanitize such output.
+
+The ``log_path`` log file is configured through the standard Python ``logging`` module on the root logger, so any Python library that Ansible or a plugin imports and that logs at ``INFO`` level or above writes into the same file.
+Only the messages that Ansible itself writes through ``Display`` are masked.
+Messages logged by other libraries, such as an HTTP client that logs request headers, reach the file unmasked.
+
+The ``persistent_log_messages`` option used by network connection plugins logs every interaction from the separate ``ansible-connection`` process.
+That process does not receive the secrets registered by the controller, so passwords and other sensitive configuration sent over the connection are written to the log in plain text.
+Only enable this option while debugging and treat the resulting log as sensitive.
+
+A callback plugin that declares ``ANSIBLE_SUPPORTS_MASKING = True`` receives unmasked task results and is responsible for masking any output it writes outside of ``Display``.
+Review third-party callbacks that set this attribute before relying on them with sensitive data.
+
+Cache plugins write the real values of facts and cached inventory to disk or an external service, since caching is not an output boundary.
+If a secret can end up in a fact, treat the cache location as sensitive or avoid caching that data.
+
+The controller only sends a module the registered secrets that appear in the module's own options.
+A module that reads or derives a sensitive value some other way, such as from a file on the managed node or from an API it calls, does not know that value is a secret and does not mask it in its logs, even if the same value has been registered on the controller.
+The value is still masked once the result reaches the controller. Module authors can register such values themselves, see :ref:`developing_secret_masking`.
+
+Ansible runs tasks in worker processes forked from the controller.
+A secret registered inside a worker, for example by a lookup or an action plugin, is sent back to the controller process only and is only inherited by workers forked after that point.
+Workers that are already running for other hosts do not learn about it, so output from those hosts in the same task may still show the value.
+Later tasks inherit the secret as expected.
+
+A secret that a module registers during its run travels back to the controller inside the module's raw JSON result, and it is only registered on the controller once that result is processed.
+A connection plugin that displays the raw standard output or standard error of the module, for example at high verbosity, shows that JSON before the new secret is known and so shows the value unmasked.
+Secrets the module received in its options are already registered and are masked in that output.
+The connection plugins shipped with ``ansible-core`` only show raw module output when :envvar:`ANSIBLE_DEBUG` is enabled.
+Third-party connection plugins may not have this protection, so check how a plugin handles raw output before relying on masking with it.
+
+.. seealso::
+
+   :ref:`playbooks_vault`
+       Encrypting sensitive data at rest with Ansible Vault
+   :ref:`keep_secret_data`
+       Hiding an entire task result with ``no_log``
+   :ref:`logging`
+       Logging Ansible output
+   :ref:`developing_secret_masking`
+       The secret masking API for module and plugin developers

--- a/docs/docsite/rst/playbook_guide/playbooks_secret_masking.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_secret_masking.rst
@@ -57,12 +57,13 @@ How vault-encrypted content is registered depends on how it is loaded:
 * A vault-encrypted file loaded as variables is parsed and each value in it is registered on its own.
 * An inline ``!vault`` value is registered as a single string when it is decrypted.
 * The ``unvault`` lookup registers the entire decrypted content of each file as a single string.
+* The ``unvault`` filter registers the decrypted text it returns as a single string, and the ``vault`` filter registers the plaintext it encrypts as a single string.
 
 A vault-encrypted file is loaded as variables through ``vars_files``, ``include_vars``, ``host_vars``, and similar mechanisms.
 Ansible walks into lists and dictionaries and registers each nested string, integer, and float value, with numbers registered in their string form.
 Dictionary keys are not registered, only the values.
 
-The difference matters when the decrypted text is structured. With a vaulted vars file, a password inside it is masked wherever that password appears on its own. With ``unvault``, only the complete decrypted text is registered, including any newlines. This means a value inside it is masked only when the whole text appears in output. To mask individual values from an ``unvault`` result, parse it and register the values you need with the ``register_secret`` filter.
+The difference matters when the decrypted text is structured. With a vaulted vars file, a password inside it is masked wherever that password appears on its own. With the ``unvault`` lookup or filter, only the complete decrypted text is registered, including any internal newlines. This means a value inside it is masked only when the whole text appears in output. To mask individual values from an ``unvault`` result, parse it and register the values you need with the ``register_secret`` filter.
 
 The value of any option declared with ``no_log`` in a module's argument spec is registered when the module validates its arguments.
 This includes values that came from a default, a fallback, or a sub-option.
@@ -74,7 +75,7 @@ Plugin authors can mark configuration options with ``secret: true`` so the resol
 In ``ansible-core`` this includes the ``ssh``, ``winrm``, and ``psrp`` connection passwords, the ``ssh`` private key and passphrase, the ``sudo``, ``su``, and ``runas`` become passwords, and the ``url`` lookup password.
 
 The ``password`` lookup registers the plaintext password it generates.
-The ``vault`` and ``unvault`` filters register the vault password passed to them, not the data being encrypted or decrypted.
+The ``vault`` and ``unvault`` filters register the vault password passed to them. The ``vault`` filter also registers the plaintext it encrypts, and the ``unvault`` filter registers the plaintext it decrypts, so the data that passes through either filter is masked in output.
 
 Registering your own secrets
 ============================
@@ -163,15 +164,28 @@ Masking works by searching output for the registered strings, so very short valu
      - Ignored. The value is not registered and is never masked.
    * - 4 to 6 characters
      - Registered, but only masked when the match sits on a word boundary. The character before and after the match must be a non-alphanumeric character, or the match must be at the start or end of the text. For example, a secret of ``abcd`` is masked in ``password=abcd`` but not in ``abcdef``.
-   * - 7 to 1024 characters
+   * - 7 to 65536 characters
      - Registered and masked wherever the value appears.
-   * - More than 1024 characters
-     - Trimmed to the first 1024 characters before registration. Only that leading portion is masked, any remainder of the value is left as is in the output.
+   * - More than 65536 characters
+     - Trimmed to the first 65536 characters before registration. Only that leading portion is masked, any remainder of the value is left as is in the output.
+
+Leading and trailing whitespace is not part of a secret.
+Spaces, tabs, carriage returns, and newlines are stripped from both ends of a value before the length rules are applied and the value is registered.
+A value that arrives with a trailing newline, such as the content of a vaulted file or a password read from a file, is masked whether or not the newline appears in the output.
+A value that is only whitespace, or that is shorter than 4 characters once stripped, is ignored.
+
+When several registered secrets overlap or sit next to each other in the output, the whole run is replaced with a single placeholder.
 
 Only string values can be registered. Booleans and ``None`` are never registered. Numbers are registered only in the specific cases noted above, such as numeric values in a vault-encrypted file, where they are registered as their string form.
 
+.. note::
+   These thresholds and rules describe the current implementation. The exact lengths, the word boundary rule, the whitespace handling, and the way matches are found and replaced may change in a future release to improve accuracy or performance. Do not write content that depends on a value of a particular length being masked or left visible.
+
 Limitations
 ===========
+
+.. warning::
+   Secret masking is best effort. It reduces the chance of a secret appearing in output, but it cannot guarantee that a secret never leaks. Treat it as one layer of defense alongside ``no_log``, Ansible Vault, and careful handling of sensitive data, and review logs and callback output before sharing them. The matching algorithm and the rules described on this page may also change in future releases.
 
 Masking is a safety net for output that Ansible controls, not a replacement for handling secrets carefully. Be aware of the following limits:
 
@@ -180,7 +194,7 @@ Masking is a safety net for output that Ansible controls, not a replacement for 
 * **Output that bypasses Ansible is not masked.**
 * **Log messages from other Python libraries are not masked.**
 * **Persistent connection logging is not masked.**
-* **Callback plugins that opt in to masking are trusted.**
+* **Callback plugins that opt in to masking are trusted with unredacted results.**
 * **Fact and inventory caches are not masked.**
 * **Modules only know the secrets in their input.**
 * **Secrets are not shared between running workers.**
@@ -188,6 +202,9 @@ Masking is a safety net for output that Ansible controls, not a replacement for 
 
 A transformed copy of a secret, such as a base64 encoded, URL encoded, hashed, or upper-cased version, is a different string.
 It is not masked unless it is registered as well.
+The one exception is JSON string escaping.
+Because most of the output Ansible produces is JSON, a secret is also masked where it appears in its JSON-escaped form, for example a secret containing a double quote, a backslash, a control character, or a non-ASCII character, both with and without ``\uXXXX`` escapes.
+You do not need to register the escaped JSON form yourself.
 
 Values shorter than 4 characters are never registered, and this happens without any warning or error.
 This applies to values registered implicitly, such as a ``no_log`` module option, a plugin option marked ``secret: true``, or a prompt input, as well as to values passed to the ``register_secret`` filter.

--- a/docs/docsite/rst/playbook_guide/playbooks_secret_masking.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_secret_masking.rst
@@ -47,7 +47,7 @@ Ansible registers the following values as secrets without any action from you:
 
 * **Vault-encrypted content**, once it is decrypted.
 * **Vault passwords** supplied by prompt, password file, or password script.
-* **Module options marked** ``no_log: true``.
+* **Module options that the module author marked** ``no_log: true`` in the module's argument spec.
 * **Prompted values**, such as passwords entered for ``vars_prompt`` or ``--ask-pass``.
 * **Plugin options marked** ``secret: true``, such as connection and become passwords.
 * **Generated and decrypted secrets** from the ``password`` and ``unvault`` lookups and the ``vault`` and ``unvault`` filters.
@@ -65,9 +65,10 @@ Dictionary keys are not registered, only the values.
 
 The difference matters when the decrypted text is structured. With a vaulted vars file, a password inside it is masked wherever that password appears on its own. With the ``unvault`` lookup or filter, only the complete decrypted text is registered, including any internal newlines. This means a value inside it is masked only when the whole text appears in output. To mask individual values from an ``unvault`` result, parse it and register the values you need with the ``register_secret`` filter.
 
-The value of any option declared with ``no_log`` in a module's argument spec is registered when the module validates its arguments.
-This includes values that came from a default, a fallback, or a sub-option.
-See :ref:`secret_masking_no_log` for how this changes the ``no_log`` behavior.
+Module authors can declare an option with ``no_log: true`` in the module's argument spec to say that its value is sensitive, for example the ``password`` option of the ``user`` module.
+The value of such an option is registered when the module validates its arguments, including values that came from a default, a fallback, or a sub-option.
+This is a setting in the module's code, not the ``no_log`` task keyword that playbook authors set on a task.
+See :ref:`secret_masking_no_log` for how masking changes the module option, and how it differs from the task keyword.
 
 Prompted values are registered for a ``vars_prompt`` with ``private: true`` (the default), the ``pause`` module with ``echo: false``, and passwords entered for ``--ask-pass``, ``--ask-become-pass``, and ``--ask-vault-pass``.
 
@@ -88,12 +89,9 @@ Use the :ansplugin:`ansible.builtin.register_secret#filter` filter to register a
       ansible.builtin.uri:
         url: https://example.com/token
         return_content: true
-      register: token_response
-      no_log: true  # Ensures the module response isn't leaked before registration
-
-    - name: Register the token so it is masked from output
-      ansible.builtin.set_fact:
-        api_token: "{{ token_response.json.token | register_secret }}"
+      register:
+        api_token: _task.result.json.token | register_secret
+      no_log: true  # Not required but recommended for defence in depth
 
     - name: The token is still usable but does not appear in output
       ansible.builtin.debug:
@@ -127,10 +125,23 @@ Use the :ansplugin:`ansible.builtin.mask_secrets#filter` filter to redact regist
 How masking changes ``no_log``
 ==============================
 
+The name ``no_log`` is used for two different things in Ansible, and secret masking affects them differently:
+
+* The ``no_log`` **module option** is set by a module author in the module's argument spec to mark an option, such as a password, as sensitive. Playbook authors do not set it, they benefit from it automatically when they use the module. Masking changes how this works.
+* The ``no_log`` **task keyword** is set by a playbook author on a task or play to hide that task's entire result from output. Masking does not change this.
+
+Both are covered below.
+
+.. _secret_masking_no_log_option:
+
+The ``no_log`` module option
+----------------------------
+
 Before ``ansible-core`` 2.22, a module option declared with ``no_log: true`` had its value replaced with the string ``VALUE_SPECIFIED_IN_NO_LOG_PARAMETER`` in the module result. This meant that a task could not register the result and use the real value in a later task.
 
 Starting with ``ansible-core`` 2.22, the real value is kept in the module result and is registered as a secret instead.
-The value is masked in callback output and module logs, but a registered result still holds the true value:
+The value is masked in callback output and module logs, but a registered result still holds the true value.
+In the following example the ``password`` option of the ``user`` module is declared with ``no_log: true`` by the module, so nothing extra is needed in the task:
 
 .. code-block:: yaml+jinja
 
@@ -145,7 +156,65 @@ The value is masked in callback output and module logs, but a registered result 
         that:
           - user_result.invocation.module_args.password == generated_hash
 
-The ``no_log`` task keyword is unchanged. Setting ``no_log: true`` on a task or play still hides the entire task result from callbacks, and is still the right choice when a task's output could contain secrets in a form that masking cannot recognize.
+.. _secret_masking_no_log_task:
+
+The ``no_log`` task keyword
+---------------------------
+
+The ``no_log`` task keyword is unchanged by secret masking.
+Setting ``no_log: true`` on a task or play still hides the entire task result from callbacks and replaces it with a message explaining that the output was censored.
+It applies to any task regardless of which module it runs and is unrelated to the module option of the same name.
+It remains the right choice when:
+
+* A task's output could contain a secret in a form that masking cannot recognize, such as an encoded or hashed copy of a registered value.
+* A task hits one of the :ref:`known limitations <secret_masking_limitations>` of masking, for example a value shorter than 4 characters or a callback plugin you do not trust with unredacted results.
+* You want to be cautious about output that may contain sensitive data even if you cannot say exactly which part is sensitive.
+
+Unlike the module option, the ``no_log`` task keyword does not register anything as a secret, it only censors the result of the task it is set on.
+Ansible does not know which value inside a task result is the sensitive one, and registering every value in the result would cause common strings such as ``present`` to be redacted throughout the rest of the run.
+This means a result registered from a task with ``no_log: true`` still holds the sensitive value in plain form, and any later task that displays it does so unmasked:
+
+.. code-block:: yaml+jinja
+
+    - name: Generate a database password
+      ansible.builtin.command: openssl rand -base64 32
+      register: password_result
+      no_log: true
+      changed_when: false
+
+    - name: The password is visible here because no_log only covered the task above
+      ansible.builtin.debug:
+        var: password_result.stdout
+
+The first task is censored, but the ``debug`` task prints the generated password in full.
+
+To hide a value from every later task as well, register it as a secret with the ``register_secret`` filter.
+The simplest way to do this from the task that produces the value is a ``register`` projection, the dictionary form of ``register`` described in :ref:`registered_variables`.
+Because ``register_secret`` returns its input unchanged, the projection both stores the value in a variable and marks it as a secret.
+You can register the full task result in the same projection, and the sensitive value is masked wherever it appears inside it:
+
+.. code-block:: yaml+jinja
+
+    - name: Generate a database password
+      ansible.builtin.command: openssl rand -base64 32
+      register:
+        db_password: _task.result.stdout | register_secret
+        password_result: _task.result
+      no_log: true
+      changed_when: false
+
+    - name: The full result can be shown, the password inside it is masked
+      ansible.builtin.debug:
+        var: password_result
+
+    - name: The value is usable but does not appear in output
+      ansible.builtin.debug:
+        msg: "Setting database password to {{ db_password }}"
+
+The second task prints the result with the generated password shown as ``$REDACTED$`` wherever it appears, and the last task prints ``Setting database password to $REDACTED$``.
+The ``db_password`` variable still holds the real value for use in module arguments and templates.
+
+It is still recommended to keep ``no_log: true`` on the task that produces the value to ensure that any failure or edge case scenarios do not inadvertently expose the secret before it is registered.
 
 .. _secret_masking_length_rules:
 
@@ -181,11 +250,13 @@ Only string values can be registered. Booleans and ``None`` are never registered
 .. note::
    These thresholds and rules describe the current implementation. The exact lengths, the word boundary rule, the whitespace handling, and the way matches are found and replaced may change in a future release to improve accuracy or performance. Do not write content that depends on a value of a particular length being masked or left visible.
 
+.. _secret_masking_limitations:
+
 Limitations
 ===========
 
 .. warning::
-   Secret masking is best effort. It reduces the chance of a secret appearing in output, but it cannot guarantee that a secret never leaks. Treat it as one layer of defense alongside ``no_log``, Ansible Vault, and careful handling of sensitive data, and review logs and callback output before sharing them. The matching algorithm and the rules described on this page may also change in future releases.
+   Secret masking is best effort. It reduces the chance of a secret appearing in output, but it cannot guarantee that a secret never leaks. Treat it as one layer of defense alongside the ``no_log`` task keyword, Ansible Vault, and careful handling of sensitive data, and review logs and callback output before sharing them. The matching algorithm and the rules described on this page may also change in future releases.
 
 Masking is a safety net for output that Ansible controls, not a replacement for handling secrets carefully. Be aware of the following limits:
 
@@ -248,7 +319,7 @@ Third-party connection plugins may not have this protection, so check how a plug
    :ref:`playbooks_vault`
        Encrypting sensitive data at rest with Ansible Vault
    :ref:`keep_secret_data`
-       Hiding an entire task result with ``no_log``
+       Hiding an entire task result with the ``no_log`` task keyword
    :ref:`logging`
        Logging Ansible output
    :ref:`developing_secret_masking`

--- a/docs/docsite/rst/playbook_guide/playbooks_secret_masking.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_secret_masking.rst
@@ -91,7 +91,7 @@ Use the :ansplugin:`ansible.builtin.register_secret#filter` filter to register a
         return_content: true
       register:
         api_token: _task.result.json.token | register_secret
-      no_log: true  # Not required but recommended for defence in depth
+      no_log: true  # Not required but recommended for defense in depth
 
     - name: The token is still usable but does not appear in output
       ansible.builtin.debug:

--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.22.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.22.rst
@@ -24,40 +24,154 @@ The complete list of porting guides can be found at :ref:`porting guides <portin
 Introduction
 ============
 
-No notable changes
+This release adds secret masking. Ansible now registers known secret values, such as decrypted vault content, ``no_log`` module options, and prompted passwords, and replaces them with ``$REDACTED$`` wherever it writes output.
+The values themselves are unchanged, so playbooks keep working with the real data and only the rendered output is masked.
+
+Most playbooks need no changes. Content that inspected the ``VALUE_SPECIFIED_IN_NO_LOG_PARAMETER`` placeholder, and modules or plugins that stripped secrets from results by hand, should be reviewed.
+Authors of custom callback plugins should update them to declare support for masking, as described in :ref:`2.22_callback_plugins`.
+
+We recommend you test your playbooks, callback plugins, and any tooling that consumes Ansible output in a staging environment with this release.
+See :ref:`playbooks_secret_masking` for the user guide and :ref:`developing_secret_masking` for the developer guide.
 
 .. _2.22_playbook:
 
 Playbook
 ========
 
-No notable changes
+Secret masking
+--------------
+
+Ansible now masks registered secrets in its output. Values such as decrypted vault content, ``no_log`` module option values, and prompted passwords are replaced with ``$REDACTED$`` on the screen, in the ``log_path`` log file, in callback output, and in module logs on the managed node. The values themselves are unchanged and remain usable by tasks. Use the new ``register_secret`` filter to register your own values and the ``mask_secrets`` filter to redact registered secrets from a string. See :ref:`playbooks_secret_masking` for details, including the minimum secret length and the limitations of masking.
+
+Module options marked with ``no_log: true`` are no longer replaced with the literal ``VALUE_SPECIFIED_IN_NO_LOG_PARAMETER`` in the module result. The real value is kept in the result and registered as a secret so it is masked in output. Playbooks that compared a result value against ``VALUE_SPECIFIED_IN_NO_LOG_PARAMETER`` should be updated.
 
 .. _2.22_engine:
 
 Engine
 ======
 
-No notable changes
+Secret masking
+--------------
+
+Masking is applied at the points where data leaves Ansible rather than to the data itself:
+
+* All ``Display`` output, including the screen, the ``log_path`` log file, warnings, deprecation messages, errors, and tracebacks.
+* Task results passed to callback plugins that do not declare ``ANSIBLE_SUPPORTS_MASKING``.
+* Module logging to syslog and the Windows Event Log, including the module invocation entry.
+
+Secrets registered in a worker process or inside a module on a managed node are sent back to the controller and registered there, so a value discovered by one task is masked in every later task.
+Registered secrets that appear in a module's arguments are passed to the module so module-side logging can mask them.
+
+Values shorter than 4 characters are never masked. Values of 4 to 6 characters are only masked when they appear as a whole word. Values longer than 1024 characters are matched on their first 1024 characters.
+Masking only matches the exact registered string, so an encoded or hashed copy of a secret is not masked unless it is registered as well.
+Masking also only covers messages Ansible writes through ``Display``. Messages that other Python libraries emit with the standard ``logging`` module share the ``log_path`` file and are not masked.
 
 .. _2.22_plugin_api:
 
 Plugin API
 ==========
 
+Secret masking API
+------------------
+
+* The ``ansible.module_utils.secrets`` module is a new public API providing ``register_secret()``, ``register_secrets()``, and ``mask_secrets()``. See :ref:`developing_secret_masking`.
+* The ``Ansible.Secrets`` C# module util provides the same API for PowerShell modules through ``[Ansible.Secrets.SecretMasker]``.
+* Plugin configuration options can set ``secret: true`` to register the resolved value as a secret regardless of the source that set it.
+* ``AnsibleModule`` no longer strips ``no_log`` values from module results.
+
+Values registered through the secrets API are masked in ``Display`` output, callback output, and module logs.
+Any plugin or module that discovers a sensitive value at runtime, such as a token returned by an API, should register it as soon as it is known.
+
+The ``secret`` configuration keyword is only supported for the ``str``, ``string``, and ``list`` types and is not supported on ``suboptions``.
+Declaring it on any other type is an error when the plugin configuration is loaded.
+The ``ansible-core`` connection and become plugins use it for their password and key options, and plugins that accept a password or token should do the same.
+
+Modules that relied on ``remove_values()`` or ``sanitize_keys()`` to strip ``no_log`` values from their results should remove those calls.
+The values are now masked at the output boundary instead, and both helpers are deprecated.
+
+.. _2.22_callback_plugins:
+
+Callback plugins
+----------------
+
+Custom callback plugins are the plugins most likely to need changes with this release.
+
+Callback plugins now receive task results in one of two forms, chosen by the new ``ANSIBLE_SUPPORTS_MASKING`` class attribute:
+
+* When the attribute is not set, or is ``False``, every string value in ``result.result`` is masked before the callback sees it, including values nested in lists and dictionaries. Existing callbacks keep working without changes but cannot see the real values.
+* When the attribute is ``True``, the callback receives the real values and is responsible for masking anything it writes outside of ``Display()``.
+
+The ``False`` behavior is a compatibility shim, not a complete solution.
+It exists only so that existing callback plugins do not break with this release.
+It masks the task result as a whole before the callback receives it, so it can only redact secrets that are present in the result at that point and may miss data that only become a secret after it is serialized to a string.
+Anything the callback derives from other sources, formats itself, or combines with data from elsewhere is outside its reach, and the walk over every result also carries a performance cost.
+
+Moving to the new mechanism, where the callback masks at each of its own egress points outside of ``Display()``, means the values are masked at the moment they are written and nothing is missed.
+This is the supported approach going forward.
+
+The compatibility shim will be deprecated in a future release and then removed.
+Removal is tentatively planned for ``ansible-core`` 2.27, but that version is subject to change until an official deprecation warning is added.
+Update your callback plugins now so they continue to redact secrets when the shim is removed:
+
+#. Set ``ANSIBLE_SUPPORTS_MASKING = True`` on the callback class.
+#. Audit every place the callback writes data. Output sent through ``Display()`` is masked automatically. Output written to a file, socket, HTTP request, database, or any other destination must be passed through ``ansible.module_utils.secrets.mask_secrets()`` first.
+#. Remove any custom code that stripped ``no_log`` values or checked for ``VALUE_SPECIFIED_IN_NO_LOG_PARAMETER``, as results no longer contain that placeholder.
+
+The following example supports both ``ansible-core`` 2.22 and earlier versions.
+On versions before 2.22 the ``ansible.module_utils.secrets`` import fails, the attribute has no effect, and the result already has ``no_log`` values removed, so ``mask_secrets()`` falls back to returning the text unchanged.
+On 2.22 and later the callback receives the real values and masks them itself:
+
+.. code-block:: python
+
+    import json
+
+    from ansible.plugins.callback import CallbackBase
+
+    try:
+        from ansible.module_utils.secrets import mask_secrets
+    except ImportError:
+        # ansible-core < 2.22 has no secret masking API. Results on those versions
+        # already have no_log values removed, so there is nothing to mask here.
+        def mask_secrets(value):
+            return value
+
+
+    class CallbackModule(CallbackBase):
+        CALLBACK_VERSION = 2.0
+        CALLBACK_TYPE = 'notification'
+        CALLBACK_NAME = 'namespace.collection_name.json_file'
+        CALLBACK_NEEDS_ENABLED = True
+
+        # Ignored by ansible-core < 2.22. On 2.22+ this opts in to receiving unmasked results.
+        ANSIBLE_SUPPORTS_MASKING = True
+
+        def v2_runner_on_ok(self, result):
+            # result.result contains real values on 2.22+, so mask the serialized form before writing it.
+            with open('/var/log/ansible-results.jsonl', 'a') as fd:
+                result_json = json.dumps(result.result, default=str)
+                redacted_json = mask_secrets(result_json)
+                fd.write(redacted_json + '\n')
+
+The ``junit`` and ``tree`` callbacks shipped with ``ansible-core`` are examples of callbacks that write to files and mask their own output.
+The task ``no_log`` keyword continues to censor the entire result regardless of this attribute as it affects the ``result`` value provided.
+See :ref:`developing_callbacks_masking` for more details.
+
 .. _2.22_command_line:
 
 Command Line
 ============
 
-No notable changes
+* Passwords entered for ``--ask-pass``, ``--ask-become-pass``, and ``--ask-vault-pass`` are registered as secrets and masked in output.
+* Values entered for a ``vars_prompt`` with ``private: true`` (the default) are registered as secrets and masked in output.
 
 .. _2.22_deprecated:
 
 Deprecated
 ==========
 
-No notable changes
+* ``ansible.module_utils.basic.heuristic_log_sanitize()`` is deprecated and will be removed in ``ansible-core`` 2.25. Secret values are now masked automatically. Use the ``ansible.module_utils.secrets`` API to handle secrets manually.
+* ``ansible.module_utils.common.parameters.remove_values()`` and ``sanitize_keys()`` are deprecated and will be removed in ``ansible-core`` 2.25. Secret values are now masked automatically. Use the ``ansible.module_utils.secrets`` API to handle secrets manually.
+* The ``live`` argument of ``ansible.utils.cmd_functions.run_cmd()`` is deprecated and will be removed in ``ansible-core`` 2.25 because it bypasses secret masking. Callers that need to stream output live should run the subprocess themselves and mask any secrets in the output.
 
 .. _2.22_modules:
 
@@ -79,7 +193,14 @@ No notable changes
 Noteworthy module changes
 -------------------------
 
-No notable changes
+* Module options marked ``no_log: true`` keep their real value in the module result instead of being replaced with ``VALUE_SPECIFIED_IN_NO_LOG_PARAMETER``. The value is registered as a secret and masked in output. See :ref:`secret_masking_no_log`.
+* Values logged by ``AnsibleModule.log()`` and the module invocation log entry now use ``$REDACTED$`` in place of the previous ``NOT_LOGGING_PARAMETER`` and ``NOT_LOGGING_PASSWORD`` placeholders, and any other registered secret in the message is masked.
+* ``AnsibleModule.log()`` and the module invocation log no longer apply the ``heuristic_log_sanitize()`` heuristics. For example, ``user:password@host`` in a URL is no longer rewritten unless the password is a registered secret.
+* ``AnsibleModule.run_command()`` no longer replaces password-like arguments such as ``--password=...`` with ``********`` in the ``cmd`` value of a failure result, and no longer passes the ``msg`` value through ``heuristic_log_sanitize()``.
+* The ``uri`` module no longer rewrites response keys to strip ``no_log`` values. Registered secrets are masked in output instead.
+
+Only registered secrets are masked in the values above.
+Modules that pass a secret on the command line or embed one in a URL, where that secret is not a ``no_log`` option, should register it with ``ansible.module_utils.secrets.register_secret()``.
 
 Plugins
 =======
@@ -87,7 +208,19 @@ Plugins
 Noteworthy plugin changes
 -------------------------
 
-No notable changes
+* The following plugin options are marked ``secret: true`` and are masked in output:
+
+  * ``ssh`` connection plugin: ``password``, ``private_key``, and ``private_key_passphrase``
+  * ``winrm`` connection plugin: ``password``
+  * ``psrp`` connection plugin: ``password`` and ``certificate_key_password``
+  * ``sudo``, ``su``, and ``runas`` become plugins: ``become_pass``
+  * ``url`` lookup plugin: ``password``
+
+* The ``password`` lookup registers the generated plaintext password as a secret. The ``unvault`` lookup registers the entire decrypted content of each file as a single secret, and the ``vault`` and ``unvault`` filters register the vault password passed to them.
+* Vault-encrypted files loaded as variables are parsed and each value is registered individually, so values inside them are masked wherever they appear on their own.
+* The ``pause`` action registers user input as a secret when ``echo: false`` is set.
+* Connection plugin authors should audit any code that displays the raw standard output or standard error of a module invocation. Secrets that a module registers during its run are returned in the raw JSON result and are not masked until the controller processes it. The connection plugins shipped with ``ansible-core`` only display raw module output when ``ANSIBLE_DEBUG`` is enabled.
+* The ``default``, ``minimal``, ``oneline``, ``junit``, and ``tree`` callback plugins set ``ANSIBLE_SUPPORTS_MASKING = True`` and mask their own output. The ``junit`` and ``tree`` callbacks pass everything they write to a file through ``mask_secrets()``.
 
 Porting custom scripts
 ======================
@@ -97,4 +230,6 @@ No notable changes
 Networking
 ==========
 
-No notable changes
+Secret masking does not apply to the messages logged by the ``persistent_log_messages`` option.
+Persistent connections run in a separate ``ansible-connection`` process that does not receive the secrets registered by the controller, so passwords and other sensitive configuration sent over the connection are written to the log in plain text.
+Only enable this option while debugging and treat the resulting log as sensitive.

--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.22.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.22.rst
@@ -99,14 +99,14 @@ Custom callback plugins are the plugins most likely to need changes with this re
 
 Callback plugins now receive task results in one of two forms, chosen by the new ``ANSIBLE_SUPPORTS_MASKING`` class attribute:
 
-* When the attribute is not set, or is ``False``, every string value in ``result.result`` is masked before the callback sees it, including values nested in lists and dictionaries. Existing callbacks keep working without changes but cannot see the real values.
+* When the attribute is not set, or is ``False``, every string value and every string dictionary key in ``result.result`` is masked before the callback sees it, at any depth of nesting. Existing callbacks keep working without changes but cannot see the real values.
 * When the attribute is ``True``, the callback receives the real values and is responsible for masking anything it writes outside of ``Display()``.
 
 The attribute is not inherited from a parent class. A callback that subclasses the ``default`` callback, or any other callback that sets the attribute, is treated as ``False`` unless it also sets ``ANSIBLE_SUPPORTS_MASKING = True`` on its own class body.
 
 The ``False`` behavior is a compatibility shim, not a complete solution.
 It exists only so that existing callback plugins do not break with this release.
-It masks the task result as a whole before the callback receives it, so it can only redact secrets that are present in the result at that point and may miss data that only become a secret after it is serialized to a string.
+It masks the task result as a whole before the callback receives it, so it can only redact secrets that are present as strings in the result at that point. Non-string values, such as an integer whose printed form is a registered secret, pass through unmasked.
 Anything the callback derives from other sources, formats itself, or combines with data from elsewhere is outside its reach, and the walk over every result also carries a performance cost.
 
 Moving to the new mechanism, where the callback masks at each of its own egress points outside of ``Display()``, means the values are masked at the moment they are written and nothing is missed.

--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.22.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.22.rst
@@ -62,8 +62,9 @@ Masking is applied at the points where data leaves Ansible rather than to the da
 Secrets registered in a worker process or inside a module on a managed node are sent back to the controller and registered there, so a value discovered by one task is masked in every later task.
 Registered secrets that appear in a module's arguments are passed to the module so module-side logging can mask them.
 
-Values shorter than 4 characters are never masked. Values of 4 to 6 characters are only masked when they appear as a whole word. Values longer than 1024 characters are matched on their first 1024 characters.
-Masking only matches the exact registered string, so an encoded or hashed copy of a secret is not masked unless it is registered as well.
+Values shorter than 4 characters are never masked. Values of 4 to 6 characters are only masked when they appear as a whole word. Values longer than 65536 characters are matched on their first 65536 characters.
+Leading and trailing whitespace is stripped from a value before it is registered, so a secret read from a file with a trailing newline is masked with or without that newline.
+Masking only matches the exact registered string, so an encoded or hashed copy of a secret is not masked unless it is registered as well. The JSON-escaped form of a secret is the one exception and is always masked.
 Masking also only covers messages Ansible writes through ``Display``. Messages that other Python libraries emit with the standard ``logging`` module share the ``log_path`` file and are not masked.
 
 .. _2.22_plugin_api:
@@ -100,6 +101,8 @@ Callback plugins now receive task results in one of two forms, chosen by the new
 
 * When the attribute is not set, or is ``False``, every string value in ``result.result`` is masked before the callback sees it, including values nested in lists and dictionaries. Existing callbacks keep working without changes but cannot see the real values.
 * When the attribute is ``True``, the callback receives the real values and is responsible for masking anything it writes outside of ``Display()``.
+
+The attribute is not inherited from a parent class. A callback that subclasses the ``default`` callback, or any other callback that sets the attribute, is treated as ``False`` unless it also sets ``ANSIBLE_SUPPORTS_MASKING = True`` on its own class body.
 
 The ``False`` behavior is a compatibility shim, not a complete solution.
 It exists only so that existing callback plugins do not break with this release.
@@ -147,9 +150,10 @@ On 2.22 and later the callback receives the real values and masks them itself:
 
         def v2_runner_on_ok(self, result):
             # result.result contains real values on 2.22+, so mask the serialized form before writing it.
+            result_json = json.dumps(result.result, default=str)
+            redacted_json = mask_secrets(result_json)
+
             with open('/var/log/ansible-results.jsonl', 'a') as fd:
-                result_json = json.dumps(result.result, default=str)
-                redacted_json = mask_secrets(result_json)
                 fd.write(redacted_json + '\n')
 
 The ``junit`` and ``tree`` callbacks shipped with ``ansible-core`` are examples of callbacks that write to files and mask their own output.
@@ -216,7 +220,7 @@ Noteworthy plugin changes
   * ``sudo``, ``su``, and ``runas`` become plugins: ``become_pass``
   * ``url`` lookup plugin: ``password``
 
-* The ``password`` lookup registers the generated plaintext password as a secret. The ``unvault`` lookup registers the entire decrypted content of each file as a single secret, and the ``vault`` and ``unvault`` filters register the vault password passed to them.
+* The ``password`` lookup registers the generated plaintext password as a secret. The ``unvault`` lookup registers the entire decrypted content of each file as a single secret. The ``vault`` and ``unvault`` filters register the vault password passed to them, and also register the plaintext being encrypted or decrypted as a single secret.
 * Vault-encrypted files loaded as variables are parsed and each value is registered individually, so values inside them are masked wherever they appear on their own.
 * The ``pause`` action registers user input as a secret when ``echo: false`` is set.
 * Connection plugin authors should audit any code that displays the raw standard output or standard error of a module invocation. Secrets that a module registers during its run are returned in the raw JSON result and are not masked until the controller processes it. The connection plugins shipped with ``ansible-core`` only display raw module output when ``ANSIBLE_DEBUG`` is enabled.

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -753,6 +753,11 @@ be applied to single tasks only, once a playbook is completed. Note that the use
 ``no_log`` attribute does not prevent data from being shown when debugging Ansible itself through
 the :envvar:`ANSIBLE_DEBUG` environment variable.
 
+Starting with ``ansible-core`` 2.22, Ansible also masks individual secret values in its output
+without hiding the whole task result. Vault-encrypted variables, ``no_log`` module options, and
+prompted passwords are masked automatically, and you can register your own values with the
+``register_secret`` filter. See :ref:`playbooks_secret_masking` for details.
+
 
 .. _when_to_use_brackets:
 .. _dynamic_variables:

--- a/docs/docsite/rst/reference_appendices/logging.rst
+++ b/docs/docsite/rst/reference_appendices/logging.rst
@@ -14,3 +14,8 @@ Protecting sensitive data with ``no_log``
 =========================================
 
 If you save Ansible output to a log, you expose any secret data in your Ansible output, such as passwords and usernames. To keep sensitive values out of your logs, mark tasks that expose them with the ``no_log: True`` attribute. However, the ``no_log`` attribute does not affect debugging output, so be careful not to debug playbooks in a production environment. See :ref:`keep_secret_data` for an example.
+
+Masking registered secrets
+==========================
+
+Starting with ``ansible-core`` 2.22, Ansible also masks known secrets in the output it writes to the screen and to the ``log_path`` log file. Values such as vault-encrypted variables, ``no_log`` module options, prompted passwords, and any value you register with the ``register_secret`` filter are replaced with ``$REDACTED$`` in the log. Masking applies to output that Ansible controls and does not cover every way a secret can reach a log, so it complements ``no_log`` rather than replacing it. In particular, messages that other Python libraries write to ``log_path`` through the standard ``logging`` module are not masked. See :ref:`playbooks_secret_masking` for what is masked, what is registered automatically, and the limitations.

--- a/docs/docsite/rst/reference_appendices/module_utils.rst
+++ b/docs/docsite/rst/reference_appendices/module_utils.rst
@@ -65,6 +65,16 @@ Standalone functions for validating various parameter types.
    :members:
 
 
+Secrets
+=======
+
+Functions for registering secrets so they are masked in Ansible output, and for masking strings manually.
+See :ref:`developing_secret_masking` for usage.
+
+.. automodule:: ansible.module_utils.secrets
+   :members:
+   :member-order: bysource
+
 Errors
 ======
 

--- a/docs/docsite/rst/vault_guide/vault.rst
+++ b/docs/docsite/rst/vault_guide/vault.rst
@@ -13,6 +13,7 @@ You can then place encrypted content under source control and share it more safe
 .. warning::
     * Encryption with Ansible Vault ONLY protects 'data at rest'.
       Once the content is decrypted ('data in use'), play and plugin authors are responsible for avoiding any secret disclosure, see :ref:`no_log <keep_secret_data>` for details on hiding output and :ref:`vault_securing_editor` for security considerations on editors you use with Ansible Vault.
+    * Starting with ``ansible-core`` 2.22, decrypted vault values are registered as secrets and masked in Ansible output. This reduces accidental disclosure but has limits, see :ref:`playbooks_secret_masking`.
 
 You can use encrypted variables and files in ad hoc commands and playbooks by supplying the passwords you used to encrypt them.
 You can modify your ``ansible.cfg`` file to specify the location of a password file or to always prompt for the password.


### PR DESCRIPTION
Adds the docs and porting guide information for the new secret masking API and engine added in Ansible 2.22. This change is still under review and not yet merged into devel.

The changes the docs are based on are from the currently in flight PR https://github.com/ansible/ansible/pull/87457. The plugins using the new `secrets` keyword fail to be generated right now as `antsibull-docs` fail on unknown options and this will have to be updated. Right now these plugins fail with

<img width="516" height="328" alt="image" src="https://github.com/user-attachments/assets/aae59350-5128-483d-af8a-05842f8e3dde" />

While it can be reviewed, some contents may be subject to changes based on how the PR goes in Ansible. This should not be merged until that PR is merged and `antsibull_docs` updates their schema to support the new `secret` option.
