### PR TITLE
ci: ignore actionlint warning about self-repo syntax

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -140,6 +140,7 @@ def actionlint(session: nox.Session) -> None:
         # https://github.com/rhysd/actionlint/issues/648#issuecomment-4289144208
         "-ignore=app-id.*create-github-app-token",
         "-ignore=client-id.*create-github-app-token",
+        r'-ignore=reusable workflow call "\$/',
         *session.posargs,
         external=True,
     )


### PR DESCRIPTION
Related to https://github.com/ansible/ansible-documentation/pull/3939 

This change adds an [ignore](https://github.com/rhysd/actionlint/blob/v1.7.12/docs/usage.md#ignore-some-errors) to the `actionlint` session for the self-repo syntax.