### PR TITLE
Add zizmor to pip-compile dev stable branches

### DIFF
--- a/.github/workflows/pip-compile-dev.yml
+++ b/.github/workflows/pip-compile-dev.yml
@@ -40,6 +40,7 @@ jobs:
               'pip-compile(typing)'
               'pip-compile(static)'
               'pip-compile(spelling)'
+              'pip-compile(zizmor)'
             python-versions: "3.12"
           - base-branch: stable-2.20
             pr-branch: pip-compile/stable-2.20/dev
@@ -48,6 +49,7 @@ jobs:
               'pip-compile(typing)'
               'pip-compile(static)'
               'pip-compile(spelling)'
+              'pip-compile(zizmor)'
             python-versions: "3.12"
           - base-branch: stable-2.19
             pr-branch: pip-compile/stable-2.19/dev
@@ -56,6 +58,7 @@ jobs:
               'pip-compile(typing)'
               'pip-compile(static)'
               'pip-compile(spelling)'
+              'pip-compile(zizmor)'
             python-versions: "3.11"
     name: "Refresh dev dependencies"
     uses: ./.github/workflows/reusable-pip-compile.yml


### PR DESCRIPTION
Discussed in https://github.com/ansible/ansible-documentation/pull/3937#pullrequestreview-5130296392 

This change adds the zizmor session to the stable branches in the pip-compile dev workflow.