### PR TITLE
docs: update Galaxy namespace request link to service-requests category

### DIFF
--- a/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
+++ b/docs/docsite/rst/community/collection_contributors/collection_requirements.rst
@@ -342,7 +342,7 @@ To create a new namespace on Galaxy for your collection, do the following:
    If the namespace already exists, check if there are any collections in the namespace from the **Collections** tab and if it has owners from the **Access** tab.
    In some cases it is possible to gain ownership of an existing namespace that has no collections or owners.
 #. Log in to the `Ansible forum <https://forum.ansible.com>`_.
-#. Submit a `namespace request <https://forum.ansible.com/new-topic?category=project&tags=galaxy-nspace-request&title=namespace%3A%20FIXME&body=%23%23%20Namespace%20Request%0ANamespace%3A%20%0A%0A%23%23%20Description%0AProvide%20us%20one%20line%20description%2C%20will%20be%20visible%20in%20Galaxy%0A%0A%23%23%20GitHub%20Org%20Link%0AProvide%20us%20with%20a%20link%20to%20your%20GitHub%20org%0A%0A%23%23%20Admins%0AProvide%20us%20with%20a%20list%20of%20Galaxy%20users%20who%20you%20would%20like%20to%20set%20up%20as%20admins%20on%20this%20namespace%0AEnsure%20each%20admin%20has%20logged%20into%20galaxy.ansible.com%2C%20which%20will%20create%20their%20user%20account>`_.
+#. Submit a `namespace request <https://forum.ansible.com/new-topic?category=service-requests/galaxy-namespace-requests>`_.
 
 The Red Hat Community and Partner Engineering team will be notified of your namespace request and create it for you.
 

--- a/docs/docsite/rst/dev_guide/developing_collections_creating.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_creating.rst
@@ -46,7 +46,7 @@ There are a few special namespaces:
 To request a new namespace in Galaxy, do the following:
 
 #. Log in to the `Ansible forum <https://forum.ansible.com>`_.
-#. Submit a `namespace request <https://forum.ansible.com/new-topic?category=project&tags=galaxy-nspace-request&title=namespace%3A%20FIXME&body=%23%23%20Namespace%20Request%0ANamespace%3A%20%0A%0A%23%23%20Description%0AProvide%20us%20one%20line%20description%2C%20will%20be%20visible%20in%20Galaxy%0A%0A%23%23%20GitHub%20Org%20Link%0AProvide%20us%20with%20a%20link%20to%20your%20GitHub%20org%0A%0A%23%23%20Admins%0AProvide%20us%20with%20a%20list%20of%20Galaxy%20users%20who%20you%20would%20like%20to%20set%20up%20as%20admins%20on%20this%20namespace%0AEnsure%20each%20admin%20has%20logged%20into%20galaxy.ansible.com%2C%20which%20will%20create%20their%20user%20account>`_.
+#. Submit a `namespace request <https://forum.ansible.com/new-topic?category=service-requests/galaxy-namespace-requests>`_.
 
 The Red Hat Community and Partner Engineering team will be notified of your namespace request and create it for you.
 


### PR DESCRIPTION
##### SUMMARY

Updates the link used to submit a new Galaxy namespace request to point at the dedicated forum category:

`https://forum.ansible.com/new-topic?category=service-requests/galaxy-namespace-requests`

This replaces the old pre-filled new-topic URL (`category=project&tags=galaxy-nspace-request&...`).

The change is applied to both places the link appears, as required by the cross-reference comments in the two files:

- `docs/docsite/rst/dev_guide/developing_collections_creating.rst`
- `docs/docsite/rst/community/collection_contributors/collection_requirements.rst`

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

- `docs/docsite/rst/dev_guide/developing_collections_creating.rst`
- `docs/docsite/rst/community/collection_contributors/collection_requirements.rst`

##### ADDITIONAL INFORMATION

Verified no references to the old `galaxy-nspace-request` pre-filled link remain in the docs tree.