### PR TITLE
docs: fix 'allows to' grammar in command guide index

### DIFF
--- a/docs/docsite/rst/command_guide/index.rst
+++ b/docs/docsite/rst/command_guide/index.rst
@@ -24,6 +24,6 @@ Ansible provides ad hoc commands and several utilities for performing various op
 
    `Ansible Navigator <https://ansible.readthedocs.io/projects/navigator/>`_
        A command-line tool and a TUI that provides a convenient user interface for most
-       of the native Ansible command-line utilities and allows to run Ansible automation content
+       of the native Ansible command-line utilities and allows you to run Ansible automation content
        inside containers (:ref:`Execution Environments<getting_started_ee_index>`)
 


### PR DESCRIPTION
Tiny docs fix: change `allows to run` to `allows you to run` in the command guide index description of Ansible Navigator.