### PR TITLE
[stable-2.19] Backport #3619 and #3941

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -42,7 +42,7 @@ jobs:
         id: create_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_KEY }}
       - name: Checkout parent repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/noxfile.py
+++ b/noxfile.py
@@ -136,6 +136,9 @@ def actionlint(session: nox.Session) -> None:
         "--workdir", "/pwd",
         # fmt: on
         ACTIONLINT_IMAGE,
+        # https://github.com/rhysd/actionlint/issues/648#issuecomment-4289144208
+        "-ignore=app-id.*create-github-app-token",
+        "-ignore=client-id.*create-github-app-token",
         *session.posargs,
         external=True,
     )

--- a/noxfile.py
+++ b/noxfile.py
@@ -139,6 +139,7 @@ def actionlint(session: nox.Session) -> None:
         # https://github.com/rhysd/actionlint/issues/648#issuecomment-4289144208
         "-ignore=app-id.*create-github-app-token",
         "-ignore=client-id.*create-github-app-token",
+        r'-ignore=reusable workflow call "\$/',
         *session.posargs,
         external=True,
     )


### PR DESCRIPTION
This backports #3619 and #3941 to stable-2.19.

This adds actionlint warnings and fixes a GHA deprecation. The other changes of #3619 were for files that do not exist on the stable branches.